### PR TITLE
docs: place governance artifacts and bootstrap epic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Rust build artifacts
+/target
+
+# Editor swap files
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 runa contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -1,0 +1,95 @@
+# Principles
+
+Seven bedrock principles govern how runa makes runtime and boundary decisions. Architecture, contract enforcement, and contribution standards derive from these principles or are shown to conflict with them.
+
+## Context
+
+Autonomous AI agents are becoming dominant users of development infrastructure. runa builds runtime infrastructure for that world: contract enforcement, artifact tracking, and handoff mechanics that support methodology at scale. Plugins such as Groundwork layer domain methodology on top of that runtime boundary. These principles emerged from sustained practice building and operating agentic systems, not from theory.
+
+## The Topology
+
+The principles organize around four structural questions every methodology must answer, with a center that connects them:
+
+- **North, the Physics**: how the system is constituted
+  - **Sovereignty**
+  - **Sequence**
+- **East, the Stance**: how participants orient
+  - **Grounding**
+  - **Obligation to Dissent**
+- **South, the Immune System**: how the system protects itself
+  - **Recursive Improvement**
+- **West, the Vector**: how work lands
+  - **Transmission**
+  - **Verifiable Completion**
+- **Center, the Spiral**: the pipeline is the principles in motion
+
+Remove any cardinal and you get a named failure:
+
+- **No North:** sovereignty confusion and arbitrary sequencing. The system has no shape.
+- **No East:** participants inherit assumptions and let problems pass. The system cannot see.
+- **No South:** object-only work and entropy accumulation. The system decays.
+- **No West:** work that never ships or ships without verification. The system produces but does not deliver.
+
+## North: The Physics
+
+### 1. Sovereignty
+
+Clean boundaries between who owns what. The operator declares WHAT: direction, vision, intent. The agent owns HOW: execution, implementation, craft. HOW-ownership means full judgment and artistry, not mechanical compliance. The agent interprets, not transcribes.
+
+Declarative framing is the communication discipline that expresses sovereignty: specify outcomes and constraints, not procedure. When boundaries hold, work flows. When they blur, corruption is symmetric. Domination by either side breaks the system.
+
+The principle is fractal. It applies at every interface: human-agent, agent-agent, skill-skill, and stage-stage.
+
+### 2. Sequence
+
+Position carries meaning. The pipeline is ordered, not a menu. Each stage's output is the next stage's required input. Skipping a stage is not efficiency; it is a topological violation. The downstream stage receives malformed input and produces structurally valid but wrongly grounded output.
+
+Interventions are placed where their corresponding failure modes occur. Grounding fires before design because inherited framing is the failure mode at that boundary. BDD fires before implementation because vague specification is the failure mode at that boundary. Each skill exists at a specific pipeline position because that position is where its absence causes damage.
+
+## East: The Stance
+
+### 3. Grounding
+
+Orient to the real need. Every artifact and decision justifies itself against today's exigency, not yesterday's momentum. Existing code is evidence about one attempt to meet requirements; it is not the requirements themselves. The question is always: what must this enable, and for whom?
+
+Grounding distinguishes descriptive truth, what exists, from normative truth, what is needed. For design work, normative truth is the starting point. Treating current behavior as the definition of what should happen is the most common grounding failure.
+
+Grounding re-fires on every new generative act, not once at project start. The trigger is creation, not sequence position.
+
+### 4. Obligation to Dissent
+
+If you see something wrong, you act. Fix it or queue it. No rationalizing, no scoping away, no "it was preexisting." Silence in the face of a known problem is complicity with that problem.
+
+The integrity of an unsupervised agentic system depends on every participant, human or agent, refusing to let problems pass. A code review that notices issues and declares them out of scope has failed. An agent that spots a defect and defers because it was not assigned to fix it has failed.
+
+Dissent is not obstruction. It is the structural requirement that keeps the system honest.
+
+## South: The Immune System
+
+### 5. Recursive Improvement
+
+Every operation refines both the object and the process that created it. Single-level work, improving only the object, accumulates entropy in the process. Dual-level work compounds improvement.
+
+This principle operates on all the others. It is the system's self-cleaning mechanism. A pipeline that delivers code but never improves its own stages decays. A team that ships features but never refines how it ships decays.
+
+The recursive spiral, refinement plus propulsion, is the topology that prevents stagnation. After completing any work, ask: did this address both the immediate thing and the process that produced it?
+
+## West: The Vector
+
+### 6. Transmission
+
+Work completes when the recipient can act on it, not when the maker finishes creating it. The door must fit who enters. Compression is limited by the recipient's capacity to cross into understanding. Artifacts that only the makers can parse are walls, not doors.
+
+Recipients include future agents loading your artifacts, contributors reading your documentation, and future instances of yourself crossing context windows. The gratitude test applies: would the recipient thank you for how you structured this? If not, transmission failed regardless of how correct the content is.
+
+### 7. Verifiable Completion
+
+Every unit of work has mechanically verifiable completion criteria: file gates, typed artifacts, BDD contracts. Completion is observable and pass/fail, not subjective and approximate.
+
+Without verifiable completion, agents cannot self-organize, reviewers cannot evaluate, and the pipeline cannot enforce its own contracts. At scale, unverifiable completion produces a system where "done" is an assertion rather than a fact.
+
+## Center: The Spiral
+
+The pipeline is the principles in motion. Each principle contributes to the pipeline's shape, and the pipeline is how the principles compose.
+
+Refinement plus propulsion: a circle that moves forward. The seven principles are not a checklist. They are a topology. They hold together or fail together.

--- a/docs/adr/0001-sovereignty.md
+++ b/docs/adr/0001-sovereignty.md
@@ -1,0 +1,26 @@
+# ADR-0001: Sovereignty
+
+**Status:** Accepted
+**Traces to:** Principle 1 (Sovereignty)
+
+## Decision
+
+Every interface between two entities in the runa system has a clean ownership boundary. Each side owns its domain fully. Neither crosses.
+
+## Context
+
+runa sits between a daemon (agentd) and methodology plugins (groundwork, others). It also mediates between operators and execution agents, between skills and their consumers, and between producers and validators. Each of these is a boundary where ownership can blur.
+
+When boundaries hold, maximum output emerges from minimum input. When they blur, corruption is symmetric — domination by either side breaks the system.
+
+The principle is fractal. It applies at every interface, at every scale.
+
+## Consequences
+
+**Runtime/methodology boundary.** runa enforces structure. It never prescribes methodology content, topology, or domain semantics. Methodologies own all artifact types, skills, schemas, and domain decisions. The interface contract defines this boundary — three primitives, nothing more. If runa begins interpreting what a methodology's artifact types mean, or suggesting what topology a methodology should use, the boundary has been violated.
+
+**Operator/agent boundary.** The operator declares WHAT through methodology configuration, manifest content, and trigger signals. The agent owns HOW — execution strategy, implementation decisions, craft. runa's enforcement mechanisms support this split: operators define schemas and declarations; agents produce artifacts that satisfy them.
+
+**Skill/consumer boundary.** A skill declares what it produces. A consumer declares what it requires. runa validates the contract between them. Neither skill nor consumer reaches into the other's domain. The typed artifact at the boundary is the interface — not shared state, not runtime internals, not implicit conventions.
+
+**What this means for the builder agent:** When designing any interface — between runa and a methodology, between runa and the daemon, between internal modules — ask: who owns what on each side? Make that ownership explicit. If a component needs to know something about another component's internals to function, the boundary is wrong.

--- a/docs/adr/0002-everything-earns-its-place.md
+++ b/docs/adr/0002-everything-earns-its-place.md
@@ -1,0 +1,28 @@
+# ADR-0002: Everything Earns Its Place
+
+**Status:** Accepted
+**Traces to:** Principle 3 (Grounding), Principle 2 (Sequence)
+
+## Decision
+
+Every element in the runa codebase — every line of code, every test, every document, every abstraction — traces to a current need or gets removed. New work grounds in what it must enable before building. Existing work that no longer serves today's exigency is debt regardless of how well it functions.
+
+## Context
+
+runa is being built from scratch after a failed migration attempt that carried historical artifacts, naming conventions, and structural assumptions from a predecessor system. That experience demonstrated the cost of preserving elements that no longer earn their place: debugging time spent untangling inherited assumptions exceeded the time a clean build would have taken.
+
+Two disciplines combine here. Grounding asks: what must this enable, and for whom? Zero tech debt asks: does this element still serve a current need? They are the same discipline applied at different moments — grounding prevents unearned elements from entering; zero tech debt removes them when they lose their justification.
+
+Sequence matters: grounding fires before generation, not after. Orient to the need first, then build. Retrofitting justification onto existing code is not grounding.
+
+## Consequences
+
+**No backward compatibility layers.** When a design changes, the old design is replaced. No shims, no adapters, no "support both during transition." The system reflects current requirements only.
+
+**No migration narratives in artifacts.** Documents, comments, and commit messages describe the present system. They do not explain what used to exist or why it changed. History lives in git, not in the codebase.
+
+**No speculative abstractions.** Every abstraction serves a current, concrete use case. "We might need this later" is not justification. If a future need arises, the abstraction is built then — grounded in that need, not in today's guess about it.
+
+**No tests that assert absence.** Tests verify what the system does, not what it doesn't do. A test that asserts "this function does not call X" or "this module does not contain Y" is testing against a ghost. If X and Y were never supposed to be there, there is nothing to test.
+
+**What this means for the builder agent:** Before writing any code, answer: what does this enable? If you cannot trace a component to a requirement in the interface contract or the ADRs, it does not belong. When modifying existing code, apply the same test — if a component no longer traces to a current need, remove it rather than working around it.

--- a/docs/adr/0003-unconditional-responsibility.md
+++ b/docs/adr/0003-unconditional-responsibility.md
@@ -1,0 +1,24 @@
+# ADR-0003: Unconditional Responsibility
+
+**Status:** Accepted
+**Traces to:** Principle 4 (Obligation to Dissent), Principle 3 (Grounding)
+
+## Decision
+
+Every participant — human or agent — is responsible for the whole system's health and trajectory, not just their assignment. If you see a problem, you own it: fix it or queue it. No scoping away, no deferral because something is "preexisting" or "out of scope."
+
+## Context
+
+runa is built and operated by autonomous agents working with minimal supervision. In that environment, problems that no one owns compound silently. A defect noticed but deferred becomes two defects — the original and the process failure that let it pass. An architectural concern flagged but scoped away becomes a structural weakness that every subsequent decision must navigate around.
+
+The integrity of an unsupervised agentic system depends on every participant refusing to let problems pass.
+
+## Consequences
+
+**No scoping away.** If you encounter a defect, a design problem, or an inconsistency while working on something else, you own it. Fix it if the fix is small. File an issue if it requires separate work. Do not note it and move on. Do not rationalize it as someone else's responsibility.
+
+**Ground against mission, not against task list.** The task is the immediate assignment. The mission is the system's purpose and trajectory. If satisfying the task while the system's trajectory drifts, the task has become a ceiling. Every piece of work should ask: does this serve the mission, or just clear an obligation?
+
+**Scope upward, not just outward.** If you are building for one use case when the architecture could serve many, that is a scoping failure. Unconditional responsibility means seeing the larger context and building for it — not gold-plating, but refusing comfortable local optima when the system needs more.
+
+**What this means for the builder agent:** When you see something wrong — a naming inconsistency, a missing edge case, a design that doesn't scale, a document that contradicts the code — act on it. If the fix is within your current scope, fix it. If it requires separate work, file an issue with enough context that someone else can act on it. The worst outcome is a known problem that everyone has seen and no one has addressed.

--- a/docs/adr/0004-compound-improvement.md
+++ b/docs/adr/0004-compound-improvement.md
@@ -1,0 +1,26 @@
+# ADR-0004: Compound Improvement
+
+**Status:** Accepted
+**Traces to:** Principle 5 (Recursive Improvement)
+
+## Decision
+
+Every operation refines both the object and the process that created it. Single-level work — improving only the object — accumulates friction in the process. The system gets better at getting better, or it decays. There is no steady state.
+
+## Context
+
+runa's development process is itself a system that either improves or degrades with each iteration. A bug fix that addresses the symptom but not the condition that allowed the bug leaves the process unchanged — the same class of bug will recur. A skill that works but whose creation process was painful means the next skill will be equally painful. Object-only work is entropy with extra steps.
+
+The recursive spiral — refinement plus propulsion — is the topology that prevents stagnation. Each pass through the system should leave both the output and the machinery in better shape.
+
+## Consequences
+
+**When you fix a bug, also fix what let the bug happen.** The bug is the object. The gap in testing, validation, or design that admitted the bug is the process. Address both. A bug fix without a process improvement is half the work.
+
+**When you add a capability, also improve how capabilities get added.** If adding a new trigger type is painful, the pain is signal. The trigger type is the object; the extension mechanism is the process. Improve both.
+
+**When a correction is needed, produce both the correction and the structural change that prevents recurrence.** A correction that will need to be made again is not a correction — it is a patch. The structural change is what makes it a correction.
+
+**Refactoring is not extra work.** It is the process-level half of every task. If the code you touched is cleaner than when you found it, you did both levels. If it is not, you did only one.
+
+**What this means for the builder agent:** After completing any unit of work, ask: did I address both the immediate thing and the process that produced it? If a test was hard to write, improve the test infrastructure. If a module was hard to understand, improve its documentation or its structure. If an error message was misleading, improve the error reporting pattern, not just the one message. The compounding effect of dual-level work is the difference between a system that improves and one that merely accumulates features.

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -1,0 +1,88 @@
+# runa Interface Contract
+
+This document defines the boundary between runa (the runtime) and methodology plugins. Everything inside this boundary, runa sees and enforces. Everything outside, methodologies own entirely.
+
+## Three Primitives
+
+The interface consists of three primitive concepts. All runtime behavior derives from these.
+
+### 1. Artifact Types
+
+An artifact type is a named category of work product with a machine-checkable contract. Methodologies define their artifact types. runa validates instances against their contracts.
+
+An artifact type declaration:
+
+- **name** — unique identifier within the methodology (e.g., `constraints`, `behavior-contract`, `test-evidence`)
+- **schema** — JSON Schema defining what a valid instance contains. This schema is the artifact's contract. There is no separate contract mechanism.
+
+runa ships no artifact types. Every artifact type is methodology-owned.
+
+### 2. Skill Declarations
+
+A skill declares its relationship to artifacts through four kinds of edges:
+
+- **requires** — the named artifact type must exist and validate before the skill can execute. Hard dependency.
+- **accepts** — the named artifact type may be consumed if available. The skill operates with or without it. Soft dependency.
+- **produces** — the named artifact type will exist and validate after the skill executes. runa fails the skill if a declared output is missing or invalid.
+- **may_produce** — the named artifact type might be produced. runa validates any instance that appears but does not fail the skill for its absence.
+
+A skill declaration:
+
+- **name** — unique identifier
+- **requires** — zero or more artifact type names
+- **accepts** — zero or more artifact type names
+- **produces** — zero or more artifact type names
+- **may_produce** — zero or more artifact type names
+- **triggers** — one trigger condition (see below)
+
+Topology is not declared. It emerges from the graph of requires/produces/may_produce relationships across skills. A pipeline emerges when skills chain linearly. A graph emerges when skills fan in or fan out. A cycle emerges when a skill produces an artifact type that another skill's trigger monitors for change. The methodology does not tell runa what shape it is. runa computes the shape from declarations.
+
+### 3. Trigger Conditions
+
+A trigger condition defines when runa should activate a skill. Triggers are composable from four primitive types:
+
+- **on_artifact(name)** — the named artifact exists and satisfies its schema
+- **on_change(name)** — the named artifact has been modified since runa last activated this skill. runa tracks activation timestamps per skill and compares against artifact modification timestamps.
+- **on_invalid(name)** — an instance of the named artifact type exists but fails validation against its declared schema
+- **on_signal(name)** — an external event (operator action, webhook, scheduler)
+
+These compose through two operators:
+
+- **all_of(conditions...)** — all conditions must be satisfied
+- **any_of(conditions...)** — at least one condition must be satisfied
+
+Nesting is permitted. `all_of(on_artifact("constraints"), any_of(on_signal("approved"), on_artifact("auto-approve")))` means: constraints must exist, and either operator approval or an auto-approve artifact must be present.
+
+## What runa Does
+
+runa is an event-driven runtime. The CLI commands (init, list, doctor, update) are windows into its state. The runtime itself is the monitoring loop.
+
+Given the declarations above, runa provides four runtime capabilities:
+
+**Monitoring.** runa watches artifact state and evaluates trigger conditions on relevant state changes. When a skill's trigger condition becomes satisfied, runa activates the skill.
+
+**Validation.** When an artifact is produced, runa validates it against its declared schema. A skill's execution is not complete until its `produces` artifacts exist and validate. `may_produce` artifacts are validated if present but not required.
+
+**Graph computation.** runa computes the dependency graph from skill declarations. This enables: freshness analysis (which artifacts are stale), execution ordering (what can run now), cycle detection (where the methodology creates loops), and blocked-skill identification (what's waiting on what).
+
+**Enforcement.** A skill cannot execute if its `requires` artifacts are missing or invalid. A skill's execution is incomplete if its `produces` artifacts are missing or invalid. These are hard constraints the runtime enforces regardless of what the methodology intends.
+
+## What runa Does Not Do
+
+runa does not define artifact types. Methodologies do.
+
+runa does not define skill content. Methodologies do.
+
+runa does not prescribe topology. Topologies emerge from declarations.
+
+runa does not interpret methodology semantics. If a methodology calls a stage "grounding" or "verification," runa does not know or care what those words mean. It sees declarations and artifacts.
+
+## Methodology Registration
+
+A methodology registers with runa through a manifest file declaring:
+
+- The methodology's artifact types and their schemas
+- The methodology's skills and their declarations
+- No other configuration
+
+The manifest format is the methodology's only interface with the runtime. runa reads it, builds the graph, begins monitoring.


### PR DESCRIPTION
## Summary

- Place all 6 governance artifacts from the project charter: PRINCIPLES.md, interface contract, and 4 foundational ADRs
- Add MIT license and Rust .gitignore
- File the decomposed epic as 12 sequenced issues (#2–#13) with behavioral acceptance criteria and dependency graph

## Changes

- `docs/PRINCIPLES.md` — seven bedrock principles governing runtime decisions
- `docs/interface-contract.md` — three interface primitives defining the runtime/methodology boundary
- `docs/adr/0001-sovereignty.md` through `docs/adr/0004-compound-improvement.md` — four foundational ADRs
- `LICENSE` — MIT license
- `.gitignore` — Rust standard entries

## Issue(s)

Refs #1

The 12-issue epic (#2–#13) has been filed as a separate deliverable of this bootstrap issue.

## Test plan

- `ls docs/PRINCIPLES.md docs/interface-contract.md docs/adr/000{1,2,3,4}-*.md` — all 6 governance docs present
- `head -1 LICENSE` — MIT license
- `grep /target .gitignore` — Rust target directory ignored
- `gh issue list --state open` — issues #1 through #13 exist
