### PR TITLE
docs: establish architectural documentation and development discipline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# Architecture
+
+Runa is a cognitive runtime for AI agents. This document describes the codebase as it exists today.
+
+## Workspace Structure
+
+Two crates, Rust 2024 edition, resolver v3:
+
+- **`libagent`** — All domain logic: data model, TOML manifest parsing, JSON Schema validation, dependency graph, artifact state tracking, trigger condition evaluation.
+- **`runa-cli`** — Thin CLI binary. Clap-based argument parsing, delegates to libagent. No domain logic.
+
+## Data Flow
+
+These are library capabilities exposed by libagent. No runtime loop exists yet. `runa init` is the only CLI integration point (uses manifest parsing only).
+
+1. **TOML manifest → model types.** `manifest::parse` reads a methodology manifest file, deserializes TOML into `Manifest` (containing `ArtifactType` and `SkillDeclaration` vectors), and validates name uniqueness at parse time.
+
+2. **Skill declarations → dependency graph.** `DependencyGraph::build` takes `&[SkillDeclaration]` and computes edges from requires/accepts → produces/may_produce relationships. Provides topological ordering (Kahn's algorithm), cycle detection (falls back to hard-edges-only on combined-graph cycle), and blocked-skill identification.
+
+3. **Artifact instances → validated state.** `ArtifactStore::record` accepts artifact data, validates it via `validation::validate_artifact` against the type's JSON Schema, computes a SHA-256 content hash, and persists the result to `.runa/artifacts/`. Both valid and invalid states are stored — invalid state is meaningful for trigger evaluation.
+
+4. **Trigger evaluation.** `trigger::evaluate` recursively evaluates a `TriggerCondition` tree against a `TriggerContext` (artifact store, per-skill activation timestamps, active signals) and returns a `TriggerResult`. Pure function, no side effects.
+
+## Modules
+
+### `model.rs`
+
+Core types: `Manifest`, `ArtifactType`, `SkillDeclaration`, `TriggerCondition`. `TriggerCondition` is a tagged enum (`#[serde(tag = "type", rename_all = "snake_case")]`) with six variants: `OnArtifact`, `OnChange`, `OnInvalid`, `OnSignal`, `AllOf`, `AnyOf`. `AllOf`/`AnyOf` hold `Vec<TriggerCondition>` for arbitrary nesting depth.
+
+### `manifest.rs`
+
+TOML parsing and structural validation. `parse` reads from a file path; `from_str` parses a TOML string. Both validate that artifact type names and skill names are unique within the manifest, returning `ManifestError` on duplicates, I/O failures, or TOML parse errors.
+
+### `validation.rs`
+
+JSON Schema validation for artifact instances using the `jsonschema` crate. `validate_artifact` compiles the schema, runs validation, and collects all violations into a `Vec<Violation>` before returning. Each `Violation` carries the artifact type name, a description, and both schema and instance JSON Pointer paths.
+
+### `graph.rs`
+
+Dependency graph built from skill declarations. Edges derive from artifact relationships: `requires` → `produces` creates hard edges, `requires` → `may_produce` and `accepts` → any producer create soft edges. `topological_order` runs Kahn's algorithm on combined (hard+soft) edges first; on cycle, retries hard-edges-only. Hard-edge cycles return `CycleError`. `blocked_skills` identifies skills whose `requires` artifacts are not in a provided available set.
+
+### `store.rs`
+
+Artifact state tracking keyed by `(type_name, instance_id)`. Each `ArtifactState` records the filesystem path, `ValidationStatus` (Valid, Invalid with violations, or Stale), millisecond-precision modification timestamp, and a `sha256:<hex>` content hash computed from canonical JSON (recursively sorted keys). Persists as JSON files under `.runa/artifacts/{type_name}/{instance_id}.json`. Uses atomic write (tmp + rename).
+
+### `trigger.rs`
+
+Recursive trigger condition evaluator. `evaluate` is a pure function that takes a `TriggerCondition`, a `TriggerContext` (read-only references to the artifact store, activation timestamps, and active signals), and a skill name. Six condition variants: `OnArtifact` checks `store.is_valid`, `OnChange` compares latest modification against the skill's activation timestamp, `OnInvalid` checks `store.has_any_invalid`, `OnSignal` checks set membership, `AllOf` short-circuits on first failure, `AnyOf` short-circuits on first success.
+
+## `.runa/` Directory Layout
+
+```
+.runa/
+  state.toml                    # Created by `runa init`: methodology_path, methodology_name
+  artifacts/                    # Created by ArtifactStore (not by init)
+    {type_name}/
+      {instance_id}.json        # ArtifactState: path, status, last_modified_ms, content_hash
+```
+
+## CLI Commands
+
+### `runa init --methodology <PATH>`
+
+Parses the manifest at `<PATH>` via `libagent::manifest::parse`, canonicalizes the path, creates `.runa/state.toml` containing the canonical methodology path and name. Reports the artifact type and skill counts on success.
+
+## Key Design Patterns
+
+- **Custom error types with source chains.** Each module defines its own error enum implementing `std::fmt::Display` and `std::error::Error` with `source()` for chaining.
+- **Inline test modules.** All tests are `#[cfg(test)] mod tests` within their source file.
+- **Tagged enum serialization.** `TriggerCondition` uses `#[serde(tag = "type", rename_all = "snake_case")]` so conditions serialize as `{"type": "on_artifact", "name": "..."}`.
+- **Canonical JSON for content hashing.** Object keys are recursively sorted before SHA-256 hashing, ensuring deterministic hashes regardless of insertion order.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cargo run --bin runa -- --version  # Run CLI
 ## Architecture
 
 **Workspace crates:**
-- `libagent` — Core library: data model, TOML manifest parsing, JSON Schema validation, dependency graph, artifact state tracking
+- `libagent` — Core library: data model, TOML manifest parsing, JSON Schema validation, dependency graph, artifact state tracking, trigger condition evaluation
 - `runa-cli` — CLI binary (minimal, depends on libagent)
 
 **libagent modules:**
@@ -30,6 +30,7 @@ cargo run --bin runa -- --version  # Run CLI
 - `validation.rs` — JSON Schema validation for artifact instances, collects all violations before returning
 - `graph.rs` — Dependency graph from skill declarations: topological ordering, cycle detection, blocked-skill identification
 - `store.rs` — Artifact state tracking: validation status, content hashing, JSON persistence in `.runa/artifacts/`
+- `trigger.rs` — Trigger condition evaluation: recursive evaluator, six condition variants, pure function against TriggerContext
 
 **Key design:**
 - `TriggerCondition` uses tagged enum serialization (`#[serde(tag = "type")]`) with `all_of`/`any_of` composition
@@ -48,3 +49,20 @@ Decisions trace to principles in `docs/PRINCIPLES.md` and ADRs in `docs/adr/`. K
 ## Dependencies
 
 Rust 2024 edition, resolver v3. Minimal dependency set: serde, serde_json, toml, jsonschema, sha2. No async/network dependencies.
+
+## Development Discipline
+
+**Ground before designing.** Define the need before reading the code. What must this change enable, and for whom?
+
+**BDD first.** Behavioral spec → test → implementation → verification. Tests describe what a system should do, not how it does it.
+
+**Coherence on landing.** Every PR that ships must update affected documentation:
+- CLI changes → README.md
+- Module, data flow, or disk layout changes → ARCHITECTURE.md
+- Module list, build commands, or pattern changes → CLAUDE.md Architecture section
+
+**Conventions:**
+- Conventional commits (e.g., `feat(trigger):`, `fix(store):`, `docs:`)
+- Branch names: `issue-N/brief-description`
+- One issue per PR
+- `cargo fmt` and `cargo clippy` clean before merge

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# runa\n\nCognitive runtime for AI agents.
+# runa
+
+Runa is an event-driven cognitive runtime for AI agents. It enforces contracts between methodologies and the runtime through three primitives: **artifact types** (JSON Schema-validated work products), **skill declarations** (relationships to artifacts via requires/accepts/produces/may_produce edges), and **trigger conditions** (composable activation rules).
+
+## Architecture
+
+Runa is a runtime layer between an orchestrating daemon and methodology plugins. Methodologies register via TOML manifests declaring their artifact types, skills, and triggers. Runa computes the dependency graph, validates artifacts against their schemas, tracks state, and evaluates trigger conditions.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for workspace structure, data flow, module descriptions, and disk layout.
+
+## Usage
+
+```bash
+runa init --methodology path/to/manifest.toml
+```
+
+Parses the methodology manifest, validates its structure, and creates a `.runa/` directory with `state.toml` recording the canonical methodology path and name. Reports the artifact type and skill counts on success.
+
+## Build
+
+Rust 2024 edition.
+
+```bash
+cargo build          # Debug build
+cargo test --lib     # Run all unit tests
+```
+
+## Documentation
+
+- [PRINCIPLES.md](docs/PRINCIPLES.md) — Seven bedrock principles governing runtime and boundary decisions
+- [Interface Contract](docs/interface-contract.md) — Three primitives defining the methodology-runtime boundary
+- [ADRs](docs/adr/) — Architectural decision records

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -1,3 +1,18 @@
+//! Core library for the runa cognitive runtime.
+//!
+//! libagent provides the data model, parsing, validation, and evaluation logic
+//! that the runtime uses to enforce contracts between methodologies and agents.
+//! The CLI is a thin layer over this library.
+//!
+//! - [`model`] — Core types: `Manifest`, `ArtifactType`, `SkillDeclaration`, `TriggerCondition`
+//! - [`manifest`] — TOML manifest parsing with uniqueness validation
+//! - [`validation`] — JSON Schema validation for artifact instances
+//! - [`graph`] — Dependency graph: topological ordering, cycle detection, blocked-skill identification
+//! - [`store`] — Artifact state tracking: validation status, content hashing, JSON persistence
+//! - [`trigger`] — Trigger condition evaluation against runtime state
+//!
+//! See `ARCHITECTURE.md` in the repository root for data flow and design details.
+
 pub mod graph;
 pub mod manifest;
 pub mod model;


### PR DESCRIPTION
## Summary

- Create `ARCHITECTURE.md` documenting workspace structure, data flow through all six libagent modules, `.runa/` directory layout, CLI commands, and key design patterns
- Rewrite `README.md` with project description, architecture pointer, `runa init` usage, build instructions, and documentation links
- Update `CLAUDE.md` with missing `trigger.rs` module entry, updated libagent description, and new Development Discipline section (ground before designing, BDD first, coherence on landing, conventions)
- Add `//!` crate doc comment to `libagent/src/lib.rs` with module list and ARCHITECTURE.md pointer

## Changes

**New file: `ARCHITECTURE.md`** — The main deliverable. Describes the codebase as it exists today: two-crate workspace, four-stage data flow (manifest parsing → dependency graph → artifact store → trigger evaluation), one-paragraph descriptions of all six libagent modules, `.runa/` disk layout, `runa init` CLI command, and design patterns (error source chains, inline tests, tagged enums, canonical JSON hashing).

**Rewritten: `README.md`** — Replaces single-line placeholder with proper project orientation: what runa is, three-primitive summary, architecture pointer, init usage, build commands, and links to PRINCIPLES.md, interface-contract.md, and ADRs.

**Updated: `CLAUDE.md`** — Adds `trigger.rs` to the module list (was missing), updates libagent description to mention trigger evaluation, and adds a Development Discipline section encoding four rules: ground before designing, BDD first, coherence on landing (per-PR documentation checklist), and conventions (conventional commits, branch naming, fmt/clippy).

**Updated: `libagent/src/lib.rs`** — Adds `//!` doc comment with 2-sentence purpose statement, module list with one-line descriptions, and pointer to ARCHITECTURE.md.

All documentation describes current code only. The factual correction from the plan applies: `runa init` uses manifest parsing only (not ArtifactStore), and ARCHITECTURE.md reflects this.

## Issue(s)

Closes #24

## Test plan

- [x] `cargo test --lib` — 90 tests pass (lib.rs doc comment doesn't break compilation)
- [x] `cargo doc --no-deps` — crate doc renders correctly
- [x] Every module named in ARCHITECTURE.md, CLAUDE.md, and lib.rs exists in `libagent/src/`
- [x] `.runa/` layout matches what `init.rs` and `store.rs` actually create
- [x] CLI usage in README matches `main.rs` clap definition
- [x] No document describes unimplemented features as current
