### PR TITLE
docs: remove stale CLI integration claim from ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Two crates, Rust 2024 edition, resolver v3:
 
 ## Data Flow
 
-These are library capabilities exposed by libagent. No runtime loop exists yet. `runa init` is the only CLI integration point (uses manifest parsing only).
+These are library capabilities exposed by libagent. No runtime loop exists yet.
 
 1. **TOML manifest → model types.** `manifest::parse` reads a methodology manifest file, deserializes TOML into `Manifest` (containing `ArtifactType` and `SkillDeclaration` vectors), and validates name uniqueness at parse time.
 


### PR DESCRIPTION
## Summary

- Remove stale claim in ARCHITECTURE.md Data Flow section that "`runa init` is the only CLI integration point"
- The claim was false since `runa list` and `runa doctor` were added; the CLI Commands section already documents all three accurately

## Test plan

- Read ARCHITECTURE.md and confirm Data Flow no longer makes overclaiming statements about CLI commands
- Verify the CLI Commands section (unchanged) still accurately describes all three commands
