### PR TITLE
refactor(config): separate configuration from runtime state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,13 @@ cargo run --bin runa -- --version  # Run CLI
 - `manifest.rs` — TOML parsing with validation (uniqueness checks at parse time)
 - `validation.rs` — JSON Schema validation for artifact instances, collects all violations before returning
 - `graph.rs` — Dependency graph from skill declarations: topological ordering, cycle detection, blocked-skill identification
-- `store.rs` — Artifact state tracking: validation status, content hashing, JSON persistence in `.runa/artifacts/`
+- `store.rs` — Artifact state tracking: validation status, content hashing, JSON persistence in `.runa/artifacts/` (configurable via `artifacts_dir` in config)
 - `trigger.rs` — Trigger condition evaluation: recursive evaluator, six condition variants, pure function against TriggerContext
 - `enforcement.rs` — Pre/post-execution enforcement: `enforce_preconditions` checks `requires`, `enforce_postconditions` checks `produces`/`may_produce`, three failure variants (Missing, Invalid, Stale)
 
 **runa-cli modules:**
-- `project.rs` — Shared `State` struct and `load()` function: reads `.runa/state.toml`, parses manifest, builds graph, opens store
-- `commands/init.rs` — `runa init`: parse manifest, create `.runa/state.toml`
+- `project.rs` — `Config` and `State` structs, config resolution chain (`--config` / `RUNA_CONFIG` / `.runa/config.toml` / XDG), `load()` function: resolves config, reads state, parses manifest, builds graph, opens store
+- `commands/init.rs` — `runa init`: parse manifest, create `.runa/config.toml` and `.runa/state.toml`
 - `commands/list.rs` — `runa list`: display skills in execution order with dependencies and blocked status
 - `commands/doctor.rs` — `runa doctor`: check artifact health, skill readiness, cycle detection; exit 1 on problems
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,19 +59,22 @@ Returns `EnforcementError` on failure, containing the skill name, enforcement ph
 
 ```
 .runa/
-  state.toml                    # Created by `runa init`: methodology_path, methodology_name
-  artifacts/                    # Created by ArtifactStore (not by init)
+  config.toml                   # Created by `runa init`: methodology_path, optional artifacts_dir
+  state.toml                    # Created by `runa init`: initialized_at, runa_version
+  artifacts/                    # Default artifact storage (configurable via artifacts_dir)
     {type_name}/
       {instance_id}.json        # ArtifactState: path, status, last_modified_ms, content_hash
 ```
 
 ## CLI Commands
 
-All commands that operate on an initialized project share `project::load`, which reads `.runa/state.toml`, parses the referenced methodology manifest, builds the dependency graph, and opens the artifact store.
+All commands that operate on an initialized project share `project::load`, which resolves the config file, reads the methodology path from it, parses the manifest, builds the dependency graph, and opens the artifact store.
 
-### `runa init --methodology <PATH>`
+Config resolution is whole-file (first found wins, no per-field merging): `--config` CLI flag → `RUNA_CONFIG` env var → `.runa/config.toml` → `$XDG_CONFIG_HOME/runa/config.toml` → error.
 
-Parses the manifest at `<PATH>` via `libagent::manifest::parse`, canonicalizes the path, creates `.runa/state.toml` containing the canonical methodology path and name. Reports the artifact type and skill counts on success.
+### `runa init --methodology <PATH> [--artifacts-dir <DIR>] [--config <PATH>]`
+
+Parses the manifest at `<PATH>` via `libagent::manifest::parse`, canonicalizes the path, creates `.runa/config.toml` (or writes to the `--config` path) containing the canonical methodology path and optional artifacts directory. Creates `.runa/state.toml` recording initialization timestamp and runa version. Reports the artifact type and skill counts on success.
 
 ### `runa list`
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for workspace structure, data flow, modul
 ## Usage
 
 ```bash
-runa init --methodology path/to/manifest.toml
+runa init --methodology path/to/manifest.toml [--artifacts-dir path/to/artifacts]
 ```
 
-Parses the methodology manifest, validates its structure, and creates a `.runa/` directory with `state.toml` recording the canonical methodology path and name. Reports the artifact type and skill counts on success.
+Parses the methodology manifest, validates its structure, and creates a `.runa/` directory with `config.toml` (operator configuration: methodology path, optional artifacts directory) and `state.toml` (runtime state: initialization timestamp, runa version). Reports the artifact type and skill counts on success.
+
+All commands support `--config <PATH>` to override the config file location. The `RUNA_CONFIG` env var serves the same purpose. For `init`, `--config` controls where the config file is written; for other commands, it controls where the config file is read from.
 
 ```bash
 runa list

--- a/runa-cli/src/commands/doctor.rs
+++ b/runa-cli/src/commands/doctor.rs
@@ -27,8 +27,8 @@ impl std::error::Error for DoctorError {
 }
 
 /// Run the doctor command. Returns `true` if healthy, `false` if problems found.
-pub fn run(working_dir: &Path) -> Result<bool, DoctorError> {
-    let loaded = project::load(working_dir).map_err(DoctorError::Project)?;
+pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<bool, DoctorError> {
+    let loaded = project::load(working_dir, config_override).map_err(DoctorError::Project)?;
 
     let mut problems = 0;
 

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::project::{RUNA_DIR, STATE_FILENAME, State};
+use crate::project::{CONFIG_FILENAME, Config, RUNA_DIR, STATE_FILENAME, State};
 
 #[derive(Debug)]
 pub struct InitSummary {
@@ -40,7 +40,16 @@ impl std::error::Error for InitError {
     }
 }
 
-pub fn run(working_dir: &Path, methodology: &Path) -> Result<InitSummary, InitError> {
+/// Run `runa init`.
+///
+/// `config_path` is where to write the config file. When `--config` is provided,
+/// it points there; otherwise it defaults to `.runa/config.toml` in working_dir.
+pub fn run(
+    working_dir: &Path,
+    methodology: &Path,
+    artifacts_dir: Option<&str>,
+    config_path: Option<&Path>,
+) -> Result<InitSummary, InitError> {
     if !methodology.exists() {
         return Err(InitError::MethodologyNotFound {
             path: methodology.to_path_buf(),
@@ -54,9 +63,26 @@ pub fn run(working_dir: &Path, methodology: &Path) -> Result<InitSummary, InitEr
     let runa_dir = working_dir.join(RUNA_DIR);
     fs::create_dir_all(&runa_dir).map_err(InitError::Io)?;
 
-    let state = State {
+    // Write config.
+    let config = Config {
         methodology_path: canonical_path.display().to_string(),
-        methodology_name: manifest.name.clone(),
+        artifacts_dir: artifacts_dir.map(String::from),
+    };
+    let config_toml = toml::to_string(&config).expect("Config serialization should not fail");
+
+    let config_dest = match config_path {
+        Some(p) => p.to_path_buf(),
+        None => runa_dir.join(CONFIG_FILENAME),
+    };
+    if let Some(parent) = config_dest.parent() {
+        fs::create_dir_all(parent).map_err(InitError::Io)?;
+    }
+    fs::write(&config_dest, config_toml).map_err(InitError::Io)?;
+
+    // Write state.
+    let state = State {
+        initialized_at: now_iso8601(),
+        runa_version: env!("CARGO_PKG_VERSION").to_string(),
     };
     let state_toml = toml::to_string(&state).expect("State serialization should not fail");
     fs::write(runa_dir.join(STATE_FILENAME), state_toml).map_err(InitError::Io)?;
@@ -66,6 +92,42 @@ pub fn run(working_dir: &Path, methodology: &Path) -> Result<InitSummary, InitEr
         artifact_type_count: manifest.artifact_types.len(),
         skill_count: manifest.skills.len(),
     })
+}
+
+fn now_iso8601() -> String {
+    // UTC timestamp without external dependencies.
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch");
+    let secs = duration.as_secs();
+
+    // Convert to calendar components (UTC).
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Days since 1970-01-01 to (year, month, day) — civil calendar algorithm.
+    let (year, month, day) = days_to_date(days);
+
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+/// Convert days since 1970-01-01 to (year, month, day).
+/// Uses the algorithm from Howard Hinnant's date library.
+fn days_to_date(days: u64) -> (u64, u64, u64) {
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
 }
 
 #[cfg(test)]
@@ -103,7 +165,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
     }
 
     #[test]
-    fn valid_manifest_creates_runa_dir_and_state_file() {
+    fn valid_manifest_creates_config_and_state_files() {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join("manifest.toml");
         fs::write(&manifest_path, valid_manifest_toml()).unwrap();
@@ -111,7 +173,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        let summary = run(&working, &manifest_path).unwrap();
+        let summary = run(&working, &manifest_path, None, None).unwrap();
 
         assert_eq!(summary.methodology_name, "groundwork");
         assert_eq!(summary.artifact_type_count, 2);
@@ -119,9 +181,123 @@ trigger = { type = "on_artifact", name = "design-doc" }
 
         let runa_dir = working.join(".runa");
         assert!(runa_dir.is_dir());
+        assert!(runa_dir.join("config.toml").is_file());
+        assert!(runa_dir.join("state.toml").is_file());
+    }
 
-        let state_path = runa_dir.join("state.toml");
-        assert!(state_path.is_file());
+    #[test]
+    fn config_file_records_methodology_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        run(&working, &manifest_path, None, None).unwrap();
+
+        let config_content = fs::read_to_string(working.join(".runa").join("config.toml")).unwrap();
+        let canonical = fs::canonicalize(&manifest_path).unwrap();
+        assert!(
+            config_content.contains(&canonical.display().to_string()),
+            "config file should contain canonical methodology path"
+        );
+    }
+
+    #[test]
+    fn config_file_records_artifacts_dir_when_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        run(&working, &manifest_path, Some("my-artifacts"), None).unwrap();
+
+        let config_content = fs::read_to_string(working.join(".runa").join("config.toml")).unwrap();
+        assert!(
+            config_content.contains("my-artifacts"),
+            "config file should contain custom artifacts_dir"
+        );
+    }
+
+    #[test]
+    fn config_file_omits_artifacts_dir_when_not_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        run(&working, &manifest_path, None, None).unwrap();
+
+        let config_content = fs::read_to_string(working.join(".runa").join("config.toml")).unwrap();
+        assert!(
+            !config_content.contains("artifacts_dir"),
+            "config file should not contain artifacts_dir when not provided"
+        );
+    }
+
+    #[test]
+    fn state_file_records_version_and_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        run(&working, &manifest_path, None, None).unwrap();
+
+        let state_content = fs::read_to_string(working.join(".runa").join("state.toml")).unwrap();
+        let state: State = toml::from_str(&state_content).unwrap();
+        assert_eq!(state.runa_version, env!("CARGO_PKG_VERSION"));
+        assert!(
+            state.initialized_at.ends_with('Z'),
+            "timestamp should be UTC ISO 8601"
+        );
+    }
+
+    #[test]
+    fn state_file_does_not_contain_methodology_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        run(&working, &manifest_path, None, None).unwrap();
+
+        let state_content = fs::read_to_string(working.join(".runa").join("state.toml")).unwrap();
+        assert!(
+            !state_content.contains("methodology_path"),
+            "state file should not contain methodology_path"
+        );
+    }
+
+    #[test]
+    fn custom_config_path_writes_config_there() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        let custom_config = dir.path().join("custom").join("config.toml");
+        run(&working, &manifest_path, None, Some(&custom_config)).unwrap();
+
+        assert!(custom_config.is_file(), "config should be at custom path");
+        // Default location should not exist.
+        assert!(
+            !working.join(".runa").join("config.toml").is_file(),
+            "default config should not be created when custom path is given"
+        );
+        // State should still be in the project.
+        assert!(working.join(".runa").join("state.toml").is_file());
     }
 
     #[test]
@@ -129,7 +305,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let dir = tempfile::tempdir().unwrap();
         let bogus = dir.path().join("no-such-file.toml");
 
-        let err = run(dir.path(), &bogus).unwrap_err();
+        let err = run(dir.path(), &bogus, None, None).unwrap_err();
         assert!(
             matches!(err, InitError::MethodologyNotFound { .. }),
             "expected MethodologyNotFound, got: {err}"
@@ -142,11 +318,23 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let manifest_path = dir.path().join("bad.toml");
         fs::write(&manifest_path, "not valid manifest").unwrap();
 
-        let err = run(dir.path(), &manifest_path).unwrap_err();
+        let err = run(dir.path(), &manifest_path, None, None).unwrap_err();
         assert!(
             matches!(err, InitError::ManifestInvalid(_)),
             "expected ManifestInvalid, got: {err}"
         );
+    }
+
+    #[test]
+    fn days_to_date_known_timestamps() {
+        // 2025-03-13 = 20160 days since 1970-01-01
+        assert_eq!(days_to_date(20160), (2025, 3, 13));
+        // Unix epoch: 1970-01-01 = day 0
+        assert_eq!(days_to_date(0), (1970, 1, 1));
+        // 2000-02-29 (leap day) = 11016 days since epoch
+        assert_eq!(days_to_date(11016), (2000, 2, 29));
+        // 2000-03-01 = 11017 days
+        assert_eq!(days_to_date(11017), (2000, 3, 1));
     }
 
     #[test]
@@ -158,34 +346,11 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        let summary1 = run(&working, &manifest_path).unwrap();
-        let summary2 = run(&working, &manifest_path).unwrap();
+        let summary1 = run(&working, &manifest_path, None, None).unwrap();
+        let summary2 = run(&working, &manifest_path, None, None).unwrap();
 
         assert_eq!(summary1.methodology_name, summary2.methodology_name);
         assert_eq!(summary1.artifact_type_count, summary2.artifact_type_count);
         assert_eq!(summary1.skill_count, summary2.skill_count);
-    }
-
-    #[test]
-    fn state_file_records_methodology_path_and_name() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("manifest.toml");
-        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
-
-        let working = dir.path().join("project");
-        fs::create_dir(&working).unwrap();
-
-        run(&working, &manifest_path).unwrap();
-
-        let state_content = fs::read_to_string(working.join(".runa").join("state.toml")).unwrap();
-        assert!(
-            state_content.contains("groundwork"),
-            "state file should contain methodology name"
-        );
-        let canonical = fs::canonicalize(&manifest_path).unwrap();
-        assert!(
-            state_content.contains(&canonical.display().to_string()),
-            "state file should contain canonical methodology path"
-        );
     }
 }

--- a/runa-cli/src/commands/list.rs
+++ b/runa-cli/src/commands/list.rs
@@ -25,8 +25,8 @@ impl std::error::Error for ListError {
     }
 }
 
-pub fn run(working_dir: &Path) -> Result<(), ListError> {
-    let loaded = project::load(working_dir).map_err(ListError::Project)?;
+pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), ListError> {
+    let loaded = project::load(working_dir, config_override).map_err(ListError::Project)?;
 
     println!("Methodology: {}", loaded.manifest.name);
 

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -9,6 +9,10 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(name = "runa", version)]
 struct Cli {
+    /// Path to config file (overrides RUNA_CONFIG and default locations)
+    #[arg(long, global = true)]
+    config: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -20,6 +24,10 @@ enum Commands {
         /// Path to the methodology manifest file
         #[arg(long)]
         methodology: PathBuf,
+
+        /// Directory for artifact storage (default: .runa/artifacts/)
+        #[arg(long)]
+        artifacts_dir: Option<String>,
     },
     /// Display skills, dependencies, and execution order
     List,
@@ -30,8 +38,19 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
 
+    // Resolve config override: --config flag takes precedence over RUNA_CONFIG env var.
+    let config_override: Option<PathBuf> = cli.config.or_else(|| {
+        std::env::var("RUNA_CONFIG")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+    });
+
     match cli.command {
-        Commands::Init { methodology } => {
+        Commands::Init {
+            methodology,
+            artifacts_dir,
+        } => {
             let working_dir = match std::env::current_dir() {
                 Ok(d) => d,
                 Err(e) => {
@@ -40,7 +59,12 @@ fn main() {
                 }
             };
 
-            match commands::init::run(&working_dir, &methodology) {
+            match commands::init::run(
+                &working_dir,
+                &methodology,
+                artifacts_dir.as_deref(),
+                config_override.as_deref(),
+            ) {
                 Ok(summary) => {
                     println!(
                         "Initialized runa project with methodology '{}'",
@@ -66,7 +90,7 @@ fn main() {
                 }
             };
 
-            if let Err(e) = commands::list::run(&working_dir) {
+            if let Err(e) = commands::list::run(&working_dir, config_override.as_deref()) {
                 eprintln!("error: {e}");
                 process::exit(1);
             }
@@ -80,7 +104,7 @@ fn main() {
                 }
             };
 
-            match commands::doctor::run(&working_dir) {
+            match commands::doctor::run(&working_dir, config_override.as_deref()) {
                 Ok(healthy) => {
                     if !healthy {
                         process::exit(1);

--- a/runa-cli/src/project.rs
+++ b/runa-cli/src/project.rs
@@ -1,19 +1,28 @@
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
 use libagent::{ArtifactStore, DependencyGraph, GraphError, Manifest, ManifestError, StoreError};
 
 pub const RUNA_DIR: &str = ".runa";
+pub const CONFIG_FILENAME: &str = "config.toml";
 pub const STATE_FILENAME: &str = "state.toml";
-const ARTIFACTS_DIR: &str = "artifacts";
+const DEFAULT_ARTIFACTS_DIR: &str = "artifacts";
 
-/// On-disk format for `.runa/state.toml`.
+/// On-disk format for `.runa/config.toml` — operator configuration.
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub methodology_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts_dir: Option<String>,
+}
+
+/// On-disk format for `.runa/state.toml` — runtime state managed by runa itself.
 #[derive(Serialize, Deserialize)]
 pub struct State {
-    pub methodology_path: String,
-    pub methodology_name: String,
+    pub initialized_at: String,
+    pub runa_version: String,
 }
 
 /// A fully loaded runa project: manifest, dependency graph, and artifact store.
@@ -26,7 +35,13 @@ pub struct LoadedProject {
 /// Errors that can occur when loading a runa project.
 #[derive(Debug)]
 pub enum ProjectError {
-    /// `.runa/state.toml` is missing — not an initialized project.
+    /// No config file found in the resolution chain.
+    ConfigNotFound,
+    /// An explicitly provided config path does not exist.
+    ConfigPathNotFound(PathBuf),
+    /// Config file exists but cannot be parsed.
+    ConfigParseFailed(String),
+    /// `.runa/state.toml` is missing — project not initialized.
     NotInitialized,
     /// Filesystem I/O failure.
     Io(std::io::Error),
@@ -43,6 +58,15 @@ pub enum ProjectError {
 impl fmt::Display for ProjectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ProjectError::ConfigNotFound => {
+                write!(f, "no config found (run 'runa init' first)")
+            }
+            ProjectError::ConfigPathNotFound(path) => {
+                write!(f, "config not found: {}", path.display())
+            }
+            ProjectError::ConfigParseFailed(detail) => {
+                write!(f, "failed to parse config: {detail}")
+            }
             ProjectError::NotInitialized => {
                 write!(f, "not a runa project (run 'runa init' first)")
             }
@@ -69,14 +93,71 @@ impl std::error::Error for ProjectError {
     }
 }
 
+/// Resolve the config file path using the resolution chain.
+///
+/// The chain returns the first config file found and uses it entirely.
+/// There is no per-field merging across config files — this is intentional.
+/// Merging adds complexity for a use case that doesn't exist.
+///
+/// Resolution order:
+/// 1. Explicit override (from `--config` CLI flag or `RUNA_CONFIG` env var)
+/// 2. `.runa/config.toml` in working directory
+/// 3. `$XDG_CONFIG_HOME/runa/config.toml` (falls back to `$HOME/.config/runa/config.toml`)
+pub(crate) fn resolve_config(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+) -> Result<PathBuf, ProjectError> {
+    // 1. Explicit override — caller already resolved --config vs RUNA_CONFIG.
+    if let Some(path) = config_override {
+        return if path.exists() {
+            Ok(path.to_path_buf())
+        } else {
+            Err(ProjectError::ConfigPathNotFound(path.to_path_buf()))
+        };
+    }
+
+    // 2. Project-level config.
+    let project_config = working_dir.join(RUNA_DIR).join(CONFIG_FILENAME);
+    if project_config.exists() {
+        return Ok(project_config);
+    }
+
+    // 3. XDG config.
+    let xdg_base = match std::env::var("XDG_CONFIG_HOME") {
+        Ok(val) if !val.is_empty() => PathBuf::from(val),
+        _ => {
+            let home = std::env::var("HOME").unwrap_or_default();
+            if home.is_empty() {
+                return Err(ProjectError::ConfigNotFound);
+            }
+            PathBuf::from(home).join(".config")
+        }
+    };
+    let xdg_config = xdg_base.join("runa").join(CONFIG_FILENAME);
+    if xdg_config.exists() {
+        return Ok(xdg_config);
+    }
+
+    Err(ProjectError::ConfigNotFound)
+}
+
 /// Load a runa project from `working_dir`.
 ///
-/// Reads `.runa/state.toml`, parses the methodology manifest it references,
-/// builds the dependency graph, and opens the artifact store.
-pub fn load(working_dir: &Path) -> Result<LoadedProject, ProjectError> {
+/// Resolves config via the resolution chain, reads state, parses the methodology
+/// manifest, builds the dependency graph, and opens the artifact store.
+pub fn load(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+) -> Result<LoadedProject, ProjectError> {
+    let config_path = resolve_config(working_dir, config_override)?;
+
+    let config_content = std::fs::read_to_string(&config_path).map_err(ProjectError::Io)?;
+    let config: Config = toml::from_str(&config_content)
+        .map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))?;
+
+    // Verify state.toml exists (project was initialized).
     let runa_dir = working_dir.join(RUNA_DIR);
     let state_path = runa_dir.join(STATE_FILENAME);
-
     let state_content = match std::fs::read_to_string(&state_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -84,17 +165,20 @@ pub fn load(working_dir: &Path) -> Result<LoadedProject, ProjectError> {
         }
         Err(e) => return Err(ProjectError::Io(e)),
     };
-
-    let state: State = toml::from_str(&state_content)
+    let _state: State = toml::from_str(&state_content)
         .map_err(|e| ProjectError::StateParseFailed(e.to_string()))?;
 
-    let manifest = libagent::manifest::parse(Path::new(&state.methodology_path))
+    let manifest = libagent::manifest::parse(Path::new(&config.methodology_path))
         .map_err(ProjectError::ManifestInvalid)?;
 
     let graph = DependencyGraph::build(&manifest.skills).map_err(ProjectError::GraphInvalid)?;
 
-    let store_dir = runa_dir.join(ARTIFACTS_DIR);
-    let store = ArtifactStore::new(manifest.artifact_types.clone(), store_dir)
+    // Resolve artifacts dir: explicit config value or default, relative to working dir.
+    let artifacts_dir = match &config.artifacts_dir {
+        Some(dir) => working_dir.join(dir),
+        None => runa_dir.join(DEFAULT_ARTIFACTS_DIR),
+    };
+    let store = ArtifactStore::new(manifest.artifact_types.clone(), artifacts_dir)
         .map_err(ProjectError::StoreError)?;
 
     Ok(LoadedProject {
@@ -102,4 +186,239 @@ pub fn load(working_dir: &Path) -> Result<LoadedProject, ProjectError> {
         graph,
         store,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // LoadedProject can't derive Debug (ArtifactStore doesn't impl it),
+    // but unwrap_err() requires T: Debug. Provide a minimal impl for tests.
+    impl std::fmt::Debug for LoadedProject {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("LoadedProject").finish_non_exhaustive()
+        }
+    }
+
+    fn valid_manifest_toml() -> &'static str {
+        r#"
+name = "test-methodology"
+
+[[artifact_types]]
+name = "constraints"
+schema = { type = "object" }
+
+[[skills]]
+name = "ground"
+produces = ["constraints"]
+trigger = { type = "on_signal", name = "init" }
+"#
+    }
+
+    fn write_project_files(working: &Path, manifest_path: &Path) {
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+
+        let canonical = fs::canonicalize(manifest_path).unwrap();
+        let config = Config {
+            methodology_path: canonical.display().to_string(),
+            artifacts_dir: None,
+        };
+        fs::write(
+            runa_dir.join("config.toml"),
+            toml::to_string(&config).unwrap(),
+        )
+        .unwrap();
+
+        let state = State {
+            initialized_at: "2026-01-01T00:00:00Z".to_string(),
+            runa_version: "0.1.0".to_string(),
+        };
+        fs::write(
+            runa_dir.join("state.toml"),
+            toml::to_string(&state).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn load_reads_config_and_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        write_project_files(&working, &manifest_path);
+
+        let loaded = load(&working, None).unwrap();
+        assert_eq!(loaded.manifest.name, "test-methodology");
+    }
+
+    #[test]
+    fn load_with_explicit_config_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        // Write state.toml in the project but config elsewhere.
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        let state = State {
+            initialized_at: "2026-01-01T00:00:00Z".to_string(),
+            runa_version: "0.1.0".to_string(),
+        };
+        fs::write(
+            runa_dir.join("state.toml"),
+            toml::to_string(&state).unwrap(),
+        )
+        .unwrap();
+
+        let canonical = fs::canonicalize(&manifest_path).unwrap();
+        let external_config_path = dir.path().join("external-config.toml");
+        let config = Config {
+            methodology_path: canonical.display().to_string(),
+            artifacts_dir: None,
+        };
+        fs::write(&external_config_path, toml::to_string(&config).unwrap()).unwrap();
+
+        let loaded = load(&working, Some(&external_config_path)).unwrap();
+        assert_eq!(loaded.manifest.name, "test-methodology");
+    }
+
+    #[test]
+    fn load_with_custom_artifacts_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+
+        let canonical = fs::canonicalize(&manifest_path).unwrap();
+        let config = Config {
+            methodology_path: canonical.display().to_string(),
+            artifacts_dir: Some("custom-artifacts".to_string()),
+        };
+        fs::write(
+            runa_dir.join("config.toml"),
+            toml::to_string(&config).unwrap(),
+        )
+        .unwrap();
+
+        let state = State {
+            initialized_at: "2026-01-01T00:00:00Z".to_string(),
+            runa_version: "0.1.0".to_string(),
+        };
+        fs::write(
+            runa_dir.join("state.toml"),
+            toml::to_string(&state).unwrap(),
+        )
+        .unwrap();
+
+        // load succeeds — artifacts_dir is resolved but doesn't need to exist yet
+        let _loaded = load(&working, None).unwrap();
+    }
+
+    #[test]
+    fn missing_config_returns_config_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = load(dir.path(), None).unwrap_err();
+        assert!(
+            matches!(err, ProjectError::ConfigNotFound),
+            "expected ConfigNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_state_returns_not_initialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+
+        // Write config but no state.
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        let canonical = fs::canonicalize(&manifest_path).unwrap();
+        let config = Config {
+            methodology_path: canonical.display().to_string(),
+            artifacts_dir: None,
+        };
+        fs::write(
+            runa_dir.join("config.toml"),
+            toml::to_string(&config).unwrap(),
+        )
+        .unwrap();
+
+        let err = load(&working, None).unwrap_err();
+        assert!(
+            matches!(err, ProjectError::NotInitialized),
+            "expected NotInitialized, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_config_prefers_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join("override.toml");
+        fs::write(&override_path, "methodology_path = \"x\"").unwrap();
+
+        // Also create project-level config to prove override wins.
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(runa_dir.join("config.toml"), "methodology_path = \"y\"").unwrap();
+
+        let resolved = resolve_config(&working, Some(&override_path)).unwrap();
+        assert_eq!(resolved, override_path);
+    }
+
+    #[test]
+    fn resolve_config_falls_back_to_project_level() {
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(runa_dir.join("config.toml"), "methodology_path = \"x\"").unwrap();
+
+        let resolved = resolve_config(&working, None).unwrap();
+        assert_eq!(resolved, runa_dir.join("config.toml"));
+    }
+
+    #[test]
+    fn resolve_config_returns_error_when_none_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_config(dir.path(), None).unwrap_err();
+        assert!(
+            matches!(err, ProjectError::ConfigNotFound),
+            "expected ConfigNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_config_explicit_path_not_found_returns_distinct_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let bogus = dir.path().join("nonexistent.toml");
+        let err = resolve_config(dir.path(), Some(&bogus)).unwrap_err();
+        assert!(
+            matches!(err, ProjectError::ConfigPathNotFound(_)),
+            "expected ConfigPathNotFound, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("nonexistent.toml"),
+            "error should include the path"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Split `State` into `Config` (operator configuration: `methodology_path`, optional `artifacts_dir`) and `State` (runtime state: `initialized_at`, `runa_version`)
- Implement config resolution chain: `--config` CLI flag → `RUNA_CONFIG` env var → `.runa/config.toml` → `$XDG_CONFIG_HOME/runa/config.toml` → error (whole-file, no per-field merging)
- `--config` is consistent across all commands: `init` writes to that path, other commands read from it

## Changes

**`project.rs`** — New `Config` and `State` structs, `resolve_config()` with whole-file resolution chain, `load()` accepts `config_override` parameter. 7 tests covering resolution chain, config/state loading, and error cases.

**`commands/init.rs`** — Writes both `config.toml` and `state.toml`. Accepts `--artifacts-dir` and `--config` parameters. ISO 8601 UTC timestamps via `SystemTime` (no new dependencies). 11 tests.

**`main.rs`** — `--config` global flag, `--artifacts-dir` on `Init`. Config override resolution happens once in main.

**`list.rs`, `doctor.rs`** — Updated signatures to pass `config_override` through to `load()`.

**Docs** — ARCHITECTURE.md (directory layout, CLI commands, config resolution), README.md (usage, config flag), AGENTS.md (module descriptions) all updated.

## Issue(s)

Closes #29

## Test plan

- `cargo test --bin runa` — 18 tests covering config/state separation, resolution chain, init with custom paths, error cases
- `cargo test --lib` — 128 libagent tests unchanged and passing
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean (only pre-existing libagent warnings)
