### PR TITLE
fix(cli): CLI diagnostic consistency and signal dispatch cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,13 +96,13 @@ Manages persisted operator signals without loading the manifest or artifact stor
 
 ### `runa list`
 
-Runs an implicit workspace scan, then displays skills in topological (execution) order with their artifact relationships and trigger conditions. For each skill, shows non-empty relationship fields (requires, accepts, produces, may_produce), the trigger condition, and a `BLOCKED` indicator if required artifact types have no valid instances. On cycle detection, falls back to manifest order with a warning.
+Runs an implicit workspace scan, then displays skills in topological (execution) order with their artifact relationships and trigger conditions. For each skill, shows non-empty relationship fields (requires, accepts, produces, may_produce), the trigger condition, and a `BLOCKED` indicator when `enforce_preconditions` reports required artifact failures. `BLOCKED` reasons are rendered with the shared `missing` / `invalid` / `stale` taxonomy. On cycle detection, falls back to manifest order with a warning.
 
 ### `runa doctor`
 
 Runs an implicit workspace scan, then reports on project health. Three checks:
 1. **Artifact health** — enumerates instances per artifact type via `store.instances_of()`, reports invalid, malformed, or stale instances with details.
-2. **Skill readiness** — for each skill, checks whether all `requires` artifact types have valid instances. Reports missing or invalid artifact types.
+2. **Skill readiness** — for each skill, uses `enforce_preconditions` to check `requires` artifact types and reports `missing`, `invalid`, or `stale` failures.
 3. **Cycle detection** — runs `graph.topological_order()`, reports any cycle.
 
 Exits 0 if no problems found, 1 otherwise.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ runa list
 ```
 
 Displays skills in execution order with their artifact relationships, trigger conditions, and blocked status. Performs an implicit scan first so the output reflects the current workspace.
+Blocked skills report required-artifact failures using the same `missing`, `invalid`, and `stale` taxonomy used elsewhere in the CLI.
 
 ```bash
 runa doctor
 ```
 
 Checks project health: artifact validity, skill readiness, and dependency cycles. Performs an implicit scan first so reported health matches the current workspace. Exits 0 if healthy, 1 if problems found.
+Skill readiness reports required-artifact failures as `missing`, `invalid`, or `stale`.
 
 ```bash
 runa scan
@@ -48,7 +50,7 @@ Manages persisted operator signals in `.runa/signals.json`, an optional runtime-
 runa status [--json]
 ```
 
-Evaluates every skill after an implicit scan and classifies it as `READY`, `BLOCKED`, or `WAITING`. Text output groups skills in that order and shows the current inputs, precondition failures, or unsatisfied trigger conditions that explain each status. `on_signal` triggers read the persisted active signal set from `.runa/signals.json`; if the file is absent or malformed, status warns and treats the signal set as empty. If the scan was only partial, status surfaces `Scan warnings` and blocks skills whose required artifact types could not be fully reconciled with reason `scan_incomplete`; partially scanned accepted artifact types are omitted from reported inputs. `--json` emits `{ "version": 1, "methodology": "...", "scan_warnings": [...], "skills": [...] }`, with a flat ordered `skills` array containing `name`, `status`, `trigger`, and the status-specific fields `inputs`, `precondition_failures`, or `unsatisfied_conditions`. Exits 0 when status evaluation succeeds, even if some skills are blocked or waiting. Commands that do not evaluate triggers do not read `signals.json`.
+Evaluates every skill after an implicit scan and classifies it as `READY`, `BLOCKED`, or `WAITING`. Text output groups skills in that order and shows the current inputs, precondition failures, or unsatisfied trigger conditions that explain each status. `on_signal` triggers read the persisted active signal set from `.runa/signals.json`; if the file is absent, unreadable, or malformed, status warns and treats the signal set as empty. If the scan was only partial, status surfaces `Scan warnings` and blocks skills whose required artifact types could not be fully reconciled with reason `scan_incomplete`; partially scanned accepted artifact types are omitted from reported inputs. `--json` emits `{ "version": 1, "methodology": "...", "scan_warnings": [...], "skills": [...] }`, with a flat ordered `skills` array containing `name`, `status`, `trigger`, and the status-specific fields `inputs`, `precondition_failures`, or `unsatisfied_conditions`. Exits 0 when status evaluation succeeds, even if some skills are blocked or waiting. Commands that do not evaluate triggers do not read `signals.json`.
 
 ```bash
 runa step --dry-run [--json]

--- a/runa-cli/src/commands/doctor.rs
+++ b/runa-cli/src/commands/doctor.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 use std::path::Path;
 
-use libagent::{ScanError as StoreScanError, ValidationStatus};
+use libagent::{
+    ArtifactFailure, ScanError as StoreScanError, ValidationStatus, enforce_preconditions,
+};
 
 use crate::project::{self, ProjectError};
 
@@ -59,22 +61,6 @@ pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<bool, D
             problems += 1;
             println!("  unreadable: {}", entry.path.display());
             println!("    {}", entry.error);
-        }
-    } else if !scan_result.partially_scanned_types.is_empty() {
-        println!();
-        println!("Scan:");
-        for partial in &scan_result.partially_scanned_types {
-            problems += 1;
-            println!(
-                "  partial: type {} was only partially readable, {} entr{} could not be scanned, removal suppressed for this type.",
-                partial.artifact_type,
-                partial.unreadable_entries,
-                if partial.unreadable_entries == 1 {
-                    "y"
-                } else {
-                    "ies"
-                }
-            );
         }
     }
 
@@ -173,35 +159,15 @@ pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<bool, D
             continue;
         }
 
-        let mut missing: Vec<&str> = Vec::new();
-        let mut invalid: Vec<&str> = Vec::new();
-
-        for req in &skill.requires {
-            if !loaded.store.is_valid(req) {
-                let instances = loaded.store.instances_of(req);
-                if instances.is_empty() {
-                    missing.push(req);
-                } else if loaded.store.has_any_invalid(req) {
-                    invalid.push(req);
-                } else {
-                    // Has instances but none valid (e.g., all stale).
-                    missing.push(req);
-                }
-            }
-        }
-
-        if missing.is_empty() && invalid.is_empty() {
-            println!("  {}: ok", skill.name);
-        } else {
+        if let Err(err) = enforce_preconditions(skill, &loaded.store) {
             problems += 1;
-            let mut reasons = Vec::new();
-            if !missing.is_empty() {
-                reasons.push(format!("missing: {}", missing.join(", ")));
-            }
-            if !invalid.is_empty() {
-                reasons.push(format!("invalid: {}", invalid.join(", ")));
-            }
-            println!("  {}: cannot execute ({})", skill.name, reasons.join("; "));
+            println!(
+                "  {}: cannot execute ({})",
+                skill.name,
+                format_failures(&err.failures)
+            );
+        } else {
+            println!("  {}: ok", skill.name);
         }
     }
 
@@ -227,4 +193,44 @@ pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<bool, D
     }
 
     Ok(problems == 0)
+}
+
+fn format_failures(failures: &[ArtifactFailure]) -> String {
+    let missing = names_for(failures, |failure| {
+        matches!(failure, ArtifactFailure::Missing { .. })
+    });
+    let invalid = names_for(failures, |failure| {
+        matches!(failure, ArtifactFailure::Invalid { .. })
+    });
+    let stale = names_for(failures, |failure| {
+        matches!(failure, ArtifactFailure::Stale { .. })
+    });
+
+    let mut reasons = Vec::new();
+    if !missing.is_empty() {
+        reasons.push(format!("missing: {}", missing.join(", ")));
+    }
+    if !invalid.is_empty() {
+        reasons.push(format!("invalid: {}", invalid.join(", ")));
+    }
+    if !stale.is_empty() {
+        reasons.push(format!("stale: {}", stale.join(", ")));
+    }
+
+    reasons.join("; ")
+}
+
+fn names_for(
+    failures: &[ArtifactFailure],
+    predicate: impl Fn(&ArtifactFailure) -> bool,
+) -> Vec<String> {
+    failures
+        .iter()
+        .filter(|failure| predicate(failure))
+        .map(|failure| match failure {
+            ArtifactFailure::Missing { artifact_type, .. }
+            | ArtifactFailure::Invalid { artifact_type, .. }
+            | ArtifactFailure::Stale { artifact_type, .. } => artifact_type.clone(),
+        })
+        .collect()
 }

--- a/runa-cli/src/commands/list.rs
+++ b/runa-cli/src/commands/list.rs
@@ -1,8 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
 use libagent::ScanError as StoreScanError;
+use libagent::{ArtifactFailure, enforce_preconditions};
 
 use crate::project::{self, ProjectError};
 
@@ -50,18 +51,6 @@ pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), Lis
         }
     };
 
-    // Build available artifacts set from store.
-    let available: HashSet<String> = loaded
-        .manifest
-        .artifact_types
-        .iter()
-        .filter(|at| loaded.store.is_valid(&at.name))
-        .map(|at| at.name.clone())
-        .collect();
-
-    let blocked = loaded.graph.blocked_skills_with_reasons(&available);
-    let blocked_map: HashMap<&str, Vec<&str>> = blocked.into_iter().collect();
-
     // Build a lookup from skill name to declaration.
     let skill_map: HashMap<&str, &libagent::SkillDeclaration> = loaded
         .manifest
@@ -95,14 +84,58 @@ pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), Lis
 
         println!("     trigger:  {}", skill.trigger);
 
-        if let Some(missing) = blocked_map.get(name) {
-            let missing_list: Vec<String> = missing.iter().map(|m| format!("'{m}'")).collect();
-            println!(
-                "     BLOCKED:  missing artifact type {}",
-                missing_list.join(", ")
-            );
+        if let Err(err) = enforce_preconditions(skill, &loaded.store) {
+            println!("     BLOCKED:  {}", format_failures(&err.failures));
         }
     }
 
     Ok(())
+}
+
+fn format_failures(failures: &[ArtifactFailure]) -> String {
+    let missing = names_for(failures, |failure| {
+        matches!(failure, ArtifactFailure::Missing { .. })
+    });
+    let invalid = names_for(failures, |failure| {
+        matches!(failure, ArtifactFailure::Invalid { .. })
+    });
+    let stale = names_for(failures, |failure| {
+        matches!(failure, ArtifactFailure::Stale { .. })
+    });
+
+    let mut reasons = Vec::new();
+    if !missing.is_empty() {
+        reasons.push(format!("missing: {}", quoted(&missing)));
+    }
+    if !invalid.is_empty() {
+        reasons.push(format!("invalid: {}", quoted(&invalid)));
+    }
+    if !stale.is_empty() {
+        reasons.push(format!("stale: {}", quoted(&stale)));
+    }
+
+    reasons.join("; ")
+}
+
+fn names_for(
+    failures: &[ArtifactFailure],
+    predicate: impl Fn(&ArtifactFailure) -> bool,
+) -> Vec<String> {
+    failures
+        .iter()
+        .filter(|failure| predicate(failure))
+        .map(|failure| match failure {
+            ArtifactFailure::Missing { artifact_type, .. }
+            | ArtifactFailure::Invalid { artifact_type, .. }
+            | ArtifactFailure::Stale { artifact_type, .. } => artifact_type.clone(),
+        })
+        .collect()
+}
+
+fn quoted(names: &[String]) -> String {
+    names
+        .iter()
+        .map(|name| format!("'{name}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -62,12 +62,12 @@ enum Commands {
 enum SignalCommand {
     /// Ensure the named signal is active
     Begin {
-        /// Signal name, must match [a-z][a-z0-9-]*
+        /// Signal name, must match [a-z0-9][a-z0-9_-]*
         name: String,
     },
     /// Ensure the named signal is inactive
     Clear {
-        /// Signal name, must match [a-z][a-z0-9-]*
+        /// Signal name, must match [a-z0-9][a-z0-9_-]*
         name: String,
     },
     /// List active signals
@@ -177,11 +177,6 @@ fn main() {
                     process::exit(1);
                 }
             };
-
-            if let Err(e) = project::resolve_config(&working_dir, config_override.as_deref()) {
-                eprintln!("error: {e}");
-                process::exit(1);
-            }
 
             let result = match command {
                 SignalCommand::Begin { name } => commands::signal::begin(&working_dir, &name),

--- a/runa-cli/src/project.rs
+++ b/runa-cli/src/project.rs
@@ -210,7 +210,7 @@ pub fn load_signals(runa_dir: &Path) -> (std::collections::HashSet<String>, Vec<
             return (
                 std::collections::HashSet::new(),
                 vec![format!(
-                    "could not parse .runa/signals.json: {}; treating as no active signals",
+                    "could not read .runa/signals.json: {}; treating as no active signals",
                     err
                 )],
             );
@@ -350,6 +350,23 @@ trigger = { type = "on_signal", name = "init" }
         assert!(signals.is_empty());
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("could not parse .runa/signals.json"));
+    }
+
+    #[test]
+    fn load_warns_when_signals_file_cannot_be_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.toml");
+        fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        write_project_files(&working, &manifest_path);
+        fs::create_dir(working.join(".runa").join("signals.json")).unwrap();
+
+        let (signals, warnings) = load_signals(&working.join(".runa"));
+        assert!(signals.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("could not read .runa/signals.json"));
     }
 
     #[test]

--- a/runa-cli/tests/doctor.rs
+++ b/runa-cli/tests/doctor.rs
@@ -50,6 +50,19 @@ fn init_project(project_dir: &std::path::Path, manifest_path: &std::path::Path) 
     );
 }
 
+fn scan_project(project_dir: &std::path::Path) {
+    let output = runa_bin()
+        .arg("scan")
+        .current_dir(project_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "scan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn doctor_healthy_exit_zero() {
     let dir = tempfile::tempdir().unwrap();
@@ -290,4 +303,44 @@ fn doctor_ignores_malformed_signals_file() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("problem"), "stdout: {stdout}");
+}
+
+#[test]
+fn doctor_reports_stale_required_artifacts_as_stale() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("manifest.toml");
+    fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    fs::create_dir_all(project_dir.join(".runa/workspace/constraints")).unwrap();
+    fs::write(
+        project_dir.join(".runa/workspace/constraints/good.json"),
+        r#"{"title":"ok"}"#,
+    )
+    .unwrap();
+
+    scan_project(&project_dir);
+
+    let store_path = project_dir.join(".runa/store/constraints/good.json");
+    let mut state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&store_path).unwrap()).unwrap();
+    state["status"] = serde_json::json!("stale");
+    fs::write(&store_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let output = runa_bin()
+        .arg("doctor")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "stale required artifacts should block doctor"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stale: constraints"), "stdout: {stdout}");
+    assert!(!stdout.contains("missing: constraints"), "stdout: {stdout}");
 }

--- a/runa-cli/tests/list.rs
+++ b/runa-cli/tests/list.rs
@@ -50,6 +50,19 @@ fn init_project(project_dir: &std::path::Path, manifest_path: &std::path::Path) 
     );
 }
 
+fn scan_project(project_dir: &std::path::Path) {
+    let output = runa_bin()
+        .arg("scan")
+        .current_dir(project_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "scan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn list_shows_skills_in_order() {
     let dir = tempfile::tempdir().unwrap();
@@ -178,5 +191,80 @@ fn list_ignores_malformed_signals_file() {
         output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn list_reports_invalid_required_artifacts_as_invalid() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("manifest.toml");
+    fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    fs::create_dir_all(project_dir.join(".runa/workspace/constraints")).unwrap();
+    fs::write(
+        project_dir.join(".runa/workspace/constraints/bad.json"),
+        r#"{"score":1}"#,
+    )
+    .unwrap();
+
+    let output = runa_bin()
+        .arg("list")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("invalid: 'constraints'"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("missing artifact type 'constraints'"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn list_reports_stale_required_artifacts_as_stale() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("manifest.toml");
+    fs::write(&manifest_path, valid_manifest_toml()).unwrap();
+
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    fs::create_dir_all(project_dir.join(".runa/workspace/constraints")).unwrap();
+    fs::write(
+        project_dir.join(".runa/workspace/constraints/good.json"),
+        r#"{"title":"ok"}"#,
+    )
+    .unwrap();
+
+    scan_project(&project_dir);
+
+    let store_path = project_dir.join(".runa/store/constraints/good.json");
+    let mut state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&store_path).unwrap()).unwrap();
+    state["status"] = serde_json::json!("stale");
+    fs::write(&store_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let output = runa_bin()
+        .arg("list")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stale: 'constraints'"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("missing artifact type 'constraints'"),
+        "stdout: {stdout}"
     );
 }

--- a/runa-cli/tests/signal.rs
+++ b/runa-cli/tests/signal.rs
@@ -45,6 +45,15 @@ fn init_project(project_dir: &Path, manifest_path: &Path) {
     );
 }
 
+fn init_project_with_args(project_dir: &Path, args: &[&str]) {
+    let output = run_command(project_dir, args);
+    assert!(
+        output.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn signal_begin_persists_state_across_invocations() {
     let dir = tempfile::tempdir().unwrap();
@@ -275,7 +284,7 @@ fn signal_commands_fail_when_project_is_not_initialized() {
 }
 
 #[test]
-fn signal_begin_fails_when_config_override_does_not_exist() {
+fn signal_begin_ignores_unused_config_override() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = dir.path().join("manifest.toml");
     fs::write(&manifest_path, manifest_toml()).unwrap();
@@ -296,13 +305,16 @@ fn signal_begin_fails_when_config_override_does_not_exist() {
         ],
     );
 
-    assert!(!output.status.success(), "command should fail");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("config not found"), "stderr: {stderr}");
     assert!(
-        !project_dir.join(".runa/signals.json").exists(),
-        "signal state should not be written on config failure"
+        output.status.success(),
+        "signal commands should ignore unused config overrides: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
+
+    let stored: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(project_dir.join(".runa/signals.json")).unwrap())
+            .unwrap();
+    assert_eq!(stored, serde_json::json!({ "active": ["foo"] }));
 }
 
 #[test]
@@ -347,4 +359,61 @@ fn signal_begin_accepts_valid_external_config_override() {
         serde_json::from_str(&fs::read_to_string(project_dir.join(".runa/signals.json")).unwrap())
             .unwrap();
     assert_eq!(stored, serde_json::json!({ "active": ["foo"] }));
+}
+
+#[test]
+fn signal_begin_works_without_config_override_after_external_config_init() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = dir.path().join("manifest.toml");
+    fs::write(&manifest_path, manifest_toml()).unwrap();
+
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+
+    let external_config = dir.path().join("external-config.toml");
+    init_project_with_args(
+        &project_dir,
+        &[
+            "init",
+            "--methodology",
+            manifest_path.to_str().unwrap(),
+            "--config",
+            external_config.to_str().unwrap(),
+        ],
+    );
+
+    assert!(
+        !project_dir.join(".runa/config.toml").exists(),
+        "project-local config should not exist when init wrote to an external path"
+    );
+
+    let output = run_command(&project_dir, &["signal", "begin", "foo"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stored: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(project_dir.join(".runa/signals.json")).unwrap())
+            .unwrap();
+    assert_eq!(stored, serde_json::json!({ "active": ["foo"] }));
+}
+
+#[test]
+fn signal_help_reports_actual_signal_name_pattern() {
+    for args in [["signal", "begin", "--help"], ["signal", "clear", "--help"]] {
+        let output = runa_bin().args(args).output().unwrap();
+        assert!(
+            output.status.success(),
+            "help should succeed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("[a-z0-9][a-z0-9_-]*"),
+            "stdout should describe the validator pattern: {stdout}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- remove the unused config gate from `runa signal` so signal commands work after external-config init and ignore irrelevant config overrides
- align `runa list` and `runa doctor` with shared precondition enforcement so blocked skills report `missing`, `invalid`, and `stale` correctly
- distinguish signal read errors from parse errors and update docs/help text to match the actual CLI contracts

## Changes

- reuse `libagent::enforce_preconditions` in the CLI readiness output for `list` and `doctor`, and drop the dead doctor scan branch
- update signal dispatch/help text and `load_signals()` warning wording in `runa-cli`
- add regression coverage for signal dispatch, signal help text, invalid/stale readiness output, and unreadable signal-state warnings; update README and architecture docs

## Issue(s)

Closes #48

## Test plan

- `cargo fmt`
- `cargo test`
