### PR TITLE
docs: add skill-install convention and rename orient skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-**At the start of every session, invoke the `using-groundwork` skill (`/using-groundwork`).**
+**At the start of every session, invoke the `orient` skill (`/orient`).**
 
 Study the following before working in this project:
 
@@ -8,5 +8,8 @@ Orientation: `README.md`
 Architecture: `ARCHITECTURE.md`
 Contribution conventions: `CONTRIBUTING.md`
 Bedrock principles: [commons](https://github.com/pentaxis93/commons)
+
+This project does not vendor agent skills in-repo. Resolve project skills from
+your global installs under `~/.claude/skills` and `~/.codex/skills`.
 
 **CLAUDE.md and AGENTS.md are the same file** — CLAUDE.md is a symlink to AGENTS.md. Edit AGENTS.md. Never break the symlink.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Every PR that ships must update affected documentation:
 
 ## Conventions
 
+- Agent skills are a user-level prerequisite, not a repo-local asset. Install
+  and maintain them under `~/.claude/skills` and `~/.codex/skills`.
 - Conventional commits (e.g., `feat(trigger):`, `fix(store):`, `docs:`)
 - Branch names: `issue-N/brief-description`
 - One issue per PR


### PR DESCRIPTION
## Summary
- Clarify that agent skills are user-level prerequisites resolved from `~/.claude/skills` and `~/.codex/skills`, not vendored in-repo
- Update session-start skill reference from `using-groundwork` to `orient`
- Add matching convention entry in CONTRIBUTING.md

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)