### PR TITLE
refactor: deduplicate CLI command error and loading boilerplate

### DIFF
--- a/runa-cli/src/commands/doctor.rs
+++ b/runa-cli/src/commands/doctor.rs
@@ -1,41 +1,12 @@
-use std::fmt;
 use std::path::Path;
 
-use libagent::{
-    ArtifactFailure, ScanError as StoreScanError, ValidationStatus, enforce_preconditions,
-};
+use libagent::{ArtifactFailure, ValidationStatus, enforce_preconditions};
 
-use crate::project::{self, ProjectError};
-
-#[derive(Debug)]
-pub enum DoctorError {
-    Project(ProjectError),
-    Scan(StoreScanError),
-}
-
-impl fmt::Display for DoctorError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DoctorError::Project(e) => write!(f, "{e}"),
-            DoctorError::Scan(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl std::error::Error for DoctorError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            DoctorError::Project(e) => Some(e),
-            DoctorError::Scan(e) => Some(e),
-        }
-    }
-}
+use super::CommandError;
 
 /// Run the doctor command. Returns `true` if healthy, `false` if problems found.
-pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<bool, DoctorError> {
-    let mut loaded = project::load(working_dir, config_override).map_err(DoctorError::Project)?;
-    let scan_result =
-        libagent::scan(&loaded.workspace_dir, &mut loaded.store).map_err(DoctorError::Scan)?;
+pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<bool, CommandError> {
+    let (loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
 
     let mut problems = 0;
 

--- a/runa-cli/src/commands/list.rs
+++ b/runa-cli/src/commands/list.rs
@@ -1,39 +1,12 @@
 use std::collections::HashMap;
-use std::fmt;
 use std::path::Path;
 
-use libagent::ScanError as StoreScanError;
-use libagent::{ArtifactFailure, enforce_preconditions};
+use libagent::ArtifactFailure;
 
-use crate::project::{self, ProjectError};
+use super::CommandError;
 
-#[derive(Debug)]
-pub enum ListError {
-    Project(ProjectError),
-    Scan(StoreScanError),
-}
-
-impl fmt::Display for ListError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ListError::Project(e) => write!(f, "{e}"),
-            ListError::Scan(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl std::error::Error for ListError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ListError::Project(e) => Some(e),
-            ListError::Scan(e) => Some(e),
-        }
-    }
-}
-
-pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), ListError> {
-    let mut loaded = project::load(working_dir, config_override).map_err(ListError::Project)?;
-    libagent::scan(&loaded.workspace_dir, &mut loaded.store).map_err(ListError::Scan)?;
+pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), CommandError> {
+    let (loaded, _scan_result) = super::load_and_scan(working_dir, config_override)?;
 
     println!("Methodology: {}", loaded.manifest.name);
 
@@ -84,7 +57,7 @@ pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), Lis
 
         println!("     trigger:  {}", protocol.trigger);
 
-        if let Err(err) = enforce_preconditions(protocol, &loaded.store, None) {
+        if let Err(err) = libagent::enforce_preconditions(protocol, &loaded.store, None) {
             println!("     BLOCKED:  {}", format_failures(&err.failures));
         }
     }

--- a/runa-cli/src/commands/mod.rs
+++ b/runa-cli/src/commands/mod.rs
@@ -1,3 +1,10 @@
+use std::fmt;
+use std::path::Path;
+
+use libagent::ScanResult;
+
+use crate::project::{self, LoadedProject, ProjectError};
+
 pub mod doctor;
 pub mod init;
 pub mod list;
@@ -5,3 +12,48 @@ pub mod protocol_eval;
 pub mod scan;
 pub mod status;
 pub mod step;
+
+#[derive(Debug)]
+pub enum CommandError {
+    Project(ProjectError),
+    Scan(libagent::ScanError),
+}
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommandError::Project(err) => write!(f, "{err}"),
+            CommandError::Scan(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for CommandError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CommandError::Project(err) => Some(err),
+            CommandError::Scan(err) => Some(err),
+        }
+    }
+}
+
+impl From<ProjectError> for CommandError {
+    fn from(err: ProjectError) -> Self {
+        CommandError::Project(err)
+    }
+}
+
+impl From<libagent::ScanError> for CommandError {
+    fn from(err: libagent::ScanError) -> Self {
+        CommandError::Scan(err)
+    }
+}
+
+pub fn load_and_scan(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+) -> Result<(LoadedProject, ScanResult), CommandError> {
+    let mut loaded = project::load(working_dir, config_override)?;
+    let scan_result = libagent::scan(&loaded.workspace_dir, &mut loaded.store)?;
+    Ok((loaded, scan_result))
+}

--- a/runa-cli/src/commands/scan.rs
+++ b/runa-cli/src/commands/scan.rs
@@ -1,41 +1,11 @@
-use std::fmt;
 use std::path::Path;
 
-use libagent::{
-    InvalidArtifact, MalformedArtifact, PartiallyScannedType, ScanError as LibScanError,
-    UnreadableArtifact,
-};
+use libagent::{InvalidArtifact, MalformedArtifact, PartiallyScannedType, UnreadableArtifact};
 
-use crate::project::{self, ProjectError};
+use super::CommandError;
 
-#[derive(Debug)]
-pub enum ScanError {
-    Project(ProjectError),
-    Scan(LibScanError),
-}
-
-impl fmt::Display for ScanError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ScanError::Project(err) => write!(f, "{err}"),
-            ScanError::Scan(err) => write!(f, "{err}"),
-        }
-    }
-}
-
-impl std::error::Error for ScanError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ScanError::Project(err) => Some(err),
-            ScanError::Scan(err) => Some(err),
-        }
-    }
-}
-
-pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), ScanError> {
-    let mut loaded = project::load(working_dir, config_override).map_err(ScanError::Project)?;
-    let result =
-        libagent::scan(&loaded.workspace_dir, &mut loaded.store).map_err(ScanError::Scan)?;
+pub fn run(working_dir: &Path, config_override: Option<&Path>) -> Result<(), CommandError> {
+    let (loaded, result) = super::load_and_scan(working_dir, config_override)?;
 
     println!("Methodology: {}", loaded.manifest.name);
     println!("Workspace: {}", loaded.workspace_dir.display());

--- a/runa-cli/src/commands/status.rs
+++ b/runa-cli/src/commands/status.rs
@@ -3,21 +3,19 @@ use std::path::Path;
 
 use serde::Serialize;
 
+use super::CommandError;
 use crate::commands::protocol_eval;
-use crate::project::{self, ProjectError};
 
 #[derive(Debug)]
 pub enum StatusError {
-    Project(ProjectError),
-    Scan(libagent::ScanError),
+    Command(CommandError),
     Json(serde_json::Error),
 }
 
 impl fmt::Display for StatusError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StatusError::Project(err) => write!(f, "{err}"),
-            StatusError::Scan(err) => write!(f, "{err}"),
+            StatusError::Command(err) => write!(f, "{err}"),
             StatusError::Json(err) => write!(f, "{err}"),
         }
     }
@@ -26,10 +24,15 @@ impl fmt::Display for StatusError {
 impl std::error::Error for StatusError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            StatusError::Project(err) => Some(err),
-            StatusError::Scan(err) => Some(err),
+            StatusError::Command(err) => Some(err),
             StatusError::Json(err) => Some(err),
         }
+    }
+}
+
+impl From<CommandError> for StatusError {
+    fn from(err: CommandError) -> Self {
+        StatusError::Command(err)
     }
 }
 
@@ -46,9 +49,7 @@ pub fn run(
     config_override: Option<&Path>,
     json_output: bool,
 ) -> Result<(), StatusError> {
-    let mut loaded = project::load(working_dir, config_override).map_err(StatusError::Project)?;
-    let scan_result =
-        libagent::scan(&loaded.workspace_dir, &mut loaded.store).map_err(StatusError::Scan)?;
+    let (loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
     let scan_findings = protocol_eval::collect_scan_findings(&scan_result, &loaded.workspace_dir);
     let evaluated = protocol_eval::evaluate_protocols(&loaded, working_dir, &scan_findings);
     let warnings = scan_findings.warnings.clone();

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -4,16 +4,15 @@ use std::path::Path;
 use libagent::context::{ArtifactRelationship, ContextInjection};
 use serde::Serialize;
 
+use super::CommandError;
 use crate::commands::protocol_eval;
-use crate::project::{self, ProjectError};
 
 const NOT_IMPLEMENTED_MESSAGE: &str =
     "Agent execution is not yet implemented. Use --dry-run to see the execution plan.";
 
 #[derive(Debug)]
 pub enum StepError {
-    Project(ProjectError),
-    Scan(libagent::ScanError),
+    Command(CommandError),
     Json(serde_json::Error),
     NotImplemented,
 }
@@ -21,8 +20,7 @@ pub enum StepError {
 impl fmt::Display for StepError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StepError::Project(err) => write!(f, "{err}"),
-            StepError::Scan(err) => write!(f, "{err}"),
+            StepError::Command(err) => write!(f, "{err}"),
             StepError::Json(err) => write!(f, "{err}"),
             StepError::NotImplemented => write!(f, "{NOT_IMPLEMENTED_MESSAGE}"),
         }
@@ -32,11 +30,16 @@ impl fmt::Display for StepError {
 impl std::error::Error for StepError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            StepError::Project(err) => Some(err),
-            StepError::Scan(err) => Some(err),
+            StepError::Command(err) => Some(err),
             StepError::Json(err) => Some(err),
             StepError::NotImplemented => None,
         }
+    }
+}
+
+impl From<CommandError> for StepError {
+    fn from(err: CommandError) -> Self {
+        StepError::Command(err)
     }
 }
 
@@ -70,9 +73,7 @@ pub fn run(
         return Err(StepError::NotImplemented);
     }
 
-    let mut loaded = project::load(working_dir, config_override).map_err(StepError::Project)?;
-    let scan_result =
-        libagent::scan(&loaded.workspace_dir, &mut loaded.store).map_err(StepError::Scan)?;
+    let (loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
     let scan_findings = protocol_eval::collect_scan_findings(&scan_result, &loaded.workspace_dir);
     let evaluated = protocol_eval::evaluate_protocols(&loaded, working_dir, &scan_findings);
     let warnings = scan_findings.warnings.clone();


### PR DESCRIPTION
Extract shared CommandError (Project + Scan variants) and load_and_scan()
into commands/mod.rs. Commands with only those two error variants (doctor,
list, scan) now use CommandError directly. Commands with additional variants
(status, step) wrap CommandError in a per-command enum. No behavioral change.

Closes #73

https://claude.ai/code/session_01XMyZfWZKq47apo6F4ptME1