### PR TITLE
docs: make commons reading list explicit in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Study the following before working in this project:
 Orientation: `README.md`
 Architecture: `ARCHITECTURE.md`
 Contribution conventions: `CONTRIBUTING.md`
-Bedrock principles: [commons](https://github.com/pentaxis93/commons)
+Bedrock principles: [commons](https://github.com/pentaxis93/commons) — read both `PRINCIPLES.md` and every ADR in `adr/`
 
 This project does not vendor agent skills in-repo. Resolve project skills from
 your global installs under `~/.claude/skills` and `~/.codex/skills`.


### PR DESCRIPTION
An agent working on #86 read commons PRINCIPLES.md but not the ADRs, then violated ADR-0002 ("no tests that assert absence") during implementation. The root cause: AGENTS.md said "Bedrock principles: commons" — a pointer to a repo, not a reading list. The agent mapped "bedrock principles" to PRINCIPLES.md and stopped.

This PR makes the reading requirement explicit: both PRINCIPLES.md and every ADR in `adr/`.

Companion PR: pentaxis93/commons#2 (adds ADR reading requirement to PRINCIPLES.md itself).
