### PR TITLE
fix(mcp): simplify runa-mcp to pure tool server with explicit protocol arguments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Three crates, Rust 2024 edition, resolver v3:
 
 - **`libagent`** — All domain logic: data model, TOML manifest parsing, JSON Schema validation, dependency graph, artifact state tracking, trigger condition evaluation, context injection construction, pre/post-execution enforcement, project loading, and protocol selection.
 - **`runa-cli`** — Thin CLI binary. Clap-based argument parsing, delegates to libagent. No domain logic.
-- **`runa-mcp`** — MCP server binary. Single-session stdio process that serves one (protocol, work_unit) pair per invocation. Loads the project, selects a ready candidate, exposes protocol outputs as MCP tools and context as an MCP prompt, then relies on the produced artifacts themselves as completion evidence.
+- **`runa-mcp`** — MCP server binary. Single-session stdio process that serves one named protocol invocation per run. Loads the project, resolves the requested protocol from the manifest, exposes protocol outputs as MCP tools and context as an MCP prompt, and writes produced artifacts into the workspace.
 
 ## Data Flow
 
@@ -30,7 +30,7 @@ These are library capabilities exposed by libagent and consumed by both the CLI 
 
 8. **CLI step execution.** `runa step` reuses the same execution-plan construction as dry-run, then, when `[agent].command` is configured, invokes that argv command once per non-cyclic ready plan entry in order. Each invocation receives the exact plan entry JSON (`protocol`, optional `work_unit`, `trigger`, `context`) on stdin, runs in the project working directory, and must exit `0` for step to continue. This issue stops at command execution: no post-execution scan, postcondition enforcement, or cascading re-selection happens yet.
 
-9. **MCP runtime loop.** `runa-mcp` loads the project, scans, selects the first ready candidate, serves an MCP session via stdio, then re-scans and checks postconditions. Successful postconditions leave completion evidence in the workspace via the output artifacts themselves.
+9. **MCP runtime loop.** `runa-mcp` parses `--protocol` and optional `--work-unit`, loads the project, resolves the named protocol from the manifest, validates that its outputs can be served as MCP tools, and serves an MCP session via stdio.
 
 ## Modules
 
@@ -96,7 +96,7 @@ Work-unit discovery and protocol selection. `discover_ready_candidates` evaluate
 
 ### `main.rs`
 
-Runtime loop: loads the project, scans the workspace, discovers ready candidates, selects the first, builds the MCP handler, serves via stdio transport, then re-scans and checks postconditions. Successful outputs become the completion evidence for the next selection pass.
+Runtime loop: parses `--protocol` and optional `--work-unit`, loads the project, resolves the named protocol from the manifest, validates its output types, builds the MCP handler, and serves via stdio transport.
 
 ### `handler.rs`
 
@@ -163,7 +163,7 @@ Exits 0 for successful status evaluation regardless of whether protocols are rea
 
 ### `runa step [--dry-run] [--json]`
 
-Runs the same implicit scan and shared candidate classification used by `runa status`, then builds an execution plan from the `READY` `(protocol, work_unit)` pairs that can be placed in a valid execution order. Candidate discovery, trigger evaluation, and freshness suppression use the same work-unit-scoped selection logic as `runa-mcp`, so `step --dry-run` previews the same ready work that live execution attempts to serve. Plan entries preserve graph order for the non-cyclic frontier and include the protocol name, optional `work_unit`, the trigger condition string, and the JSON-serialized `libagent::context::ContextInjection` payload, including preloaded protocol instructions. If a hard dependency cycle exists, `step` reports the cycle as a warning, excludes the cycle participants from the plan, and still includes any unrelated orderable READY protocols.
+Runs the same implicit scan and shared candidate classification used by `runa status`, then builds an execution plan from the `READY` `(protocol, work_unit)` pairs that can be placed in a valid execution order. Candidate discovery, trigger evaluation, and freshness suppression use the work-unit-scoped selection logic in `selection.rs`, so `step --dry-run` previews the same ready work that `step` execution attempts to invoke. Plan entries preserve graph order for the non-cyclic frontier and include the protocol name, optional `work_unit`, the trigger condition string, and the JSON-serialized `libagent::context::ContextInjection` payload, including preloaded protocol instructions. If a hard dependency cycle exists, `step` reports the cycle as a warning, excludes the cycle participants from the plan, and still includes any unrelated orderable READY protocols.
 
 With `--dry-run`, text output prints the execution plan followed by the grouped READY/BLOCKED/WAITING view. JSON output adds an `execution_plan` array plus an optional `cycle` path while reusing the same `protocols` status entries and `scan_warnings` envelope fields as `runa status`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Semantic Versioning.
 - Allow `runa step` to execute a configured `[agent].command` by sending each
   planned protocol payload as pretty-printed JSON on stdin, while keeping
   `--dry-run` as the exact execution preview surface.
+- Simplify `runa-mcp` into a pure tool server with required `--protocol` and
+  optional `--work-unit` arguments, removing workspace scanning, candidate
+  selection, and shutdown postcondition checks from the MCP process.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,7 +195,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -581,7 +587,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -843,6 +849,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,7 +997,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1015,6 +1044,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -1122,12 +1165,14 @@ dependencies = [
  "futures",
  "paste",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -1162,6 +1207,7 @@ dependencies = [
 name = "runa-mcp"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "libagent",
  "rmcp",
  "serde",
@@ -1317,6 +1363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,8 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1434,6 +1494,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1629,6 +1700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1803,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,9 +1845,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -1762,9 +1885,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -1772,7 +1920,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1781,7 +1938,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1790,7 +1947,16 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Unreadable produced artifacts do not block protocols directly, but they do conse
 runa step [--dry-run] [--json]
 ```
 
-Builds an operator-facing execution plan after an implicit scan. `step` uses the same candidate-selection logic as `runa-mcp`: protocols are evaluated per discovered work unit, and activated work is suppressed when valid outputs are newer than the relevant inputs for that work unit. The execution plan therefore contains `READY` `(protocol, work_unit)` pairs that can be placed in a valid execution order. Each plan entry includes the protocol name, optional `work_unit`, the human-readable trigger that activated it, and a serialized agent-facing context payload. The context payload contains the protocol name, the preloaded `PROTOCOL.md` instruction content, all valid required and available accepted inputs with text paths, content hashes, and relationships, plus expected outputs split into `produces` and `may_produce`.
+Builds an operator-facing execution plan after an implicit scan. `step` evaluates protocols per discovered work unit and suppresses activated work when valid outputs are newer than the relevant inputs for that work unit. The execution plan therefore contains `READY` `(protocol, work_unit)` pairs that can be placed in a valid execution order. Each plan entry includes the protocol name, optional `work_unit`, the human-readable trigger that activated it, and a serialized agent-facing context payload. The context payload contains the protocol name, the preloaded `PROTOCOL.md` instruction content, all valid required and available accepted inputs with text paths, content hashes, and relationships, plus expected outputs split into `produces` and `may_produce`.
 
 If the graph contains a hard dependency cycle, `step` reports the cycle as a warning and excludes the cyclic protocols from `execution_plan`; non-cyclic READY protocols still appear when they are orderable. `--dry-run` prints the execution plan and the same grouped protocol status view used by `runa status`, so operators can still see blocked and waiting reasons when nothing is runnable. `--json` emits `{ "version": 2, "methodology": "...", "scan_warnings": [...], "cycle": ["..."] | null, "execution_plan": [...], "protocols": [...] }`, where `execution_plan` entries and `protocols` status entries may include an optional `work_unit`, and `protocols` reuses the same status entries as `runa status --json`.
 
@@ -85,18 +85,16 @@ Like `runa status`, unreadable produced artifacts conservatively keep all work u
 
 ## MCP Server
 
-`runa-mcp` is a single-session stdio MCP server that orchestrates one protocol execution per invocation. It is designed to be started by an outer orchestrator (e.g., an MCP client) for each protocol run.
+`runa-mcp` is a single-session stdio MCP server that serves one named protocol invocation per process. It is designed to be started by an outer orchestrator (e.g., an MCP client) for each protocol run.
 
 ```bash
-runa-mcp
+runa-mcp --protocol <name> [--work-unit <name>]
 ```
 
-On startup, the server loads the project from the current directory (or `RUNA_WORKING_DIR`), scans the workspace, and selects the first ready (protocol, work_unit) candidate. It then serves an MCP session over stdio with:
+On startup, the server loads the project from the current directory (or `RUNA_WORKING_DIR`), resolves the named protocol from the manifest, validates that its output types can be served as MCP tools, and then serves an MCP session over stdio with:
 
 - **Tools** — One tool per output artifact type (`produces` + `may_produce`). The tool input schema is the artifact's JSON Schema with `work_unit` removed. The server injects `work_unit` automatically.
 - **Prompts** — A single `"context"` prompt that delivers the protocol name, preloaded instructions, required and available inputs as prose, and expected outputs.
-
-When the session ends, the server re-scans the workspace and checks postconditions. Valid output artifacts in the workspace are the completion evidence; the next run derives freshness directly from their timestamps. The outer orchestrator can then restart `runa-mcp` for the next protocol.
 
 Environment variables:
 - `RUNA_WORKING_DIR` — Project directory (defaults to current directory)
@@ -109,7 +107,7 @@ Rust 2024 edition.
 
 ```bash
 cargo build          # Debug build
-cargo test --lib     # Run all unit tests
+cargo test --workspace
 ```
 
 ## Documentation

--- a/runa-mcp/Cargo.toml
+++ b/runa-mcp/Cargo.toml
@@ -9,6 +9,7 @@ name = "runa-mcp"
 path = "src/main.rs"
 
 [dependencies]
+clap.workspace = true
 libagent.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -17,4 +18,6 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 tempfile.workspace = true
+tokio = { workspace = true, features = ["process", "time"] }

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -1,28 +1,40 @@
 mod context;
 mod handler;
 
-use libagent::project::{self, RUNA_DIR, STORE_DIRNAME};
-use libagent::{
-    ArtifactStore, configure_tracing, discover_ready_candidates, enforce_postconditions, scan,
-};
+use clap::Parser;
+use libagent::configure_tracing;
+use libagent::project;
 use rmcp::service::ServiceExt;
 use rmcp::transport::io;
-use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use handler::RunaHandler;
 
+#[derive(Parser)]
+#[command(name = "runa-mcp", version)]
+struct Cli {
+    /// Name of the protocol to serve
+    #[arg(long)]
+    protocol: String,
+
+    /// Optional work unit scope for tool serving
+    #[arg(long)]
+    work_unit: Option<String>,
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    let cli = Cli::parse();
+
     if let Err(err) = configure_tracing(None) {
         let _ = writeln!(std::io::stderr(), "runa-mcp: {err}");
         process::exit(1);
     }
 
-    if let Err(e) = run().await {
+    if let Err(e) = run(cli).await {
         error!(
             operation = "mcp_session",
             outcome = "failed",
@@ -34,9 +46,7 @@ async fn main() {
     }
 }
 
-async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Parse args: working_dir from RUNA_WORKING_DIR or cwd,
-    //    config override from RUNA_CONFIG.
+async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let working_dir = match std::env::var("RUNA_WORKING_DIR") {
         Ok(dir) => PathBuf::from(dir),
         Err(_) => std::env::current_dir()?,
@@ -47,103 +57,44 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         configure_tracing(Some(&config.logging))?;
     }
 
-    // 2. Load project.
-    let mut loaded = project::load(&working_dir, config_ref)?;
-    let runa_dir = working_dir.join(RUNA_DIR);
-
-    // 3. Scan workspace.
-    let scan_result = scan(&loaded.workspace_dir, &mut loaded.store)?;
-
-    // 4. Collect partially scanned types.
-    let partially_scanned: HashSet<String> = scan_result
-        .partially_scanned_types
+    let loaded = project::load(&working_dir, config_ref)?;
+    let protocol = loaded
+        .manifest
+        .protocols
         .iter()
-        .map(|p| p.artifact_type.clone())
-        .collect();
+        .find(|protocol| protocol.name == cli.protocol)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "protocol '{}' not found in manifest '{}'",
+                cli.protocol, loaded.manifest.name
+            )
+        })?;
 
-    // 5. Discover ready candidates.
-    let topo_order = match loaded.graph.topological_order() {
-        Ok(order) => order,
-        Err(cycle) => {
-            warn!(
-                operation = "topological_order",
-                outcome = "cycle_fallback",
-                error = %cycle,
-                "falling back to orderable protocols after cycle detection"
-            );
-            let exclude: HashSet<&str> = cycle.path.iter().map(|s| s.as_str()).collect();
-            loaded.graph.topological_order_excluding(&exclude)
-        }
-    };
-    let topo_refs: Vec<&str> = topo_order.to_vec();
-
-    let candidates = discover_ready_candidates(
-        &loaded.manifest.protocols,
-        &loaded.store,
-        &topo_refs,
-        &partially_scanned,
-    );
-
-    // 6. Select first viable candidate.
-    let (candidate, protocol) = {
-        let mut found = None;
-        for c in &candidates {
-            let Some(p) = loaded
-                .manifest
-                .protocols
-                .iter()
-                .find(|p| p.name == c.protocol_name)
-            else {
-                warn!(
-                    operation = "candidate_selection",
-                    outcome = "skipped_unknown_protocol",
-                    protocol = %c.protocol_name,
-                    work_unit = ?c.work_unit,
-                    "skipping unknown protocol candidate"
-                );
-                continue;
-            };
-            let p = p.clone();
-
-            if let Err(e) =
-                handler::validate_output_types(&p, &loaded.store, c.work_unit.as_deref())
-            {
-                warn!(
-                    operation = "candidate_selection",
-                    outcome = "skipped_invalid_output_types",
-                    protocol = %p.name,
-                    work_unit = ?c.work_unit,
-                    error = %e,
-                    "skipping protocol candidate with unsupported output types"
-                );
-                continue;
-            }
-            found = Some((c, p));
-            break;
-        }
-        match found {
-            Some(pair) => pair,
-            None => return Err("no viable protocol candidates found".into()),
-        }
-    };
+    handler::validate_output_types(&protocol, &loaded.store, cli.work_unit.as_deref()).map_err(
+        |err| {
+            format!(
+                "protocol '{}' cannot be served via MCP tools: {err}",
+                protocol.name
+            )
+        },
+    )?;
 
     info!(
         operation = "mcp_session",
         outcome = "serving",
-        protocol = %candidate.protocol_name,
-        work_unit = ?candidate.work_unit,
-        "serving protocol candidate"
+        protocol = %protocol.name,
+        work_unit = ?cli.work_unit,
+        "serving protocol"
     );
 
-    // 7. Build handler.
     let handler = RunaHandler::new(
         protocol.clone(),
-        candidate.work_unit.clone(),
+        cli.work_unit.clone(),
         loaded.store,
         loaded.workspace_dir.clone(),
     );
 
-    // 8. Serve via stdio transport.
     let (stdin, stdout) = io::stdio();
     let service = handler.serve((stdin, stdout)).await.inspect_err(|e| {
         error!(
@@ -155,64 +106,5 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     })?;
     service.waiting().await?;
 
-    // 9. Re-scan workspace with a fresh store.
-    let store_dir = runa_dir.join(STORE_DIRNAME);
-    let mut store = ArtifactStore::new(loaded.manifest.artifact_types.clone(), store_dir)?;
-    let post_scan = scan(&loaded.workspace_dir, &mut store)?;
-
-    // 10. Check postconditions.
-    let work_unit_ref = candidate.work_unit.as_deref();
-    let output_type_names: HashSet<&str> = protocol
-        .produces
-        .iter()
-        .chain(protocol.may_produce.iter())
-        .map(|s| s.as_str())
-        .collect();
-    let partial_output_types: Vec<&str> = post_scan
-        .partially_scanned_types
-        .iter()
-        .filter(|ps| output_type_names.contains(ps.artifact_type.as_str()))
-        .map(|ps| ps.artifact_type.as_str())
-        .collect();
-    if !partial_output_types.is_empty() {
-        warn!(
-            operation = "postconditions",
-            outcome = "scan_incomplete",
-            protocol = %protocol.name,
-            work_unit = ?candidate.work_unit,
-            artifact_types = ?partial_output_types,
-            "post-session scan incomplete for output types"
-        );
-        // Unconditional: postcondition outcomes must reach the operator
-        // even when tracing filters suppress warn-level events.
-        eprintln!(
-            "runa-mcp: post-session scan incomplete for output types {partial_output_types:?} of '{}' work_unit={:?}",
-            protocol.name, candidate.work_unit
-        );
-    } else if enforce_postconditions(&protocol, &store, work_unit_ref).is_ok() {
-        info!(
-            operation = "postconditions",
-            outcome = "met",
-            protocol = %protocol.name,
-            work_unit = ?candidate.work_unit,
-            "postconditions met"
-        );
-    } else {
-        warn!(
-            operation = "postconditions",
-            outcome = "not_met",
-            protocol = %protocol.name,
-            work_unit = ?candidate.work_unit,
-            "postconditions not met"
-        );
-        // Unconditional: postcondition outcomes must reach the operator
-        // even when tracing filters suppress warn-level events.
-        eprintln!(
-            "runa-mcp: postconditions not met for '{}' work_unit={:?}",
-            protocol.name, candidate.work_unit
-        );
-    }
-
-    // 11. Exit 0.
     Ok(())
 }

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -1,0 +1,215 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+use rmcp::model::CallToolRequestParam;
+use rmcp::service::ServiceExt;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tokio::process::Command;
+
+fn write_methodology(
+    dir: &Path,
+    manifest_toml: &str,
+    schemas: &[(&str, &str)],
+    protocols: &[&str],
+) -> PathBuf {
+    let manifest_path = dir.join("manifest.toml");
+    fs::write(&manifest_path, manifest_toml).unwrap();
+
+    let schemas_dir = dir.join("schemas");
+    fs::create_dir_all(&schemas_dir).unwrap();
+    for (name, content) in schemas {
+        fs::write(schemas_dir.join(format!("{name}.schema.json")), content).unwrap();
+    }
+
+    for protocol_name in protocols {
+        let protocol_dir = dir.join("protocols").join(protocol_name);
+        fs::create_dir_all(&protocol_dir).unwrap();
+        fs::write(
+            protocol_dir.join("PROTOCOL.md"),
+            format!("# {protocol_name}\n"),
+        )
+        .unwrap();
+    }
+
+    manifest_path
+}
+
+fn manifest_toml() -> &'static str {
+    r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "summary"
+
+[[artifact_types]]
+name = "implementation"
+
+[[protocols]]
+name = "summarize"
+produces = ["summary"]
+trigger = { type = "on_change", name = "summary" }
+
+[[protocols]]
+name = "implement"
+produces = ["implementation"]
+trigger = { type = "on_change", name = "implementation" }
+"#
+}
+
+fn methodology_schemas() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "summary",
+            r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+        ),
+        (
+            "implementation",
+            r#"{"type":"object","required":["title","work_unit"],"properties":{"title":{"type":"string"},"work_unit":{"type":"string"}}}"#,
+        ),
+    ]
+}
+
+fn methodology_protocols() -> Vec<&'static str> {
+    vec!["summarize", "implement"]
+}
+
+fn init_project(project_dir: &Path, manifest_path: &Path) {
+    let runa_dir = project_dir.join(".runa");
+    fs::create_dir_all(&runa_dir).unwrap();
+
+    let manifest_path = fs::canonicalize(manifest_path).unwrap();
+    fs::write(
+        runa_dir.join("config.toml"),
+        format!(
+            "methodology_path = {:?}\n",
+            manifest_path.display().to_string()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        runa_dir.join("state.toml"),
+        "initialized_at = \"2026-03-25T00:00:00Z\"\nruna_version = \"0.1.0\"\n",
+    )
+    .unwrap();
+}
+
+fn setup_project() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_methodology(
+        dir.path(),
+        manifest_toml(),
+        &methodology_schemas(),
+        &methodology_protocols(),
+    );
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    dir
+}
+
+#[test]
+fn missing_protocol_argument_fails_clearly() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = StdCommand::new(env!("CARGO_BIN_EXE_runa-mcp"))
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--protocol"), "stderr: {stderr}");
+}
+
+#[test]
+fn unknown_protocol_name_references_manifest() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+
+    let output = StdCommand::new(env!("CARGO_BIN_EXE_runa-mcp"))
+        .arg("--protocol")
+        .arg("missing")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("missing"), "stderr: {stderr}");
+    assert!(stderr.contains("manifest"), "stderr: {stderr}");
+    assert!(stderr.contains("groundwork"), "stderr: {stderr}");
+}
+
+#[tokio::test]
+async fn starts_and_serves_tools_without_workspace_directory() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+    let workspace_dir = project_dir.join(".runa/workspace");
+    assert!(!workspace_dir.exists());
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("summarize")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let tools = service.list_all_tools().await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name.as_ref(), "summary");
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn scoped_protocol_writes_artifact_with_injected_work_unit() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("implement")
+                        .arg("--work-unit")
+                        .arg("wu-1")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let tools = service.list_all_tools().await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name.as_ref(), "implementation");
+
+    service
+        .call_tool(CallToolRequestParam {
+            name: "implementation".into(),
+            arguments: serde_json::json!({
+                "instance_id": "impl-1",
+                "title": "ship it"
+            })
+            .as_object()
+            .cloned(),
+        })
+        .await
+        .unwrap();
+
+    let artifact =
+        fs::read_to_string(project_dir.join(".runa/workspace/implementation/impl-1.json")).unwrap();
+    assert!(artifact.contains("\"title\": \"ship it\""), "{artifact}");
+    assert!(artifact.contains("\"work_unit\": \"wu-1\""), "{artifact}");
+
+    service.cancel().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- make `runa-mcp` serve one caller-selected protocol via required `--protocol` and optional `--work-unit`
- remove MCP-side workspace scanning, candidate selection, and shutdown postcondition checking so orchestration stays with `runa step`
- add binary-level MCP integration coverage and update public docs to reflect the new runtime boundary

## Changes

- replace `runa-mcp` startup candidate discovery with explicit manifest protocol resolution and named-protocol validation
- keep handler tool-serving behavior unchanged while preserving `RUNA_WORKING_DIR` and `RUNA_CONFIG`
- add stdio MCP tests for missing `--protocol`, unknown protocol errors, startup without a workspace directory, and scoped artifact writes with injected `work_unit`
- update `README.md`, `ARCHITECTURE.md`, and `CHANGELOG.md` to describe `runa-mcp` as a pure tool server

## Issue(s)

Closes #86

## Test plan

- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`
