### PR TITLE
docs: create methodology authoring guide for plugin authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Semantic Versioning.
 ### Changed
 
 - Rewrite `README.md` so it now opens with a plain-language runtime model and a checked-in `runa init` + `runa step --dry-run` quick start for adopters and methodology authors before the full command reference.
+- Add `docs/methodology-authoring-guide.md` as the first-step companion to the interface contract, with a concrete two-protocol `request -> outline -> summary` example and README links that route new methodology authors to it.
 
 - Split CLI execution into `runa step` and `runa run`. `step` now executes or previews only the next concrete protocol invocation, while `run` owns cascade-to-quiescence behavior, tolerant continuation after per-protocol failures, and outcome-specific exit codes (`0`, `2`, `3`, `130` for interrupted).
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ runa step --dry-run
 
 `runa step --dry-run` is the right first check because it requires no agent wrapper or `[agent].command` config. You should see `summarize` reported as `READY`, with `request/input` listed as the required input and `summary` listed as the expected output type.
 
-If you want the exact contract that defines these terms, read [Interface Contract](docs/interface-contract.md). If you want the runtime internals, read [ARCHITECTURE.md](ARCHITECTURE.md). The rest of this README is the full command and configuration reference.
+If you want to author your first methodology, read [Methodology Authoring Guide](docs/methodology-authoring-guide.md). If you want the exact contract that defines these terms, read [Interface Contract](docs/interface-contract.md). If you want the runtime internals, read [ARCHITECTURE.md](ARCHITECTURE.md). The rest of this README is the full command and configuration reference.
 
 ## Architecture
 
@@ -196,5 +196,6 @@ cargo test --workspace
 
 ## Documentation
 
+- [Methodology Authoring Guide](docs/methodology-authoring-guide.md) — Build a first working methodology with a concrete two-protocol chain
 - [Commons](https://github.com/pentaxis93/commons) — Bedrock principles and architectural decision records (ADRs)
 - [Interface Contract](docs/interface-contract.md) — Three primitives defining the methodology-runtime boundary

--- a/docs/methodology-authoring-guide.md
+++ b/docs/methodology-authoring-guide.md
@@ -1,0 +1,176 @@
+# Methodology Authoring Guide
+
+This guide is for someone who has finished the README and understands the
+three primitives at a conceptual level: artifact types, protocol declarations,
+and trigger conditions. Its goal is narrower than the
+[Interface Contract](interface-contract.md): build one valid methodology that
+`runa` can load, and use that example to show how protocol chaining emerges
+from declarations.
+
+## Start With A Complete Chain
+
+Use one small pipeline, not isolated fragments. The smallest useful chain has:
+
+- one input artifact type
+- one protocol that turns that input into an intermediate artifact
+- one protocol that requires the intermediate artifact and turns it into a
+  final artifact
+
+This guide uses `request -> outline -> summary`.
+
+The full methodology layout looks like this:
+
+```text
+authoring-guide-example/
+├── manifest.toml
+├── protocols/
+│   ├── plan-summary/
+│   │   └── PROTOCOL.md
+│   └── write-summary/
+│       └── PROTOCOL.md
+└── schemas/
+    ├── outline.schema.json
+    ├── request.schema.json
+    └── summary.schema.json
+```
+
+## Write The Manifest
+
+The manifest names artifact types and protocol declarations. It does not embed
+schemas or instruction paths. `runa` derives those from the layout convention.
+
+```toml
+name = "authoring-guide-example"
+
+[[artifact_types]]
+name = "request"
+
+[[artifact_types]]
+name = "outline"
+
+[[artifact_types]]
+name = "summary"
+
+[[protocols]]
+name = "plan-summary"
+requires = ["request"]
+produces = ["outline"]
+trigger = { type = "on_artifact", name = "request" }
+
+[[protocols]]
+name = "write-summary"
+requires = ["outline"]
+produces = ["summary"]
+trigger = { type = "on_artifact", name = "outline" }
+```
+
+The trigger syntax matters: `TriggerCondition` is a tagged enum, so the TOML
+must use the exact tagged shape `type = "..."` plus the fields that variant
+expects. For `on_artifact`, that means `name`.
+
+## Add The Schemas
+
+Each artifact type needs a schema file at `schemas/{name}.schema.json`.
+
+`schemas/request.schema.json`
+
+```json
+{
+  "type": "object",
+  "required": ["text"],
+  "properties": {
+    "text": {
+      "type": "string"
+    }
+  }
+}
+```
+
+`schemas/outline.schema.json`
+
+```json
+{
+  "type": "object",
+  "required": ["points"],
+  "properties": {
+    "points": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  }
+}
+```
+
+`schemas/summary.schema.json`
+
+```json
+{
+  "type": "object",
+  "required": ["summary"],
+  "properties": {
+    "summary": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Add The Protocol Instructions
+
+Each protocol needs an instruction file at `protocols/{name}/PROTOCOL.md`.
+
+`protocols/plan-summary/PROTOCOL.md`
+
+```md
+Read the `request` artifact and produce an `outline` artifact with the key
+points to cover.
+```
+
+`protocols/write-summary/PROTOCOL.md`
+
+```md
+Read the `outline` artifact and produce a `summary` artifact that turns those
+points into a concise summary.
+```
+
+## How The Chain Works
+
+`runa` does not ask you to declare a pipeline separately. The chain emerges
+from the protocol declarations:
+
+- `plan-summary` requires `request` and produces `outline`
+- `write-summary` requires `outline` and produces `summary`
+
+That is enough for `runa` to compute the dependency edge between the two
+protocols. When a valid `request` artifact exists, `plan-summary` can become
+ready. When a valid `outline` artifact exists, `write-summary` can become
+ready.
+
+This is the core pattern for methodology authoring: declare artifact
+relationships honestly, and let the runtime derive topology from them.
+
+## Check That `runa` Accepts It
+
+Once the methodology directory exists, point a fresh project at its manifest:
+
+```bash
+mkdir authoring-guide-demo
+cd authoring-guide-demo
+runa init --methodology ../authoring-guide-example/manifest.toml
+runa list
+```
+
+`runa init` should succeed without parse errors. `runa list` should show
+`plan-summary` before `write-summary`, with `request` and `outline` as the
+required artifacts that define the chain.
+
+## Where To Go Next
+
+- Read the [Interface Contract](interface-contract.md) for the authoritative
+  definition of artifact types, protocol declarations, trigger conditions, and
+  the layout convention.
+- Read [groundwork](https://github.com/pentaxis93/groundwork) for a real
+  methodology built on runa.


### PR DESCRIPTION
## Summary

- add a methodology authoring guide that walks plugin authors through a first working `request -> outline -> summary` chain
- document the exact manifest trigger shape runa accepts and show the required `schemas/` and `protocols/` layout concretely
- link the new guide from the README and record the new author-facing doc surface in the changelog

## Changes

- create `docs/methodology-authoring-guide.md` as a lean companion to `docs/interface-contract.md`
- add README entry points so readers who finish the overview can immediately find the authoring guide
- add an `Unreleased` changelog entry for the new documentation surface

## Issue(s)

Closes #103

## Test plan

- recreate the documented methodology example in a temporary methodology directory
- run `runa init --methodology <temp-methodology>/manifest.toml` from a fresh temporary project directory
- run `runa list` from that project and confirm `plan-summary` appears before `write-summary` with `on_artifact(request)` and `on_artifact(outline)` triggers
