### PR TITLE
docs: rewrite README for adopters and methodology authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,103 @@
 # runa
 
-Runa is an event-driven cognitive runtime for AI agents. It enforces contracts between methodologies and the runtime through three primitives: **artifact types** (JSON Schema-validated work products), **protocol declarations** (relationships to artifacts via requires/accepts/produces/may_produce edges), and **trigger conditions** (composable activation rules).
+Runa is a runtime for AI agents that enforces contracts on agent-produced work.
 
-Runa targets Linux. Read-only commands and dry-run planning remain available as documented, but live `runa step` and live `runa run` fail explicitly on non-Linux platforms instead of degrading execution contracts silently.
+An AI agent receives instructions and produces files. Without enforcement, nothing guarantees that the agent produced what was asked, that its output conforms to a declared schema, or that downstream work can safely depend on it. Runa provides that enforcement. It validates work products against schemas, computes what should run next from declared dependencies, activates work when conditions are met, and delivers the right input context to each agent invocation.
 
-## Architecture
+Runa is not an agent framework and does not include an AI model. It is the runtime layer between an orchestrator and the agents it directs — the layer that makes declarative workflows reliable by enforcing their contracts.
 
-Runa is a runtime layer between an orchestrating daemon and methodology plugins. Methodologies register via TOML manifests declaring their artifact types, protocols, and triggers. Schema content and protocol instruction files live at conventional locations relative to the manifest (`schemas/{name}.schema.json` and `protocols/{name}/PROTOCOL.md`). Runa derives these paths from the manifest, computes the dependency graph, validates artifacts against their schemas, tracks state, and evaluates trigger conditions.
+## Core Concepts
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for workspace structure, data flow, module descriptions, and disk layout.
+Runa's interface rests on four concepts. Each builds on the ones before it.
 
-## Usage
+An **artifact type** is a named category of work product — for example, `constraints`, `design-doc`, or `test-evidence` — with a JSON Schema that defines what a valid instance contains. The schema is the artifact's contract. Runa validates every instance against it.
 
-```bash
-runa init --methodology path/to/manifest.toml [--artifacts-dir path/to/workspace]
+A **protocol** (in runa, this term means a declared unit of work — not a network protocol or communication standard) specifies its relationship to artifacts through four edges: **requires** (must exist and validate before execution), **accepts** (consumed if available), **produces** (must exist and validate after execution), and **may_produce** (validated if present, not required). Each protocol also carries an activation rule. Execution order is not declared — it emerges from the dependency graph of requires/produces relationships across protocols.
+
+A **trigger condition** is the activation rule that defines when runa activates a protocol. Three primitive types — `on_artifact` (a named artifact exists and validates), `on_change` (a named artifact is newer than the protocol's outputs for the same work unit), and `on_invalid` (a named artifact exists but fails validation) — compose through `all_of` and `any_of` operators with arbitrary nesting depth.
+
+A **methodology** is a plugin configuration that registers with runa through a TOML manifest file. The manifest declares the methodology's artifact types, protocols, and trigger conditions. A directory layout convention places JSON Schemas at `schemas/{name}.schema.json` and protocol instruction files at `protocols/{name}/PROTOCOL.md`, both relative to the manifest. Runa derives these paths from declared names; the manifest contains no explicit path fields.
+
+## Quick Start
+
+A methodology needs a manifest file, a JSON Schema for each artifact type, and an instruction file for each protocol. Here is a minimal example with one protocol that consumes a `spec` artifact and produces a `report`.
+
+Directory layout:
+
+```
+my-methodology/
+  manifest.toml
+  schemas/
+    spec.schema.json
+    report.schema.json
+  protocols/
+    analyze/
+      PROTOCOL.md
 ```
 
-Parses the methodology manifest, validates its structure, and creates a `.runa/` directory with `config.toml` (operator configuration: methodology path, optional artifact workspace directory, optional logging settings, optional agent command), `state.toml` (runtime state: initialization timestamp, runa version), `.runa/workspace/` (default artifact workspace), and `.runa/store/` (internal artifact state store). Reports the artifact type and protocol counts on success.
+`manifest.toml`:
 
-Commands that load a project manifest support `--config <PATH>` to override the config file location. The `RUNA_CONFIG` env var serves the same purpose. For `init`, `--config` controls where the config file is written; for manifest-loading commands, it controls where the config file is read from.
+```toml
+name = "example"
 
-## Logging
+[[artifact_types]]
+name = "spec"
 
-Runtime diagnostics use `tracing` on stderr. Command output remains on stdout.
+[[artifact_types]]
+name = "report"
 
-- Default logging is quiet on successful runs (`warn` and above, human-readable text)
-- `RUST_LOG` overrides the active filter for both `runa` and `runa-mcp`
-- `config.toml` can provide logging defaults when `RUST_LOG` is unset
+[[protocols]]
+name = "analyze"
+requires = ["spec"]
+produces = ["report"]
+trigger = { type = "on_artifact", name = "spec" }
+```
 
-Optional config snippet:
+Each schema file is a standard JSON Schema. A minimal valid schema:
+
+`schemas/spec.schema.json` and `schemas/report.schema.json`:
+
+```json
+{ "type": "object" }
+```
+
+`protocols/analyze/PROTOCOL.md` contains the instruction text delivered to the agent at execution time. Any content is valid.
+
+Initialize and inspect:
+
+```bash
+runa init --methodology my-methodology/manifest.toml
+runa state
+```
+
+`runa state` shows that `analyze` is WAITING — no `spec` artifact exists yet. Create a spec artifact in the workspace and inspect again:
+
+```bash
+echo '{}' > .runa/workspace/spec/first.json
+runa state
+runa step --dry-run
+```
+
+`runa state` now shows `analyze` as READY. `runa step --dry-run` previews the execution: the protocol to run, the input artifacts it will receive, and the MCP server configuration for the agent runtime.
+
+## Configuration
+
+### Config Resolution
+
+Commands that load a methodology share a common config resolution chain. The first match wins; there is no per-field merging across sources:
+
+1. `--config <PATH>` CLI flag
+2. `RUNA_CONFIG` environment variable
+3. `.runa/config.toml`
+4. `$XDG_CONFIG_HOME/runa/config.toml`
+
+For `runa init`, `--config` controls where the config file is written. For all other commands, it controls where the config file is read from.
+
+### Logging
+
+Runtime diagnostics use `tracing` on stderr. Command output stays on stdout.
+
+Default behavior is quiet on successful runs: `warn` and above in human-readable text. `RUST_LOG` overrides the active filter for both `runa` and `runa-mcp`. When `RUST_LOG` is unset, the filter falls back to `config.logging.filter`, then to `warn`.
 
 ```toml
 [logging]
@@ -36,98 +105,177 @@ format = "json"   # "text" (default) or "json"
 filter = "info"   # any tracing env-filter directive
 ```
 
-`format = "json"` switches stderr events to machine-readable JSON. This does not change stdout command output. `RUST_LOG` controls the filter only; output format is always determined by `config.logging.format` (defaulting to `text`).
+`format = "json"` switches stderr events to machine-readable JSON without changing stdout command output. `RUST_LOG` controls the filter only; output format is always determined by `config.logging.format`.
 
-Optional agent execution config:
+### Agent Execution
+
+Live `runa step` and `runa run` (without `--dry-run`) require an `[agent].command` entry in the config:
 
 ```toml
 [agent]
 command = ["./examples/agent-claude-code.sh"]
 ```
 
-`runa step` and `runa run` without `--dry-run` require `[agent].command`. Runa executes that argv command in the project root, renders a natural-language execution prompt from the planned protocol context, writes that prompt on stdin, and leaves stdout/stderr attached to the child process. Before each invocation it also exports `RUNA_MCP_CONFIG`, a JSON description of how the wrapper should spawn `runa-mcp` for the selected protocol run. The wrapper adapts that config to the specific agent runtime. `--json` is dry-run only.
+Runa executes that command in the project root with stdout and stderr attached to the terminal, renders a natural-language execution prompt from the planned protocol context, and writes the prompt on stdin. Before each invocation, runa exports `RUNA_MCP_CONFIG` — a JSON payload containing the resolved `runa-mcp` command, arguments, and environment — so the agent wrapper can launch the MCP server as its own child process. The payload is runtime-agnostic (`{command, args, env}`); agent wrappers adapt it to their runtime's schema. See `examples/agent-claude-code.sh` for a Claude Code wrapper that converts the payload to Claude's `mcpServers` format.
 
-The exported `RUNA_MCP_CONFIG` payload stays runtime-agnostic: `{command,args,env}`. Agent wrappers are responsible for adapting that generic server description to their runtime's schema. The Claude example wrapper wraps it as `{"mcpServers":{"runa":...}}` before invoking `claude`. The exported command and env paths are absolute whenever `runa` resolves them from the local filesystem, so wrappers do not depend on their child process cwd to launch `runa-mcp`.
+## Command Reference
 
-```bash
-runa list
-```
+All commands accept a global `--config <PATH>` flag to override the config file location.
 
-Displays protocols in execution order with their artifact relationships, trigger conditions, and blocked status. Performs an implicit scan first so the output reflects the current workspace.
-Blocked protocols report required-artifact failures using the same `missing`, `invalid`, and `stale` taxonomy used elsewhere in the CLI.
+### `runa init`
 
 ```bash
-runa doctor
+runa init --methodology <PATH> [--artifacts-dir <DIR>] [--config <PATH>]
 ```
 
-Checks project health: artifact validity, protocol readiness, and dependency cycles. Performs an implicit scan first so reported health matches the current workspace. Exits 0 if healthy, 1 if problems found.
-Skill readiness reports required-artifact failures as `missing`, `invalid`, or `stale`.
+Initializes a runa project. Parses the methodology manifest at `<PATH>`, validates its structure and layout convention (schemas and instruction files at their conventional paths), canonicalizes the methodology path, and creates the `.runa/` project directory containing:
+
+- `config.toml` — methodology path, optional artifact workspace directory, optional logging and agent settings
+- `state.toml` — initialization timestamp, runa version
+- `store/` — internal artifact state store
+- the artifact workspace directory (default `.runa/workspace/`)
+
+Reports the artifact type and protocol counts on success.
+
+**Flags:**
+
+- `--methodology <PATH>` — Path to the methodology manifest file. Required.
+- `--artifacts-dir <DIR>` — Artifact workspace directory. Defaults to `.runa/workspace/`.
+
+**Exit codes:** 0 on success. 1 on parse, validation, or I/O failure.
+
+### `runa scan`
 
 ```bash
-runa scan
+runa scan [--config <PATH>]
 ```
 
-Scans the artifact workspace, reconciles it into `.runa/store/`, records valid, invalid, and malformed artifacts, and reports new/modified/revalidated/removed instances plus unreadable entries and unrecognized workspace directories. If the workspace is missing, scan succeeds only when the store is still empty; otherwise it fails to avoid wiping stored state. Per-file read failures are reported as findings and do not abort the scan. Exits 0 if reconciliation succeeds, even when findings are present.
+Reconciles the artifact workspace into `.runa/store/`. Reads `*.json` files under `<workspace>/<type_name>/`, validates each against its artifact type schema, and classifies results as new, modified (content hash changed), revalidated (content unchanged but schema hash changed), or removed. Invalid and malformed artifacts are recorded in store state rather than discarded. Unreadable files become scan-gap metadata. Unrecognized top-level workspace directories are reported separately.
+
+A missing workspace directory is an error unless the store is still empty.
+
+**Exit codes:** 0 on successful reconciliation, even when invalid, malformed, or unreadable findings are present. Non-zero on project-load, store, or I/O failure.
+
+### `runa list`
 
 ```bash
-runa state [--json]
+runa list [--config <PATH>]
 ```
 
-Evaluates every protocol after an implicit scan and classifies it as `READY`, `BLOCKED`, or `WAITING`. Evaluation is work-unit scoped: protocols are checked once per discovered work unit, with unscoped protocols still evaluated once overall. Text output groups protocols in that order and shows the current inputs, precondition failures, or unsatisfied trigger conditions that explain each status. If the scan was only partial, state surfaces `Scan warnings` and blocks protocols whose required artifact types could not be fully reconciled with reason `scan_incomplete`; partially scanned accepted artifact types are omitted from reported inputs. `--json` emits `{ "version": 2, "methodology": "...", "scan_warnings": [...], "protocols": [...] }`, with a flat ordered `protocols` array containing `name`, optional `work_unit`, `status`, `trigger`, and the status-specific fields `inputs`, `precondition_failures`, or `unsatisfied_conditions`. Exits 0 when state evaluation succeeds, even if some protocols are blocked or waiting.
-Unreadable produced artifacts do not block protocols directly, but they do conservatively disable freshness suppression for every work unit of that output type until a clean scan restores trustworthy completion evidence.
+Displays protocols in topological (execution) order after an implicit scan. For each protocol, shows non-empty relationship fields (requires, accepts, produces, may_produce), the trigger condition, and a `BLOCKED` indicator when required artifacts are missing, invalid, or stale. On cycle detection, falls back to manifest order with a warning.
+
+**Exit codes:** 0 on success. 1 on failure.
+
+### `runa state`
 
 ```bash
-runa step [--dry-run] [--json]
+runa state [--json] [--config <PATH>]
 ```
 
-Builds an operator-facing preview of the next execution after an implicit scan. `step` evaluates protocols per discovered work unit and suppresses activated work when valid outputs are newer than the relevant inputs for that work unit. `step --dry-run` therefore reports at most one concrete `(protocol, work_unit)` candidate: the next non-cyclic READY execution in graph order. That entry includes the protocol name, optional `work_unit`, the human-readable trigger that activated it, an MCP server config for the selected candidate, and a serialized agent-facing context payload. The context payload contains the protocol name, optional `work_unit`, the preloaded `PROTOCOL.md` instruction content, all valid required and available accepted inputs with display-only `display_path` strings, content hashes, and relationships, plus expected outputs split into `produces` and `may_produce`. Live prompt rendering still reads the exact filesystem path internally, so valid Unix filenames with non-UTF8 bytes are preserved end-to-end.
-`--dry-run` is planning-only: it previews the next concrete MCP launch config but does not require a discoverable `runa-mcp` binary. Live execution resolves `runa-mcp` only when a READY candidate will actually run, preferring a sibling binary next to the running `runa` executable and falling back to `PATH`.
+Evaluates every protocol after an implicit scan and classifies each as `READY`, `BLOCKED`, or `WAITING`. Classification is ordered and mutually exclusive: WAITING when the trigger is not satisfied, BLOCKED when the trigger is satisfied but preconditions fail, READY otherwise. Evaluation is work-unit scoped: protocols with work-unit-bearing inputs are checked once per discovered work unit; unscoped protocols are evaluated once overall.
 
-If the graph contains a hard dependency cycle, `step` reports the cycle as a warning and excludes the cyclic protocols from `execution_plan`; non-cyclic READY protocols still appear when they are orderable. `--dry-run` prints the next execution and the same grouped protocol status view used by `runa state`, so operators can still see blocked and waiting reasons when nothing is runnable. `--json` emits `{ "version": 4, "methodology": "...", "scan_warnings": [...], "cycle": ["..."] | null, "execution_plan": [...], "protocols": [...] }`, where `execution_plan` now contains at most one entry and `protocols` reuses the same status entries as `runa state --json`.
+Text output groups protocols in READY, BLOCKED, then WAITING order, preserving topological protocol order within each group. READY entries list valid required and accepted artifact instances. BLOCKED entries list required-artifact failures (missing, invalid, stale, scan_incomplete). WAITING entries list the trigger condition and the specific reason it is not satisfied.
 
-Without `--dry-run`, `step` requires `[agent].command`. If no READY work exists, it prints `No READY protocols.` and exits without requiring `runa-mcp`. Otherwise it resolves `runa-mcp`, executes exactly one READY candidate, re-scans the workspace, enforces postconditions for that `(protocol, work_unit)`, then prints the refreshed READY/BLOCKED/WAITING view so the operator can see what became ready next. A non-zero exit still stops execution immediately and skips the post-execution reconciliation cycle.
+When scan reconciliation is partial, `state` surfaces scan warnings and blocks protocols whose required artifact types could not be fully reconciled. Partially scanned accepted types are omitted from reported inputs.
 
-Live `runa step` targets Linux. On non-Linux platforms it fails explicitly before resolving agent or MCP execution.
+**Flags:**
+
+- `--json` — Emits a versioned JSON envelope: `{ "version": 2, "methodology": "...", "scan_warnings": [...], "protocols": [...] }`. The `protocols` array is flat and ordered, with each entry containing `name`, optional `work_unit`, `status`, `trigger`, and the status-specific field `inputs`, `precondition_failures`, or `unsatisfied_conditions`.
+
+**Exit codes:** 0 when evaluation succeeds, regardless of whether protocols are ready, blocked, or waiting. Non-zero on project-load, scan, or serialization failure.
+
+### `runa doctor`
 
 ```bash
-runa run [--dry-run] [--json]
+runa doctor [--config <PATH>]
 ```
 
-`run` is the cascade command. Live execution walks the same non-cyclic READY frontier as `step`, but continues until quiescence instead of stopping after one protocol. Previously exhausted work reopens only when a later successful execution, postcondition-failing reconciliation, or agent-failing reconciliation changes inputs that are relevant to that candidate. Agent failures and postcondition failures are tolerated for the remainder of the invocation: the failed candidate is skipped, any artifacts emitted before failure are reconciled into the workspace state for downstream readiness, other READY work continues, and the command exits `2` after quiescence if any protocol failed. If no READY work exists and some work remains blocked, waiting on external input, or trapped in a hard dependency cycle, `run` exits `3`. A fully satisfied topology exits `0`. The first `Ctrl-C` is boundary-scoped: the current protocol run is allowed to finish its reconciliation cycle. After that reconciliation, `run` exits `130` with outcome `interrupted` only if an interrupt prevented the next READY candidate from starting. If the same reconciliation leaves no further READY work, the quiescent topology outcome takes precedence (`0`, `2`, or `3`) because the interrupt did not prevent any work from executing. A second `Ctrl-C` forces immediate exit with status `130`.
+Checks project health after an implicit scan. Three checks:
 
-`run --dry-run` projects the full optimistic cascade from manifest topology only: declared `produces` outputs, `requires`/`accepts` edges, trigger declarations, and the current evaluated work-unit state. `may_produce` outputs remain optional and do not advance the projection unless they already exist on disk. Initially ready entries include the same MCP config and context shape used by `step --dry-run` only on their first concrete emission; downstream projected entries carry only protocol name, optional work unit, trigger, and projection kind. Projected work-unit scoping comes from manifest relationships plus the current artifact state, not from synthesizing artifact payloads. The dry-run projection never synthesizes values, never forks the artifact store, and never bypasses schema validation. Its exit status still reflects the current evaluated topology after the initial scan rather than forcing success because a projection was printed.
+1. **Artifact health** — enumerates instances per artifact type and reports invalid, malformed, or stale instances with details.
+2. **Protocol readiness** — checks each protocol's required artifact types and reports missing, invalid, or stale failures.
+3. **Cycle detection** — reports hard dependency cycles in the protocol graph.
 
-Live `runa run` targets Linux. On non-Linux platforms it fails explicitly before resolving agent or MCP execution.
+**Exit codes:** 0 if no problems found. 1 if any check reports a problem.
+
+### `runa step`
+
+```bash
+runa step [--dry-run] [--json] [--config <PATH>]
+```
+
+Selects at most one `(protocol, work_unit)` candidate after an implicit scan: the next non-cyclic READY execution in topological order. Activated work is suppressed when valid outputs are newer than relevant inputs for that work unit. Unreadable output instances conservatively disable freshness suppression for every work unit of the affected output type.
+
+With `--dry-run`, text output prints the next execution plus the grouped READY/BLOCKED/WAITING status view. The execution entry includes the protocol name, optional work unit, the trigger that activated it, an MCP server config, and the serialized agent-facing context payload (protocol name, optional work unit, instruction content, valid required and available accepted inputs with display paths and content hashes, and expected outputs split into `produces` and `may_produce`). Dry-run does not require a discoverable `runa-mcp` binary. If the graph contains a hard dependency cycle, `step` reports it as a warning and excludes cyclic protocols from the execution plan.
+
+Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux host. On non-Linux platforms, it fails explicitly before resolving `runa-mcp` or launching an agent. If no READY work exists, it prints `No READY protocols.` and exits without requiring `runa-mcp`. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), executes the candidate, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
+
+**Flags:**
+
+- `--dry-run` — Preview only. Does not execute the agent.
+- `--json` — Dry-run only. Emits a versioned JSON envelope: `{ "version": 4, "methodology": "...", "scan_warnings": [...], "cycle": [...] | null, "execution_plan": [...], "protocols": [...] }`. The `execution_plan` array contains at most one entry. The `protocols` array reuses the same status entries as `runa state --json`.
+
+**Exit codes:** 0 on success. 1 on failure (non-Linux for live execution, agent error, postcondition violation, project-load error).
+
+### `runa run`
+
+```bash
+runa run [--dry-run] [--json] [--config <PATH>]
+```
+
+The cascade command. Walks the READY frontier repeatedly until quiescence instead of stopping after one execution.
+
+With `--dry-run`, projects the full optimistic cascade from manifest topology: declared `produces` outputs, dependency edges, trigger declarations, and the current evaluated work-unit state. `may_produce` outputs do not advance the projection unless they already exist on disk. Initially ready entries include MCP config and full context on first emission; downstream projected entries carry only protocol name, optional work unit, trigger, and projection kind. The projection never synthesizes artifact values, forks the store, or bypasses schema validation.
+
+Without `--dry-run`, requires a Linux host. On non-Linux platforms, fails explicitly before installing the interrupt handler, resolving `runa-mcp`, or launching an agent. Failed candidates are skipped for the rest of the invocation; any artifacts emitted before failure are still reconciled into workspace state for downstream readiness. Previously exhausted work reopens when a later reconciliation changes relevant inputs.
+
+**Interrupt behavior.** The first `Ctrl-C` is boundary-scoped: the current protocol run completes its scan and postcondition reconciliation. After that reconciliation, `run` exits `130` only if the interrupt prevented the next READY candidate from starting. If no further READY work remains, the quiescent topology outcome takes precedence. A second `Ctrl-C` forces immediate exit with status `130`; the isolated child process may continue running after `runa` terminates.
+
+**Flags:**
+
+- `--dry-run` — Preview the projected cascade. Does not execute agents.
+- `--json` — Dry-run only. Same envelope structure as `runa step --json`, but `execution_plan` may contain multiple entries including projected downstream work.
+
+**Exit codes** (apply to both live and dry-run — dry-run reflects current topology state, not the projection):
+
+| Code | Meaning |
+|------|---------|
+| 0 | Topology fully satisfied. |
+| 1 | Fatal error (project-load, config, non-Linux). |
+| 2 | Quiescent with protocol failures or postcondition violations during the invocation. |
+| 3 | Quiescent but work remains blocked, waiting, or trapped in a cycle. |
+| 130 | Interrupted — `Ctrl-C` prevented the next candidate from starting. |
 
 ## MCP Server
 
-`runa-mcp` is a single-session stdio MCP server that serves one named protocol invocation per process. It is designed to be started by an outer orchestrator (e.g., an MCP client) for each protocol run.
+`runa-mcp` is a single-session stdio MCP server that serves one named protocol invocation per process.
 
 ```bash
 runa-mcp --protocol <name> [--work-unit <name>]
 ```
 
-On startup, the server loads the project from the current directory (or `RUNA_WORKING_DIR`), resolves the named protocol from the manifest, validates that its output types can be served as MCP tools, and then serves an MCP session over stdio with:
+On startup, the server loads the project, resolves the named protocol from the manifest, validates that its output types can be served as MCP tools, and serves an MCP session over stdio. Each output artifact type (`produces` and `may_produce`) becomes one MCP tool. The tool input schema is the artifact type's JSON Schema with the `work_unit` field removed — the server injects `work_unit` automatically from the `--work-unit` argument.
 
-- **Tools** — One tool per output artifact type (`produces` + `may_produce`). The tool input schema is the artifact's JSON Schema with `work_unit` removed. The server injects `work_unit` automatically.
+`runa step` does not spawn `runa-mcp` directly. It passes the agent wrapper a `RUNA_MCP_CONFIG` JSON payload containing the resolved `runa-mcp` command, arguments, and environment so the agent runtime can launch the server as its own child process. The exported command and environment paths are absolute whenever runa resolves them from the local filesystem, so wrappers do not depend on child process cwd to launch `runa-mcp`.
 
-Environment variables:
-- `RUNA_WORKING_DIR` — Project directory (defaults to current directory)
-- `RUNA_CONFIG` — Config file override (same as `--config` in the CLI)
-- `RUST_LOG` — Tracing filter override for stderr diagnostics
+**Environment variables:**
 
-`runa step` does not spawn `runa-mcp` directly. It passes the agent wrapper a `RUNA_MCP_CONFIG` JSON payload containing the resolved `runa-mcp` command location, candidate-specific arguments, and required environment so the agent runtime can launch the MCP server as its own child process.
+- `RUNA_WORKING_DIR` — Project directory. Defaults to the current directory.
+- `RUNA_CONFIG` — Config file override (same as `--config` in the CLI).
+- `RUST_LOG` — Tracing filter override for stderr diagnostics.
 
 ## Build
 
-Rust 2024 edition.
+Rust 2024 edition. Runa targets Linux.
 
 ```bash
-cargo build          # Debug build
+cargo build
 cargo test --workspace
 ```
 
 ## Documentation
 
-- [Commons](https://github.com/pentaxis93/commons) — Bedrock principles and architectural decision records (ADRs)
-- [Interface Contract](docs/interface-contract.md) — Three primitives defining the methodology-runtime boundary
+- [Interface Contract](docs/interface-contract.md) — The three primitives defining the methodology-runtime boundary
+- [Architecture](ARCHITECTURE.md) — Workspace structure, data flow, module descriptions, disk layout
+- [Contributing](CONTRIBUTING.md) — Conventions for landing PRs
+- [Commons](https://github.com/pentaxis93/commons) — Bedrock principles and architectural decision records


### PR DESCRIPTION
## Summary

Rewrites README.md to serve two entry-level audiences — adopters evaluating runa and methodology authors building on it — before serving the reference need.

- Opens with a jargon-free mental model (~120 words, zero domain terms)
- Defines artifact type, protocol, trigger, methodology in dependency order before first substantive use
- Adds a working quick start (manifest + `runa init` / `runa step --dry-run`) verified against the parser
- Provides complete command reference for all 7 CLI commands + runa-mcp with consistent template (syntax, behavior, flags, exit codes, constraints)
- Moves configuration (resolution chain, logging, agent execution) into its own section between quick start and reference

Closes #102

## Test plan

- [x] Opening 300 words contain no undefined domain terms (verified by word-position analysis)
- [x] All four vocabulary terms defined before first substantive deployment
- [x] Quick start manifest parses and initializes successfully (`runa init` run against example)
- [x] Command reference cross-referenced against ARCHITECTURE.md and clap definitions
- [x] Vocabulary consistent with `docs/interface-contract.md`
- [x] `cargo test --workspace` passes