### PR TITLE
docs: expand CONTRIBUTING.md and AGENTS.md for onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,64 @@ This project does not vendor agent skills in-repo. Resolve project skills from
 your global installs under `~/.claude/skills` and `~/.codex/skills`.
 
 **CLAUDE.md and AGENTS.md are the same file** — CLAUDE.md is a symlink to AGENTS.md. Edit AGENTS.md. Never break the symlink.
+
+## Context injection
+
+When `runa step` invokes an agent, it delivers a context injection as a
+natural-language prompt on stdin. The context contains everything the agent
+needs to execute the protocol without querying the store directly.
+
+**Fields:**
+
+- **protocol** — the name of the protocol being executed.
+- **work_unit** — optional scoping identifier. Present when the protocol's
+  inputs are partitioned by work unit; absent for unscoped protocols.
+- **instructions** — the protocol's `PROTOCOL.md` content.
+- **inputs** — valid artifact instances available to this execution. Each
+  input carries:
+  - `artifact_type` — the artifact type name
+  - `instance_id` — the instance identifier (also the filename stem)
+  - `display_path` — workspace-relative path to the artifact file
+  - `content_hash` — `sha256:<hex>` digest of the artifact's canonical JSON
+  - `relationship` — `requires` (hard dependency, guaranteed valid) or
+    `accepts` (soft dependency, available but not required)
+- **expected_outputs** — artifact type names the agent is expected to produce,
+  split into:
+  - `produces` — must be delivered. The protocol fails postconditions if any
+    are missing or invalid after execution.
+  - `may_produce` — optional. Validated if present, not required.
+
+**Rendered prompt structure:**
+
+The prompt organizes this context under headings: required inputs appear under
+"What you've been given", accepted inputs under "Additional context", and
+expected outputs under "What you need to deliver". The prompt instructs the
+agent to call the MCP tool matching each output type name.
+
+## Artifact production contract
+
+Agents produce artifacts by calling tools on the `runa-mcp` MCP server. Each
+protocol invocation gets its own single-session `runa-mcp` process.
+
+**Tool derivation.** The server exposes one MCP tool per output artifact type
+(`produces` and viable `may_produce` types). The tool name matches the artifact
+type name.
+
+**Tool input schema.** Each tool's input schema is derived from the artifact
+type's JSON Schema with two modifications:
+- `work_unit` is removed — the server injects it automatically from the
+  execution context.
+- `instance_id` is added as a required string field — the agent supplies this
+  to name the artifact instance. It becomes the filename:
+  `<workspace>/<type_name>/<instance_id>.json`.
+
+**Validation.** The server validates the artifact against the full schema
+(including the injected `work_unit`) before writing it to the workspace.
+Invalid artifacts are rejected with validation error details and never written
+to disk.
+
+**Postcondition enforcement.** After the agent process exits, `runa step`
+re-scans the workspace and enforces postconditions: every `produces` artifact
+type must have valid instances; `may_produce` artifacts are validated if present
+but their absence is not a failure. A postcondition violation fails the protocol
+execution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,57 @@
 # Contributing
 
-## Coherence on landing
+## Development setup
 
-Every PR that ships must update affected documentation:
-- CLI changes, build commands → README.md
-- Module, data flow, disk layout, or design pattern changes → ARCHITECTURE.md
+Runa requires the Rust 2024 edition toolchain. No external services or
+databases are needed.
+
+```bash
+cargo build
+cargo test --workspace
+cargo fmt --check
+cargo clippy
+```
+
+Runa targets Linux. Live `runa step` and live `runa run` are Linux-only.
+
+## Architecture constraint
+
+The workspace has three crates:
+
+- **libagent** — all domain logic: manifest parsing, validation, dependency
+  graph, artifact state, trigger evaluation, context injection, enforcement,
+  protocol selection.
+- **runa-cli** — thin CLI binary. Argument parsing and output formatting only.
+  Delegates to libagent.
+- **runa-mcp** — thin MCP server binary. Serves one protocol invocation per
+  process. Delegates to libagent.
+
+New domain logic goes in libagent. The CLI and MCP server must not contain
+domain logic — this keeps behavior testable and reasoned about in one place.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for module detail.
 
 ## Conventions
 
-- Runa targets Linux. Live `runa step` and live `runa run` are Linux-only.
-- Agent skills are a user-level prerequisite, not a repo-local asset. Install
-  and maintain them under `~/.claude/skills` and `~/.codex/skills`.
 - Conventional commits (e.g., `feat(trigger):`, `fix(store):`, `docs:`)
 - Branch names: `issue-N/brief-description`
 - One issue per PR
 - `cargo fmt` and `cargo clippy` clean before merge
+- Agent skills are a user-level prerequisite, not a repo-local asset. Install
+  and maintain them under `~/.claude/skills` and `~/.codex/skills`.
+
+## Pull request checklist
+
+- [ ] Tests pass: `cargo test --workspace`
+- [ ] Formatted: `cargo fmt --check`
+- [ ] Lint-clean: `cargo clippy`
+- [ ] One issue per PR
+- [ ] Documentation updated for any user-visible change (see below)
+
+## Documentation coherence
+
+Documentation updates ship in the same PR as the changes that caused them.
+
+- CLI changes, build commands, configuration changes → [README.md](README.md)
+- Module, data flow, disk layout, or design pattern changes → [ARCHITECTURE.md](ARCHITECTURE.md)
+- Significant architectural decisions → new ADR
+- User-visible behavior changes → [CHANGELOG.md](CHANGELOG.md)


### PR DESCRIPTION
## Summary

- Expands CONTRIBUTING.md from 6 lines of conventions to a full contributor onboarding guide: development setup, three-crate architecture constraint, conventions, PR checklist, and documentation coherence rules.
- Expands AGENTS.md with two new sections: the context injection structure agents receive from `runa step`, and the artifact production contract through `runa-mcp` (tool derivation, validation-before-write, postcondition enforcement).
- Both documents use vocabulary consistent with README.md and `docs/interface-contract.md`.

## Test plan

- [ ] `ls -la CLAUDE.md` confirms symlink to AGENTS.md is intact
- [ ] CONTRIBUTING.md enables a new contributor to run `cargo test --workspace` without additional guidance
- [ ] CONTRIBUTING.md states the three-crate architecture principle as a contributor constraint
- [ ] CONTRIBUTING.md covers: build commands, test commands, commit convention, branch naming, PR checklist, documentation coherence
- [ ] AGENTS.md describes context injection fields: protocol, work_unit, instructions, inputs (with relationships and content hashes), expected outputs
- [ ] AGENTS.md describes artifact production contract: MCP tool availability, validation, postcondition enforcement
- [ ] Vocabulary consistent with README.md and `docs/interface-contract.md`

Closes #104
