### PR TITLE
docs: self-maintaining commons references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Architecture: `ARCHITECTURE.md`
 Methodology authoring: `docs/methodology-authoring-guide.md`
 Interface contract: `docs/interface-contract.md`
 Contribution conventions: `CONTRIBUTING.md`
-Bedrock principles: [commons](https://github.com/pentaxis93/commons) — read both `PRINCIPLES.md` and every ADR in `adr/`
+Shared governance: [commons](https://github.com/pentaxis93/commons) — read everything in this repo
 
 This project does not vendor agent skills in-repo. Resolve project skills from
 your global installs under `~/.claude/skills` and `~/.codex/skills`.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Both projects are in early development.
 - [Architecture](ARCHITECTURE.md) — Workspace structure, data flow, module descriptions, disk layout
 - [Contributing](CONTRIBUTING.md) — Conventions for landing PRs
 - [Quickstart Example](examples/quickstart-methodology/) — A two-protocol review pipeline you can browse and run
-- [Commons](https://github.com/pentaxis93/commons) — Bedrock principles and architectural decision records
+- [Commons](https://github.com/pentaxis93/commons) — Shared governance for the ecosystem
 
 ## Commands
 


### PR DESCRIPTION
Applies design principle #12 (self-maintaining over maintainer-dependent) to runa's own references to commons.

AGENTS.md: 'read both PRINCIPLES.md and every ADR' → 'read everything in this repo'
README.md: 'Bedrock principles and architectural decision records' → 'Shared governance for the ecosystem'

When commons gains new documents (like the just-added DESIGN-PRINCIPLES.md), these references don't go stale.