### PR TITLE
refactor(config): remove artifacts_dir configurability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,9 +106,9 @@ Runtime loop: parses `--protocol` and optional `--work-unit`, loads the project,
 
 ```
 .runa/
-  config.toml                   # Created by `runa init`: methodology_path, optional artifacts_dir, optional logging, optional agent.command
+  config.toml                   # Created by `runa init`: methodology_path, optional logging, optional agent.command
   state.toml                    # Created by `runa init`: initialized_at, runa_version
-  workspace/                    # Default artifact workspace (configurable via artifacts_dir)
+  workspace/                    # Artifact workspace (non-configurable)
     {type_name}/
       {instance_id}.json        # Agent-produced artifact file
   store/                        # Internal runtime state store (not configurable)
@@ -123,9 +123,9 @@ Commands that operate on a loaded methodology share `project::load`, which resol
 
 Config resolution is whole-file (first found wins, no per-field merging): `--config` CLI flag → `RUNA_CONFIG` env var → `.runa/config.toml` → `$XDG_CONFIG_HOME/runa/config.toml` → error.
 
-### `runa init --methodology <PATH> [--artifacts-dir <DIR>] [--config <PATH>]`
+### `runa init --methodology <PATH> [--config <PATH>]`
 
-Parses the manifest at `<PATH>` via `libagent::manifest::parse`, canonicalizes the path, creates `.runa/config.toml` (or writes to the `--config` path) containing the canonical methodology path, optional artifact workspace directory, optional logging settings, and optional agent execution settings. Creates `.runa/state.toml`, `.runa/store/`, and the resolved artifact workspace directory. Reports the artifact type and protocol counts on success.
+Parses the manifest at `<PATH>` via `libagent::manifest::parse`, canonicalizes the path, creates `.runa/config.toml` (or writes to the `--config` path) containing the canonical methodology path plus optional logging settings and optional agent execution settings. Creates `.runa/state.toml`, `.runa/store/`, and the fixed artifact workspace directory at `.runa/workspace/`. Reports the artifact type and protocol counts on success.
 
 ### `runa list`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Semantic Versioning.
 
 - `runa-cli` now uses the shared commons exit code convention across
   `init`, `scan`, `list`, `state`, `doctor`, `step`, and `run`.
+- Breaking change: `.runa/config.toml` no longer accepts `artifacts_dir`.
+  Artifact files now always live under `.runa/workspace/`, and configs that
+  still declare `artifacts_dir` fail to load with an actionable error.
 - Breaking change for callers parsing runa exit codes:
   code `2` no longer means `QuiescentFailures`.
   Code `2` now means `usage_error`, and the old `QuiescentFailures`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -45,22 +45,21 @@ All commands accept a global `--config <PATH>` flag to override the config file 
 ### `runa init`
 
 ```bash
-runa init --methodology <PATH> [--artifacts-dir <DIR>] [--config <PATH>]
+runa init --methodology <PATH> [--config <PATH>]
 ```
 
 Initializes a runa project. Parses the methodology manifest at `<PATH>`, validates its structure and layout convention (schemas and instruction files at their conventional paths), canonicalizes the methodology path, and creates the `.runa/` project directory containing:
 
-- `config.toml` — methodology path, optional artifact workspace directory, optional logging and agent settings
+- `config.toml` — methodology path, optional logging and agent settings
 - `state.toml` — initialization timestamp, runa version
 - `store/` — internal artifact state store
-- the artifact workspace directory (default `.runa/workspace/`)
+- the fixed artifact workspace directory `.runa/workspace/`
 
 Reports the artifact type and protocol counts on success.
 
 **Flags:**
 
 - `--methodology <PATH>` — Path to the methodology manifest file. Required.
-- `--artifacts-dir <DIR>` — Artifact workspace directory. Defaults to `.runa/workspace/`.
 
 **Exit codes:** 0 on success. 6 on parse, validation, or I/O failure.
 

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -58,8 +58,6 @@ impl AgentConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     pub methodology_path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifacts_dir: Option<String>,
     #[serde(default, skip_serializing_if = "LoggingConfig::is_default")]
     pub logging: LoggingConfig,
     #[serde(default, skip_serializing_if = "AgentConfig::is_default")]
@@ -200,7 +198,17 @@ pub fn read_config(
 ) -> Result<Config, ProjectError> {
     let config_path = resolve_config(working_dir, config_override)?;
     let config_content = std::fs::read_to_string(&config_path).map_err(ProjectError::Io)?;
-    toml::from_str(&config_content).map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))
+    let config_value: toml::Value = toml::from_str(&config_content)
+        .map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))?;
+    if config_value.get("artifacts_dir").is_some() {
+        return Err(ProjectError::ConfigParseFailed(
+            "'artifacts_dir' has been removed; artifacts always live under '.runa/workspace/' and are no longer configurable"
+                .to_string(),
+        ));
+    }
+    config_value
+        .try_into()
+        .map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))
 }
 
 /// Load a runa project from `working_dir`.
@@ -231,12 +239,7 @@ pub fn load(
 
     let graph = DependencyGraph::build(&manifest.protocols).map_err(ProjectError::GraphInvalid)?;
 
-    // Resolve artifact workspace dir: explicit config value or default,
-    // relative to the project `.runa/` directory.
-    let workspace_dir = match &config.artifacts_dir {
-        Some(dir) => working_dir.join(dir),
-        None => runa_dir.join(DEFAULT_WORKSPACE_DIR),
-    };
+    let workspace_dir = runa_dir.join(DEFAULT_WORKSPACE_DIR);
     let store_dir = runa_dir.join(STORE_DIRNAME);
     let mut store = ArtifactStore::new(manifest.artifact_types.clone(), store_dir)
         .map_err(ProjectError::StoreError)?;
@@ -296,7 +299,6 @@ trigger = { type = "on_change", name = "constraints" }
         let canonical = fs::canonicalize(manifest_path).unwrap();
         let config = Config {
             methodology_path: canonical.display().to_string(),
-            artifacts_dir: None,
             logging: LoggingConfig::default(),
             agent: AgentConfig::default(),
         };
@@ -358,7 +360,6 @@ trigger = { type = "on_change", name = "constraints" }
         let external_config_path = dir.path().join("external-config.toml");
         let config = Config {
             methodology_path: canonical.display().to_string(),
-            artifacts_dir: None,
             logging: LoggingConfig::default(),
             agent: AgentConfig::default(),
         };
@@ -369,7 +370,7 @@ trigger = { type = "on_change", name = "constraints" }
     }
 
     #[test]
-    fn load_with_custom_artifacts_dir() {
+    fn load_rejects_removed_artifacts_dir_field() {
         let dir = tempfile::tempdir().unwrap();
         write_methodology_layout(dir.path());
         let manifest_path = dir.path().join("manifest.toml");
@@ -381,15 +382,15 @@ trigger = { type = "on_change", name = "constraints" }
         fs::create_dir_all(&runa_dir).unwrap();
 
         let canonical = fs::canonicalize(&manifest_path).unwrap();
-        let config = Config {
-            methodology_path: canonical.display().to_string(),
-            artifacts_dir: Some("custom-artifacts".to_string()),
-            logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
-        };
         fs::write(
             runa_dir.join("config.toml"),
-            toml::to_string(&config).unwrap(),
+            format!(
+                r#"
+methodology_path = "{}"
+artifacts_dir = "custom-artifacts"
+"#,
+                canonical.display()
+            ),
         )
         .unwrap();
 
@@ -403,9 +404,16 @@ trigger = { type = "on_change", name = "constraints" }
         )
         .unwrap();
 
-        // load succeeds — artifacts_dir is resolved but doesn't need to exist yet
-        let loaded = load(&working, None).unwrap();
-        assert_eq!(loaded.workspace_dir, working.join("custom-artifacts"));
+        let err = load(&working, None).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("artifacts_dir"),
+            "error should name removed field: {message}"
+        );
+        assert!(
+            message.contains(".runa/workspace"),
+            "error should name invariant workspace path: {message}"
+        );
     }
 
     #[test]
@@ -433,7 +441,6 @@ trigger = { type = "on_change", name = "constraints" }
         let canonical = fs::canonicalize(&manifest_path).unwrap();
         let config = Config {
             methodology_path: canonical.display().to_string(),
-            artifacts_dir: None,
             logging: LoggingConfig::default(),
             agent: AgentConfig::default(),
         };
@@ -502,6 +509,34 @@ trigger = { type = "on_change", name = "constraints" }
         assert!(
             err.to_string().contains("nonexistent.toml"),
             "error should include the path"
+        );
+    }
+
+    #[test]
+    fn read_config_rejects_removed_artifacts_dir_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
+            r#"
+methodology_path = "/tmp/methodology.toml"
+artifacts_dir = "custom-artifacts"
+"#,
+        )
+        .unwrap();
+
+        let err = read_config(&working, None).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("artifacts_dir"),
+            "error should name removed field: {message}"
+        );
+        assert!(
+            message.contains(".runa/workspace"),
+            "error should name invariant workspace path: {message}"
         );
     }
 

--- a/libagent/src/projection.rs
+++ b/libagent/src/projection.rs
@@ -86,20 +86,16 @@ pub fn project_cascade(
     let mut emitted = HashSet::new();
     let mut plan = Vec::new();
 
-    loop {
-        let Some(next) =
-            discover_ready_candidates_projection(protocols, &projection, topological_order, scope)
-                .into_iter()
-                .find(|candidate| {
-                    !exhausted.contains(&candidate_key(
-                        &candidate.protocol_name,
-                        candidate.work_unit.as_deref(),
-                    ))
-                })
-        else {
-            break;
-        };
-
+    while let Some(next) =
+        discover_ready_candidates_projection(protocols, &projection, topological_order, scope)
+            .into_iter()
+            .find(|candidate| {
+                !exhausted.contains(&candidate_key(
+                    &candidate.protocol_name,
+                    candidate.work_unit.as_deref(),
+                ))
+            })
+    {
         let key = candidate_key(&next.protocol_name, next.work_unit.as_deref());
         let first_emission = emitted.insert(key.clone());
         let projection_class = if initial_ready.contains(&key) && first_emission {

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -49,7 +49,6 @@ impl std::error::Error for InitError {
 pub fn run(
     working_dir: &Path,
     methodology: &Path,
-    artifacts_dir: Option<&str>,
     config_path: Option<&Path>,
 ) -> Result<InitSummary, InitError> {
     if !methodology.exists() {
@@ -66,15 +65,12 @@ pub fn run(
     fs::create_dir_all(&runa_dir).map_err(InitError::Io)?;
     fs::create_dir_all(runa_dir.join(STORE_DIRNAME)).map_err(InitError::Io)?;
 
-    let workspace_dir = artifacts_dir
-        .map(|dir| working_dir.join(dir))
-        .unwrap_or_else(|| runa_dir.join(DEFAULT_WORKSPACE_DIR));
+    let workspace_dir = runa_dir.join(DEFAULT_WORKSPACE_DIR);
     fs::create_dir_all(&workspace_dir).map_err(InitError::Io)?;
 
     // Write config.
     let config = Config {
         methodology_path: canonical_path.display().to_string(),
-        artifacts_dir: artifacts_dir.map(String::from),
         logging: crate::project::LoggingConfig::default(),
         agent: crate::project::AgentConfig::default(),
     };
@@ -200,7 +196,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        let summary = run(&working, &manifest_path, None, None).unwrap();
+        let summary = run(&working, &manifest_path, None).unwrap();
 
         assert_eq!(summary.methodology_name, "groundwork");
         assert_eq!(summary.artifact_type_count, 2);
@@ -220,30 +216,13 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        run(&working, &manifest_path, None, None).unwrap();
+        run(&working, &manifest_path, None).unwrap();
 
         let config_content = fs::read_to_string(working.join(".runa").join("config.toml")).unwrap();
         let canonical = fs::canonicalize(&manifest_path).unwrap();
         assert!(
             config_content.contains(&canonical.display().to_string()),
             "config file should contain canonical methodology path"
-        );
-    }
-
-    #[test]
-    fn config_file_records_artifacts_dir_when_provided() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest_path = write_methodology_layout(dir.path());
-
-        let working = dir.path().join("project");
-        fs::create_dir(&working).unwrap();
-
-        run(&working, &manifest_path, Some("my-artifacts"), None).unwrap();
-
-        let config_content = fs::read_to_string(working.join(".runa").join("config.toml")).unwrap();
-        assert!(
-            config_content.contains("my-artifacts"),
-            "config file should contain custom artifacts_dir"
         );
     }
 
@@ -255,7 +234,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        run(&working, &manifest_path, None, None).unwrap();
+        run(&working, &manifest_path, None).unwrap();
 
         let config_content = fs::read_to_string(working.join(".runa").join("config.toml")).unwrap();
         assert!(
@@ -272,7 +251,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        run(&working, &manifest_path, None, None).unwrap();
+        run(&working, &manifest_path, None).unwrap();
 
         let state_content = fs::read_to_string(working.join(".runa").join("state.toml")).unwrap();
         let state: State = toml::from_str(&state_content).unwrap();
@@ -291,7 +270,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        run(&working, &manifest_path, None, None).unwrap();
+        run(&working, &manifest_path, None).unwrap();
 
         let state_content = fs::read_to_string(working.join(".runa").join("state.toml")).unwrap();
         assert!(
@@ -309,7 +288,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         fs::create_dir(&working).unwrap();
 
         let custom_config = dir.path().join("custom").join("config.toml");
-        run(&working, &manifest_path, None, Some(&custom_config)).unwrap();
+        run(&working, &manifest_path, Some(&custom_config)).unwrap();
 
         assert!(custom_config.is_file(), "config should be at custom path");
         // Default location should not exist.
@@ -326,7 +305,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let dir = tempfile::tempdir().unwrap();
         let bogus = dir.path().join("no-such-file.toml");
 
-        let err = run(dir.path(), &bogus, None, None).unwrap_err();
+        let err = run(dir.path(), &bogus, None).unwrap_err();
         assert!(
             matches!(err, InitError::MethodologyNotFound { .. }),
             "expected MethodologyNotFound, got: {err}"
@@ -339,7 +318,7 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let manifest_path = dir.path().join("bad.toml");
         fs::write(&manifest_path, "not valid manifest").unwrap();
 
-        let err = run(dir.path(), &manifest_path, None, None).unwrap_err();
+        let err = run(dir.path(), &manifest_path, None).unwrap_err();
         assert!(
             matches!(err, InitError::ManifestInvalid(_)),
             "expected ManifestInvalid, got: {err}"
@@ -366,8 +345,8 @@ trigger = { type = "on_artifact", name = "design-doc" }
         let working = dir.path().join("project");
         fs::create_dir(&working).unwrap();
 
-        let summary1 = run(&working, &manifest_path, None, None).unwrap();
-        let summary2 = run(&working, &manifest_path, None, None).unwrap();
+        let summary1 = run(&working, &manifest_path, None).unwrap();
+        let summary2 = run(&working, &manifest_path, None).unwrap();
 
         assert_eq!(summary1.methodology_name, summary2.methodology_name);
         assert_eq!(summary1.artifact_type_count, summary2.artifact_type_count);

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -29,10 +29,6 @@ enum Commands {
         /// Path to the methodology manifest file
         #[arg(long)]
         methodology: PathBuf,
-
-        /// Directory for artifact workspace files (default: .runa/workspace/)
-        #[arg(long)]
-        artifacts_dir: Option<String>,
     },
     /// Display protocols, dependencies, and execution order
     List,
@@ -126,16 +122,8 @@ fn main() {
     }
 
     match cli.command {
-        Commands::Init {
-            methodology,
-            artifacts_dir,
-        } => {
-            match commands::init::run(
-                &working_dir,
-                &methodology,
-                artifacts_dir.as_deref(),
-                config_override_ref,
-            ) {
+        Commands::Init { methodology } => {
+            match commands::init::run(&working_dir, &methodology, config_override_ref) {
                 Ok(summary) => {
                     println!(
                         "Initialized runa project with methodology '{}'",

--- a/runa-cli/tests/init.rs
+++ b/runa-cli/tests/init.rs
@@ -124,3 +124,32 @@ fn init_is_idempotent() {
     let stdout = String::from_utf8_lossy(&output2.stdout);
     assert!(stdout.contains("groundwork"));
 }
+
+#[test]
+fn init_rejects_removed_artifacts_dir_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let output = runa_bin()
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .arg("--artifacts-dir")
+        .arg("custom-artifacts")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--artifacts-dir"), "stderr: {stderr}");
+}


### PR DESCRIPTION
## Summary

- remove the `artifacts_dir` config surface so `.runa/workspace/` is the only artifact location
- reject legacy configs that still declare `artifacts_dir` with an explicit invariant error
- align init behavior, regression coverage, and docs/changelog with the fixed `.runa/` workspace contract

## Changes

- runtime/config: remove `artifacts_dir` from the shared config model, reject the removed field during config parsing, and resolve the workspace path unconditionally to `.runa/workspace/`
- cli/tests: drop `--artifacts-dir` from `runa init`, stop writing the field into `.runa/config.toml`, and add coverage for legacy-config rejection and removed-flag rejection
- docs: update architecture and CLI reference surfaces to describe `.runa/workspace/` as non-configurable, and record the breaking change in the changelog

## GitHub Issue(s)

Closes #135

## Test plan

- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy`
