### PR TITLE
feat(init): actionable error for unusable .runa state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Semantic Versioning.
 - `runa run` now validates its effective agent command before reporting a
   quiescent `nothing_ready` outcome, so malformed or missing live command
   input is no longer masked when no protocols are READY.
+- `runa init` now reports an actionable diagnostic when pre-existing `.runa/`
+  state is owned by another user or is not writable, including likely causes
+  and remediation instead of a raw permission error.
 
 ## [0.1.0] — 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ Semantic Versioning.
   quiescent `nothing_ready` outcome, so malformed or missing live command
   input is no longer masked when no protocols are READY.
 - `runa init` now reports an actionable diagnostic when pre-existing `.runa/`
-  state is owned by another user or is not writable, including likely causes
-  and remediation instead of a raw permission error.
+  state or the selected config destination is not writable, including likely
+  causes and remediation instead of a raw permission error.
 
 ## [0.1.0] — 2026-04-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "libagent",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tokio = { version = "1", features = ["rt", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 ctrlc = "3.4"
+libc = "0.2"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -61,11 +61,11 @@ Initializes a runa project. Parses the methodology manifest at `<PATH>`, validat
 
 Reports the artifact type and protocol counts on success.
 
-If pre-existing `.runa/` state is owned by another user or cannot be written by
-the current user, `init` fails before writing project state and reports the
-path, owner UID, current UID, likely causes, and remediation. This usually
-means the directory is managed by another tool such as agentd, was left by a
-sudo-created init, or the command is running in the wrong directory.
+If pre-existing `.runa/` state or the selected config destination cannot be
+written by the current user, `init` fails before writing project state and
+reports the path, owner UID, current UID, likely causes, and remediation. This
+usually means the path is managed by another tool, was left by a sudo-created
+init, or the command is running in the wrong directory.
 
 **Flags:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -61,6 +61,12 @@ Initializes a runa project. Parses the methodology manifest at `<PATH>`, validat
 
 Reports the artifact type and protocol counts on success.
 
+If pre-existing `.runa/` state is owned by another user or cannot be written by
+the current user, `init` fails before writing project state and reports the
+path, owner UID, current UID, likely causes, and remediation. This usually
+means the directory is managed by another tool such as agentd, was left by a
+sudo-created init, or the command is running in the wrong directory.
+
 **Flags:**
 
 - `--methodology <PATH>` — Path to the methodology manifest file. Required.

--- a/runa-cli/Cargo.toml
+++ b/runa-cli/Cargo.toml
@@ -17,6 +17,7 @@ tempfile.workspace = true
 toml.workspace = true
 tracing.workspace = true
 ctrlc.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -101,15 +101,11 @@ pub fn run(
 
     let runa_dir = working_dir.join(RUNA_DIR);
     let config_dest = match config_path {
-        Some(p) => p.to_path_buf(),
+        Some(p) if p.is_absolute() => p.to_path_buf(),
+        Some(p) => working_dir.join(p),
         None => runa_dir.join(CONFIG_FILENAME),
     };
-    let config_dest_for_preflight = if config_dest.is_absolute() {
-        config_dest.clone()
-    } else {
-        working_dir.join(&config_dest)
-    };
-    preflight_existing_runa_paths(&runa_dir, &config_dest_for_preflight)?;
+    preflight_existing_runa_paths(&runa_dir, &config_dest)?;
 
     fs::create_dir_all(&runa_dir).map_err(InitError::Io)?;
     fs::create_dir_all(runa_dir.join(STORE_DIRNAME)).map_err(InitError::Io)?;
@@ -506,6 +502,65 @@ trigger = { type = "on_artifact", name = "design-doc" }
             matches!(err, InitError::ManifestInvalid(_)),
             "expected ManifestInvalid, got: {err}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_working_dir_reports_default_config_preflight_before_writing_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let unique = format!(
+            "target/init-relative-preflight-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let root = PathBuf::from(unique);
+        let methodology_dir = root.join("methodology");
+        fs::create_dir_all(&methodology_dir).unwrap();
+        let manifest_path = write_methodology_layout(&methodology_dir);
+
+        let working = root.join("project");
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        let config_path = runa_dir.join("config.toml");
+        fs::write(&config_path, "old config").unwrap();
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o400)).unwrap();
+
+        let err = run(&working, &manifest_path, None).unwrap_err();
+
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        assert!(
+            matches!(err, InitError::ExistingRunaPathUnusable(_)),
+            "expected preflight diagnostic, got: {err}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains(config_path.to_string_lossy().as_ref()),
+            "message should name the default config path: {message}"
+        );
+        assert!(message.contains("not writable"), "message: {message}");
+        assert!(
+            !message.contains("Permission denied"),
+            "message should not expose raw EACCES: {message}"
+        );
+        assert!(
+            !runa_dir.join("store").exists(),
+            "store should not be created before the diagnostic"
+        );
+        assert!(
+            !runa_dir.join("workspace").exists(),
+            "workspace should not be created before the diagnostic"
+        );
+        assert!(
+            !runa_dir.join("state.toml").exists(),
+            "state should not be created before the diagnostic"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -155,25 +155,45 @@ fn preflight_existing_runa_paths(runa_dir: &Path, config_dest: &Path) -> Result<
     paths.push(config_dest.to_path_buf());
 
     for path in paths {
-        preflight_existing_runa_path(&path)?;
+        preflight_init_output_path(&path)?;
     }
-
-    preflight_config_parent_creation(config_dest)?;
 
     Ok(())
 }
 
 #[cfg(unix)]
-fn preflight_config_parent_creation(config_dest: &Path) -> Result<(), InitError> {
-    let Some(parent) = config_dest.parent() else {
-        return Ok(());
-    };
+fn preflight_init_output_path(path: &Path) -> Result<(), InitError> {
+    match fs::metadata(path) {
+        Ok(metadata) => preflight_existing_runa_path_metadata(path, metadata),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            preflight_existing_parent_for_creation(path)
+        }
+        Err(error) => Err(InitError::Io(error)),
+    }
+}
 
-    let mut candidate = Some(parent);
+#[cfg(not(unix))]
+fn preflight_init_output_path(_path: &Path) -> Result<(), InitError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn preflight_existing_parent_for_creation(path: &Path) -> Result<(), InitError> {
+    let mut candidate = path.parent();
     while let Some(path) = candidate {
         match fs::metadata(path) {
-            Ok(_) => return preflight_existing_runa_path(path),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(metadata) => return preflight_existing_runa_path_metadata(path, metadata),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+                ) =>
+            {
                 candidate = path.parent();
             }
             Err(error) => return Err(InitError::Io(error)),
@@ -183,20 +203,12 @@ fn preflight_config_parent_creation(config_dest: &Path) -> Result<(), InitError>
     Ok(())
 }
 
-#[cfg(not(unix))]
-fn preflight_config_parent_creation(_config_dest: &Path) -> Result<(), InitError> {
-    Ok(())
-}
-
 #[cfg(unix)]
-fn preflight_existing_runa_path(path: &Path) -> Result<(), InitError> {
+fn preflight_existing_runa_path_metadata(
+    path: &Path,
+    metadata: fs::Metadata,
+) -> Result<(), InitError> {
     use std::os::unix::fs::MetadataExt;
-
-    let metadata = match fs::metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(InitError::Io(error)),
-    };
 
     if let Some(diagnostic) = diagnose_existing_runa_path(
         path,
@@ -232,11 +244,6 @@ fn diagnose_existing_runa_path(
         current_uid,
         reason,
     })
-}
-
-#[cfg(not(unix))]
-fn preflight_existing_runa_path(_path: &Path) -> Result<(), InitError> {
-    Ok(())
 }
 
 #[cfg(unix)]

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::project::{
@@ -58,7 +59,7 @@ impl fmt::Display for ExistingRunaPathDiagnostic {
             f,
             "pre-existing runa state is not usable: {} {reason} \
              (owned by uid {}, current uid {}). \
-             This usually means the directory is managed by another tool such as agentd, \
+             This usually means the directory is managed by another tool, \
              was left behind by a sudo-created init, or this command is running in the wrong directory. \
              If another tool manages this directory, do not run `runa init` here. \
              If this is leftover state, remove it and retry, or run `runa init` in the intended project directory.",
@@ -151,9 +152,8 @@ fn preflight_existing_runa_paths(runa_dir: &Path, config_dest: &Path) -> Result<
         runa_dir.join(DEFAULT_WORKSPACE_DIR),
         runa_dir.join(STATE_FILENAME),
     ];
-    if config_dest.starts_with(runa_dir)
-        && let Some(parent) = config_dest.parent()
-    {
+    paths.push(config_dest.to_path_buf());
+    if let Some(parent) = config_dest.parent() {
         paths.push(parent.to_path_buf());
     }
 
@@ -178,7 +178,7 @@ fn preflight_existing_runa_path(path: &Path) -> Result<(), InitError> {
         path,
         metadata.uid(),
         current_uid(),
-        owner_can_write(&metadata),
+        current_process_can_write(path, &metadata).map_err(InitError::Io)?,
     ) {
         return Err(InitError::ExistingRunaPathUnusable(diagnostic));
     }
@@ -192,12 +192,14 @@ fn diagnose_existing_runa_path(
     current_uid: u32,
     current_user_can_write: bool,
 ) -> Option<ExistingRunaPathDiagnostic> {
+    if current_user_can_write {
+        return None;
+    }
+
     let reason = if owner_uid != current_uid {
         Some(ExistingRunaPathReason::OwnerMismatch)
-    } else if !current_user_can_write {
-        Some(ExistingRunaPathReason::NotWritable)
     } else {
-        None
+        Some(ExistingRunaPathReason::NotWritable)
     };
 
     reason.map(|reason| ExistingRunaPathDiagnostic {
@@ -220,14 +222,34 @@ fn current_uid() -> u32 {
 }
 
 #[cfg(unix)]
-fn owner_can_write(metadata: &fs::Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt;
+fn current_process_can_write(path: &Path, metadata: &fs::Metadata) -> io::Result<bool> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
 
-    let mode = metadata.mode();
-    if metadata.file_type().is_dir() {
-        mode & 0o300 == 0o300
+    let access_mode = if metadata.file_type().is_dir() {
+        libc::W_OK | libc::X_OK
     } else {
-        mode & 0o200 == 0o200
+        libc::W_OK
+    };
+    let path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+
+    // `AT_EACCESS` checks effective process credentials, matching whether
+    // `init` will be able to create or overwrite this path.
+    let result =
+        unsafe { libc::faccessat(libc::AT_FDCWD, path.as_ptr(), access_mode, libc::AT_EACCESS) };
+    if result == 0 {
+        Ok(true)
+    } else {
+        let error = io::Error::last_os_error();
+        if matches!(
+            error.kind(),
+            io::ErrorKind::PermissionDenied | io::ErrorKind::NotFound
+        ) {
+            Ok(false)
+        } else {
+            Err(error)
+        }
     }
 }
 
@@ -456,15 +478,29 @@ trigger = { type = "on_artifact", name = "design-doc" }
     }
 
     #[test]
-    fn existing_runa_path_diagnostic_reports_owner_mismatch() {
-        let diagnostic = diagnose_existing_runa_path(Path::new(".runa"), 0, 1000, true).unwrap();
+    fn existing_runa_path_diagnostic_ignores_owner_mismatch_when_writable() {
+        let diagnostic = diagnose_existing_runa_path(Path::new(".runa"), 0, 1000, true);
+
+        assert!(
+            diagnostic.is_none(),
+            "owner mismatch alone should not fail writable state"
+        );
+    }
+
+    #[test]
+    fn existing_runa_path_diagnostic_reports_owner_mismatch_when_unwritable() {
+        let diagnostic = diagnose_existing_runa_path(Path::new(".runa"), 0, 1000, false).unwrap();
 
         let message = diagnostic.to_string();
         assert!(message.contains(".runa"), "message: {message}");
         assert!(message.contains("owned by uid 0"), "message: {message}");
         assert!(message.contains("current uid 1000"), "message: {message}");
         assert!(message.contains("different user"), "message: {message}");
-        assert!(message.contains("agentd"), "message: {message}");
+        assert!(
+            message.contains("managed by another tool"),
+            "message: {message}"
+        );
+        assert!(!message.contains("agentd"), "message: {message}");
         assert!(message.contains("remove"), "message: {message}");
     }
 

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -480,6 +480,34 @@ trigger = { type = "on_artifact", name = "design-doc" }
     }
 
     #[test]
+    fn relative_working_dir_writes_default_config_to_resolved_runa_path() {
+        let unique = format!(
+            "target/init-relative-success-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let root = PathBuf::from(unique);
+        let methodology_dir = root.join("methodology");
+        fs::create_dir_all(&methodology_dir).unwrap();
+        let manifest_path = write_methodology_layout(&methodology_dir);
+
+        let working = root.join("project");
+        fs::create_dir(&working).unwrap();
+
+        run(&working, &manifest_path, None).unwrap();
+
+        assert!(
+            working.join(".runa").join("config.toml").is_file(),
+            "default config should be written under the resolved relative working directory"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
     fn nonexistent_methodology_returns_error() {
         let dir = tempfile::tempdir().unwrap();
         let bogus = dir.path().join("no-such-file.toml");

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -153,14 +153,38 @@ fn preflight_existing_runa_paths(runa_dir: &Path, config_dest: &Path) -> Result<
         runa_dir.join(STATE_FILENAME),
     ];
     paths.push(config_dest.to_path_buf());
-    if let Some(parent) = config_dest.parent() {
-        paths.push(parent.to_path_buf());
-    }
 
     for path in paths {
         preflight_existing_runa_path(&path)?;
     }
 
+    preflight_config_parent_creation(config_dest)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn preflight_config_parent_creation(config_dest: &Path) -> Result<(), InitError> {
+    let Some(parent) = config_dest.parent() else {
+        return Ok(());
+    };
+
+    let mut candidate = Some(parent);
+    while let Some(path) = candidate {
+        match fs::metadata(path) {
+            Ok(_) => return preflight_existing_runa_path(path),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                candidate = path.parent();
+            }
+            Err(error) => return Err(InitError::Io(error)),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn preflight_config_parent_creation(_config_dest: &Path) -> Result<(), InitError> {
     Ok(())
 }
 

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -17,7 +17,22 @@ pub struct InitSummary {
 pub enum InitError {
     MethodologyNotFound { path: PathBuf },
     ManifestInvalid(libagent::ManifestError),
+    ExistingRunaPathUnusable(ExistingRunaPathDiagnostic),
     Io(std::io::Error),
+}
+
+#[derive(Debug)]
+pub struct ExistingRunaPathDiagnostic {
+    path: PathBuf,
+    owner_uid: u32,
+    current_uid: u32,
+    reason: ExistingRunaPathReason,
+}
+
+#[derive(Debug)]
+enum ExistingRunaPathReason {
+    OwnerMismatch,
+    NotWritable,
 }
 
 impl fmt::Display for InitError {
@@ -27,8 +42,30 @@ impl fmt::Display for InitError {
                 write!(f, "methodology not found: {}", path.display())
             }
             InitError::ManifestInvalid(e) => write!(f, "{e}"),
+            InitError::ExistingRunaPathUnusable(diagnostic) => write!(f, "{diagnostic}"),
             InitError::Io(e) => write!(f, "{e}"),
         }
+    }
+}
+
+impl fmt::Display for ExistingRunaPathDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let reason = match self.reason {
+            ExistingRunaPathReason::OwnerMismatch => "is owned by a different user",
+            ExistingRunaPathReason::NotWritable => "is not writable by the current user",
+        };
+        write!(
+            f,
+            "pre-existing runa state is not usable: {} {reason} \
+             (owned by uid {}, current uid {}). \
+             This usually means the directory is managed by another tool such as agentd, \
+             was left behind by a sudo-created init, or this command is running in the wrong directory. \
+             If another tool manages this directory, do not run `runa init` here. \
+             If this is leftover state, remove it and retry, or run `runa init` in the intended project directory.",
+            self.path.display(),
+            self.owner_uid,
+            self.current_uid
+        )
     }
 }
 
@@ -37,7 +74,7 @@ impl std::error::Error for InitError {
         match self {
             InitError::ManifestInvalid(e) => Some(e),
             InitError::Io(e) => Some(e),
-            InitError::MethodologyNotFound { .. } => None,
+            InitError::MethodologyNotFound { .. } | InitError::ExistingRunaPathUnusable(_) => None,
         }
     }
 }
@@ -62,6 +99,17 @@ pub fn run(
     let canonical_path = fs::canonicalize(methodology).map_err(InitError::Io)?;
 
     let runa_dir = working_dir.join(RUNA_DIR);
+    let config_dest = match config_path {
+        Some(p) => p.to_path_buf(),
+        None => runa_dir.join(CONFIG_FILENAME),
+    };
+    let config_dest_for_preflight = if config_dest.is_absolute() {
+        config_dest.clone()
+    } else {
+        working_dir.join(&config_dest)
+    };
+    preflight_existing_runa_paths(&runa_dir, &config_dest_for_preflight)?;
+
     fs::create_dir_all(&runa_dir).map_err(InitError::Io)?;
     fs::create_dir_all(runa_dir.join(STORE_DIRNAME)).map_err(InitError::Io)?;
 
@@ -76,10 +124,6 @@ pub fn run(
     };
     let config_toml = toml::to_string(&config).expect("Config serialization should not fail");
 
-    let config_dest = match config_path {
-        Some(p) => p.to_path_buf(),
-        None => runa_dir.join(CONFIG_FILENAME),
-    };
     if let Some(parent) = config_dest.parent() {
         fs::create_dir_all(parent).map_err(InitError::Io)?;
     }
@@ -98,6 +142,93 @@ pub fn run(
         artifact_type_count: manifest.artifact_types.len(),
         protocol_count: manifest.protocols.len(),
     })
+}
+
+fn preflight_existing_runa_paths(runa_dir: &Path, config_dest: &Path) -> Result<(), InitError> {
+    let mut paths = vec![
+        runa_dir.to_path_buf(),
+        runa_dir.join(STORE_DIRNAME),
+        runa_dir.join(DEFAULT_WORKSPACE_DIR),
+        runa_dir.join(STATE_FILENAME),
+    ];
+    if config_dest.starts_with(runa_dir)
+        && let Some(parent) = config_dest.parent()
+    {
+        paths.push(parent.to_path_buf());
+    }
+
+    for path in paths {
+        preflight_existing_runa_path(&path)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn preflight_existing_runa_path(path: &Path) -> Result<(), InitError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(InitError::Io(error)),
+    };
+
+    if let Some(diagnostic) = diagnose_existing_runa_path(
+        path,
+        metadata.uid(),
+        current_uid(),
+        owner_can_write(&metadata),
+    ) {
+        return Err(InitError::ExistingRunaPathUnusable(diagnostic));
+    }
+
+    Ok(())
+}
+
+fn diagnose_existing_runa_path(
+    path: &Path,
+    owner_uid: u32,
+    current_uid: u32,
+    current_user_can_write: bool,
+) -> Option<ExistingRunaPathDiagnostic> {
+    let reason = if owner_uid != current_uid {
+        Some(ExistingRunaPathReason::OwnerMismatch)
+    } else if !current_user_can_write {
+        Some(ExistingRunaPathReason::NotWritable)
+    } else {
+        None
+    };
+
+    reason.map(|reason| ExistingRunaPathDiagnostic {
+        path: path.to_path_buf(),
+        owner_uid,
+        current_uid,
+        reason,
+    })
+}
+
+#[cfg(not(unix))]
+fn preflight_existing_runa_path(_path: &Path) -> Result<(), InitError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // SAFETY: `geteuid` has no preconditions and cannot fail.
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(unix)]
+fn owner_can_write(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let mode = metadata.mode();
+    if metadata.file_type().is_dir() {
+        mode & 0o300 == 0o300
+    } else {
+        mode & 0o200 == 0o200
+    }
 }
 
 fn now_iso8601() -> String {
@@ -135,7 +266,6 @@ fn days_to_date(days: u64) -> (u64, u64, u64) {
     let y = if m <= 2 { y + 1 } else { y };
     (y, m, d)
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -323,6 +453,19 @@ trigger = { type = "on_artifact", name = "design-doc" }
             matches!(err, InitError::ManifestInvalid(_)),
             "expected ManifestInvalid, got: {err}"
         );
+    }
+
+    #[test]
+    fn existing_runa_path_diagnostic_reports_owner_mismatch() {
+        let diagnostic = diagnose_existing_runa_path(Path::new(".runa"), 0, 1000, true).unwrap();
+
+        let message = diagnostic.to_string();
+        assert!(message.contains(".runa"), "message: {message}");
+        assert!(message.contains("owned by uid 0"), "message: {message}");
+        assert!(message.contains("current uid 1000"), "message: {message}");
+        assert!(message.contains("different user"), "message: {message}");
+        assert!(message.contains("agentd"), "message: {message}");
+        assert!(message.contains("remove"), "message: {message}");
     }
 
     #[test]

--- a/runa-cli/tests/init.rs
+++ b/runa-cli/tests/init.rs
@@ -186,10 +186,112 @@ fn init_reports_actionable_error_for_unwritable_existing_runa_directory() {
     assert!(stderr.contains("owned by uid"), "stderr: {stderr}");
     assert!(stderr.contains("current uid"), "stderr: {stderr}");
     assert!(stderr.contains("not writable"), "stderr: {stderr}");
-    assert!(stderr.contains("agentd"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("managed by another tool"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("agentd"), "stderr: {stderr}");
     assert!(stderr.contains("remove"), "stderr: {stderr}");
     assert!(
         !stderr.contains("Permission denied (os error 13)"),
         "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn init_reports_actionable_error_for_unwritable_existing_config_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let runa_dir = project_dir.join(".runa");
+    std::fs::create_dir(&runa_dir).unwrap();
+    let config_path = runa_dir.join("config.toml");
+    std::fs::write(&config_path, "old config").unwrap();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+    let output = runa_bin()
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(".runa/config.toml"), "stderr: {stderr}");
+    assert!(stderr.contains("not writable"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("managed by another tool"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("agentd"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !runa_dir.join("store").exists(),
+        "store should not be created before the diagnostic"
+    );
+    assert!(
+        !runa_dir.join("workspace").exists(),
+        "workspace should not be created before the diagnostic"
+    );
+    assert!(
+        !runa_dir.join("state.toml").exists(),
+        "state should not be created before the diagnostic"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn init_reports_actionable_error_for_unwritable_custom_config_file_before_creating_runa_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let custom_config_dir = dir.path().join("custom");
+    std::fs::create_dir(&custom_config_dir).unwrap();
+    let custom_config_path = custom_config_dir.join("config.toml");
+    std::fs::write(&custom_config_path, "old config").unwrap();
+    std::fs::set_permissions(&custom_config_path, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+    let output = runa_bin()
+        .arg("--config")
+        .arg(&custom_config_path)
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(&custom_config_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(custom_config_path.to_string_lossy().as_ref()),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("not writable"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !project_dir.join(".runa").exists(),
+        ".runa should not be created before the diagnostic"
     );
 }

--- a/runa-cli/tests/init.rs
+++ b/runa-cli/tests/init.rs
@@ -295,3 +295,59 @@ fn init_reports_actionable_error_for_unwritable_custom_config_file_before_creati
         ".runa should not be created before the diagnostic"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn init_reports_actionable_error_for_unwritable_custom_config_ancestor_before_creating_runa_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let locked_config_ancestor = dir.path().join("locked");
+    std::fs::create_dir(&locked_config_ancestor).unwrap();
+    let custom_config_path = locked_config_ancestor.join("new").join("config.toml");
+    std::fs::set_permissions(
+        &locked_config_ancestor,
+        std::fs::Permissions::from_mode(0o500),
+    )
+    .unwrap();
+
+    let output = runa_bin()
+        .arg("--config")
+        .arg(&custom_config_path)
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(
+        &locked_config_ancestor,
+        std::fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(locked_config_ancestor.to_string_lossy().as_ref()),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("not writable"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("managed by another tool"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !project_dir.join(".runa").exists(),
+        ".runa should not be created before the diagnostic"
+    );
+}

--- a/runa-cli/tests/init.rs
+++ b/runa-cli/tests/init.rs
@@ -1,5 +1,7 @@
 mod common;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
 fn runa_bin() -> Command {
@@ -152,4 +154,42 @@ fn init_rejects_removed_artifacts_dir_flag() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("--artifacts-dir"), "stderr: {stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn init_reports_actionable_error_for_unwritable_existing_runa_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let runa_dir = project_dir.join(".runa");
+    std::fs::create_dir(&runa_dir).unwrap();
+    std::fs::set_permissions(&runa_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = runa_bin()
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(&runa_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(".runa"), "stderr: {stderr}");
+    assert!(stderr.contains("owned by uid"), "stderr: {stderr}");
+    assert!(stderr.contains("current uid"), "stderr: {stderr}");
+    assert!(stderr.contains("not writable"), "stderr: {stderr}");
+    assert!(stderr.contains("agentd"), "stderr: {stderr}");
+    assert!(stderr.contains("remove"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "stderr: {stderr}"
+    );
 }

--- a/runa-cli/tests/init.rs
+++ b/runa-cli/tests/init.rs
@@ -351,3 +351,117 @@ fn init_reports_actionable_error_for_unwritable_custom_config_ancestor_before_cr
         ".runa should not be created before the diagnostic"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn init_reports_actionable_error_for_unsearchable_custom_config_ancestor_before_creating_runa_dir()
+{
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let locked_config_ancestor = dir.path().join("locked");
+    std::fs::create_dir(&locked_config_ancestor).unwrap();
+    let missing_child = locked_config_ancestor.join("new");
+    let custom_config_path = missing_child.join("config.toml");
+    std::fs::set_permissions(
+        &locked_config_ancestor,
+        std::fs::Permissions::from_mode(0o600),
+    )
+    .unwrap();
+
+    let output = runa_bin()
+        .arg("--config")
+        .arg(&custom_config_path)
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(
+        &locked_config_ancestor,
+        std::fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(locked_config_ancestor.to_string_lossy().as_ref()),
+        "stderr should name inaccessible ancestor, not a missing child: {stderr}"
+    );
+    assert!(
+        !stderr.contains(missing_child.to_string_lossy().as_ref()),
+        "stderr should not name the missing child as the unusable path: {stderr}"
+    );
+    assert!(stderr.contains("not writable"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("managed by another tool"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !project_dir.join(".runa").exists(),
+        ".runa should not be created before the diagnostic"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn init_reports_actionable_error_for_unwritable_project_directory_before_writing_custom_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path =
+        common::write_methodology(dir.path(), valid_manifest_toml(), SCHEMAS, PROTOCOLS);
+
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let custom_config_dir = dir.path().join("custom");
+    std::fs::create_dir(&custom_config_dir).unwrap();
+    let custom_config_path = custom_config_dir.join("config.toml");
+    std::fs::set_permissions(&project_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = runa_bin()
+        .arg("--config")
+        .arg(&custom_config_path)
+        .arg("init")
+        .arg("--methodology")
+        .arg(&manifest_path)
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(&project_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(project_dir.to_string_lossy().as_ref()),
+        "stderr should name unwritable project directory: {stderr}"
+    );
+    assert!(stderr.contains("not writable"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("managed by another tool"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !project_dir.join(".runa").exists(),
+        ".runa should not be created before the diagnostic"
+    );
+    assert!(
+        !custom_config_path.exists(),
+        "custom config should not be written before the diagnostic"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a preflight diagnostic for pre-existing `.runa/` state that is owned by another user or not writable by the current user.
- Preserves `runa init` semantics: unusable state still fails, but the failure now names the path, owner UID, current UID, likely causes, and remediation.
- Documents the operator-visible diagnostic and records it in the changelog.

## Changes

- `runa init` checks existing `.runa/`, store, workspace, state, and in-tree config parent paths before creating or writing project state.
- Unix diagnostics follow symlinks via metadata and report ownership/writeability failures through a dedicated init error variant.
- Regression coverage verifies the actionable error text and preserves clean/idempotent init behavior.

## GitHub Issue(s)

Closes #137

## Test plan

- `cargo fmt --check`
- `cargo test -p runa-cli init -- --nocapture`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`
- `git diff --check`
