### PR TITLE
fix(release-ceremony): restore annotated tag trust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - "v*"
 
 permissions:
   contents: read
@@ -22,6 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          set -euo pipefail
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
       - name: Require annotated tag
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
@@ -32,6 +43,9 @@ jobs:
           git fetch --force origin refs/heads/main:refs/remotes/origin/main
           tag_commit="$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")"
           git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
 
       - name: Install Rust toolchain
         run: |
@@ -56,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           release_flags=()
-          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+-rc[.][0-9]+$ ]]; then
+          if [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)-rc[.][1-9][0-9]*$ ]]; then
             release_flags+=(--prerelease)
           fi
           gh release create "$GITHUB_REF_NAME" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ Semantic Versioning.
 - Live `runa step` and `runa run` preserve inherited agent stdout/stderr when
   `RUNA_TRANSCRIPT_DIR` is unset, keeping transcript capture opt-in and
   retaining the default attached-terminal behavior.
+- Release publication now delegates `v*` tag filtering to `release-check`,
+  restores annotated tag refs after checkout, and verifies the restored tag
+  still matches the triggering event commit before tag-trust checks. Refs
+  tesserine/commons#34.
 
 ## [0.1.0] — 2026-04-03
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,10 +68,13 @@ the existing tag.
 
 ## Post-Release Gate
 
-The tag push runs `.github/workflows/release.yml`. That workflow verifies the
-annotated tag, builds both release binaries, verifies workspace and binary
-identity, extracts release notes from `CHANGELOG.md`, and publishes the GitHub
-Release. Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
+The tag push runs `.github/workflows/release.yml`. That workflow restores the
+tag ref, verifies that its commit still matches the event commit, and verifies
+the annotated tag and main-branch ancestry with git-only checks before running
+repository release code. It then builds both release binaries, verifies
+workspace and binary identity, extracts release notes from `CHANGELOG.md`, and
+publishes the GitHub Release.
+Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
 
 Manual GitHub Release creation, when needed after a workflow failure, uses the
 same notes source:

--- a/runa-cli/tests/release_check.rs
+++ b/runa-cli/tests/release_check.rs
@@ -165,6 +165,45 @@ license.workspace = true
 "#
         ),
     );
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+"#,
+    );
     fixture.install_release_check();
     fixture
 }
@@ -199,6 +238,276 @@ fn metadata_accepts_a_coherent_runa_release_surface() {
     let output = fixture.run_release_check(&["metadata"]);
 
     assert_success(&output);
+}
+
+#[test]
+fn metadata_rejects_release_workflows_without_v_star_tag_delegation() {
+    let fixture = valid_fixture("metadata-workflow-old-tag-filters", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml must declare exactly one release tag pattern",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_with_path_filters_on_tag_publication() {
+    let fixture = valid_fixture("metadata-workflow-path-filter", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+    paths:
+      - "CHANGELOG.md"
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml tag publication must not use paths filters",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_without_early_tag_validation() {
+    let fixture = valid_fixture("metadata-workflow-missing-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml must validate the release tag before expensive release work",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_validate_tags_before_tag_trust() {
+    let fixture = valid_fixture("metadata-workflow-pretrust-validation", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml must establish tag trust before running repository code",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_do_not_restore_annotated_tag_refs() {
+    let fixture = valid_fixture("metadata-workflow-missing-tag-ref-restore", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml must restore annotated tag refs before checking tag type",
+    );
+}
+
+#[test]
+fn metadata_rejects_release_workflows_that_do_not_verify_restored_tag_matches_event() {
+    let fixture = valid_fixture("metadata-workflow-missing-event-identity", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Require annotated tag
+        run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Validate release tag
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml must verify the restored tag matches the triggering event before checking tag type",
+    );
+}
+
+#[test]
+fn metadata_ignores_yaml_and_shell_comments_when_validating_workflow_shape() {
+    let fixture = valid_fixture("metadata-workflow-comment-only", "1.2.3");
+    fixture.write(
+        ".github/workflows/release.yml",
+        r#"name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # run: ./scripts/release-check release "$GITHUB_REF_NAME"
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
+      - name: Commented annotated tag check
+        run: |
+          # git cat-file -t "refs/tags/$GITHUB_REF_NAME"
+
+      - name: Require tag target on main
+        run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+"#,
+    );
+
+    let output = fixture.run_release_check(&["metadata"]);
+
+    assert_failure_contains(
+        &output,
+        ".github/workflows/release.yml must validate the release tag before expensive release work",
+    );
 }
 
 #[test]
@@ -413,6 +722,33 @@ fn release_rejects_tag_versions_that_do_not_match_workspace_version() {
     assert_failure_contains(
         &output,
         "workspace version 1.2.3 does not match tag version 1.2.4",
+    );
+}
+
+#[test]
+fn release_accepts_source_only_validation_before_binaries_are_built() {
+    let fixture = valid_fixture("release-source-only", "1.2.3");
+
+    let output = fixture.run_release_check(&["release", "v1.2.3"]);
+
+    assert_success(&output);
+}
+
+#[test]
+fn release_rejects_partial_binary_validation_arguments() {
+    let fixture = valid_fixture("release-partial-binary-args", "1.2.3");
+    fixture.write("fake-runa", "#!/usr/bin/env sh\nprintf 'runa 1.2.3\\n'\n");
+    fs::set_permissions(
+        fixture.root.join("fake-runa"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("fake runa should be executable");
+
+    let output = fixture.run_release_check(&["release", "v1.2.3", "--runa-bin", "fake-runa"]);
+
+    assert_failure_contains(
+        &output,
+        "--runa-bin and --runa-mcp-bin must be supplied together",
     );
 }
 

--- a/runa-cli/tests/release_check.rs
+++ b/runa-cli/tests/release_check.rs
@@ -753,6 +753,63 @@ fn release_rejects_partial_binary_validation_arguments() {
 }
 
 #[test]
+fn release_rejects_empty_binary_validation_paths() {
+    let fixture = valid_fixture("release-empty-binary-args", "1.2.3");
+
+    let output =
+        fixture.run_release_check(&["release", "v1.2.3", "--runa-bin", "", "--runa-mcp-bin", ""]);
+
+    assert_failure_contains(&output, "--runa-bin requires a non-empty path");
+}
+
+#[test]
+fn release_rejects_empty_runa_binary_path_even_with_runa_mcp_path() {
+    let fixture = valid_fixture("release-empty-runa-bin", "1.2.3");
+    fixture.write(
+        "fake-runa-mcp",
+        "#!/usr/bin/env sh\nprintf 'runa-mcp 1.2.3\\n'\n",
+    );
+    fs::set_permissions(
+        fixture.root.join("fake-runa-mcp"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("fake runa-mcp should be executable");
+
+    let output = fixture.run_release_check(&[
+        "release",
+        "v1.2.3",
+        "--runa-bin",
+        "",
+        "--runa-mcp-bin",
+        "fake-runa-mcp",
+    ]);
+
+    assert_failure_contains(&output, "--runa-bin requires a non-empty path");
+}
+
+#[test]
+fn release_rejects_empty_runa_mcp_binary_path_even_with_runa_path() {
+    let fixture = valid_fixture("release-empty-runa-mcp-bin", "1.2.3");
+    fixture.write("fake-runa", "#!/usr/bin/env sh\nprintf 'runa 1.2.3\\n'\n");
+    fs::set_permissions(
+        fixture.root.join("fake-runa"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("fake runa should be executable");
+
+    let output = fixture.run_release_check(&[
+        "release",
+        "v1.2.3",
+        "--runa-bin",
+        "fake-runa",
+        "--runa-mcp-bin",
+        "",
+    ]);
+
+    assert_failure_contains(&output, "--runa-mcp-bin requires a non-empty path");
+}
+
+#[test]
 fn release_checks_both_runa_binary_identities() {
     let fixture = valid_fixture("release-binaries-success", "1.2.3");
     fixture.write("fake-runa", "#!/usr/bin/env sh\nprintf 'runa 1.2.3\\n'\n");

--- a/runa-cli/tests/workspace_contract.rs
+++ b/runa-cli/tests/workspace_contract.rs
@@ -247,60 +247,18 @@ fn release_workflow_tag_patterns() -> Vec<String> {
     patterns
 }
 
-fn documented_actions_pattern_matches(pattern: &str, candidate: &str) -> bool {
-    let pattern = pattern.as_bytes();
-    let candidate = candidate.as_bytes();
-    let mut pattern_index = 0;
-    let mut candidate_index = 0;
-
-    while pattern_index < pattern.len() {
-        if pattern[pattern_index] == b'[' {
-            let range_end = pattern[pattern_index..]
-                .iter()
-                .position(|byte| *byte == b']')
-                .map(|offset| pattern_index + offset)
-                .expect("test pattern character class should close");
-            assert_eq!(
-                &pattern[pattern_index..=range_end],
-                b"[0-9]",
-                "test matcher only models the documented digit class used by release tags"
-            );
-            let one_or_more = pattern.get(range_end + 1) == Some(&b'+');
-            let start = candidate_index;
-            while candidate
-                .get(candidate_index)
-                .is_some_and(u8::is_ascii_digit)
-            {
-                candidate_index += 1;
-            }
-            if one_or_more {
-                if candidate_index == start {
-                    return false;
-                }
-                pattern_index = range_end + 2;
-            } else {
-                if candidate_index != start + 1 {
-                    return false;
-                }
-                pattern_index = range_end + 1;
-            }
-            continue;
-        }
-
-        if candidate.get(candidate_index) != pattern.get(pattern_index) {
-            return false;
-        }
-        pattern_index += 1;
-        candidate_index += 1;
-    }
-
-    candidate_index == candidate.len()
+fn line_number_containing(contents: &str, needle: &str) -> Option<usize> {
+    contents
+        .lines()
+        .position(|line| line.contains(needle))
+        .map(|index| index + 1)
 }
 
-fn matches_any_documented_actions_pattern(patterns: &[String], candidate: &str) -> bool {
-    patterns
-        .iter()
-        .any(|pattern| documented_actions_pattern_matches(pattern, candidate))
+fn first_line_number_containing_any(contents: &str, needles: &[&str]) -> Option<usize> {
+    contents
+        .lines()
+        .position(|line| needles.iter().any(|needle| line.contains(needle)))
+        .map(|index| index + 1)
 }
 
 #[test]
@@ -323,44 +281,66 @@ fn release_check_script_is_the_release_verifier_surface() {
 }
 
 #[test]
-fn github_release_workflow_triggers_only_for_documented_tag_shapes() {
+fn github_release_workflow_delegates_v_prefixed_tags_to_release_check() {
     let patterns = release_workflow_tag_patterns();
 
-    assert!(
-        !patterns.iter().any(|pattern| pattern == "v*.*.*"),
-        "release workflow should not trigger on arbitrary v*.*.* tags"
-    );
     assert_eq!(
         patterns,
-        ["v[0-9]+.[0-9]+.[0-9]+", "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"],
-        "release workflow should trigger only documented stable and RC tag shapes"
+        ["v*"],
+        "release workflow should delegate v-prefixed tag shape validation to release-check"
     );
 }
 
 #[test]
-fn github_release_workflow_tag_filters_match_the_documented_release_contract() {
-    let patterns = release_workflow_tag_patterns();
+fn github_release_workflow_validates_tags_before_expensive_release_work() {
+    let workflow = read_workspace_file(".github/workflows/release.yml");
+    let validation_line = line_number_containing(
+        &workflow,
+        "run: ./scripts/release-check release \"$GITHUB_REF_NAME\"",
+    )
+    .expect("release workflow should validate the tag with release-check");
+    let expensive_work_line = first_line_number_containing_any(
+        &workflow,
+        &["rustup toolchain install", "cargo build --release"],
+    )
+    .expect("release workflow should perform expensive release work");
 
-    for accepted in ["v0.1.2", "v10.20.300", "v0.1.2-rc.1", "v10.20.300-rc.400"] {
-        assert!(
-            matches_any_documented_actions_pattern(&patterns, accepted),
-            "release workflow tag filters should match documented tag {accepted}"
-        );
-    }
+    assert!(
+        validation_line < expensive_work_line,
+        "release workflow should validate the release tag before installing toolchains or building"
+    );
+}
 
-    for rejected in [
-        "v0.1",
-        "v0.1.2.3",
-        "v0.1.2-beta.1",
-        "v0.1.2-rc",
-        "v0.1.2-rc.x",
-        "runa-v0.1.2",
-    ] {
-        assert!(
-            !matches_any_documented_actions_pattern(&patterns, rejected),
-            "release workflow tag filters should reject undocumented tag {rejected}"
-        );
-    }
+#[test]
+fn github_release_workflow_establishes_tag_trust_before_repository_code_execution() {
+    let workflow = read_workspace_file(".github/workflows/release.yml");
+    let tag_ref_restore_line = line_number_containing(&workflow, "git fetch --tags --force origin")
+        .expect("release workflow should restore annotated tag refs after checkout");
+    let event_identity_line = line_number_containing(
+        &workflow,
+        "restored_commit=$(git rev-parse \"refs/tags/$GITHUB_REF_NAME^{commit}\")",
+    )
+    .expect("release workflow should verify restored tag identity");
+    let annotated_tag_line = line_number_containing(&workflow, "git cat-file -t")
+        .expect("release workflow should require an annotated tag");
+    let main_ancestry_line = line_number_containing(&workflow, "git merge-base --is-ancestor")
+        .expect("release workflow should require the tag target on main");
+    let repository_code_line = first_line_number_containing_any(
+        &workflow,
+        &[
+            "./scripts/release-check release \"$GITHUB_REF_NAME\"",
+            "cargo build",
+        ],
+    )
+    .expect("release workflow should run trusted repository release code");
+
+    assert!(
+        tag_ref_restore_line < event_identity_line
+            && event_identity_line < annotated_tag_line
+            && annotated_tag_line < repository_code_line
+            && main_ancestry_line < repository_code_line,
+        "release workflow should establish tag trust before running repository code"
+    );
 }
 
 #[test]
@@ -404,7 +384,8 @@ fn github_release_workflow_marks_only_rc_tags_as_prereleases() {
     let workflow = read_workspace_file(".github/workflows/release.yml");
 
     assert!(
-        workflow.contains("^v[0-9]+[.][0-9]+[.][0-9]+-rc[.][0-9]+$"),
+        workflow
+            .contains("^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)-rc[.][1-9][0-9]*$"),
         "release workflow should mark only documented RC tags as GitHub prereleases"
     );
     assert!(
@@ -426,5 +407,9 @@ fn release_documentation_describes_runa_release_identity() {
     assert!(
         releasing.contains("Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases."),
         "RELEASING.md should describe prerelease publication with RC precision"
+    );
+    assert!(
+        releasing.contains("verifies that its commit still matches the event commit"),
+        "RELEASING.md should describe the event-identity trust check"
     );
 }

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -9,7 +9,7 @@ usage() {
 usage:
   scripts/release-check metadata
   scripts/release-check notes vX.Y.Z[-rc.N]
-  scripts/release-check release vX.Y.Z[-rc.N] --runa-bin PATH --runa-mcp-bin PATH
+  scripts/release-check release vX.Y.Z[-rc.N] [--runa-bin PATH --runa-mcp-bin PATH]
 EOF
 }
 
@@ -163,6 +163,192 @@ check_cargo_lock_versions() {
     ' "$lockfile" || exit 1
 }
 
+workflow_tag_patterns() {
+    local workflow="$repo_root/.github/workflows/release.yml"
+
+    awk '
+        $0 == "    tags:" {
+            inside = 1
+            next
+        }
+        inside && $0 ~ /^      - / {
+            value = $0
+            sub(/^      - /, "", value)
+            gsub(/"/, "", value)
+            print value
+            next
+        }
+        inside {
+            exit
+        }
+    ' "$workflow"
+}
+
+workflow_executable_lines() {
+    local workflow="$1"
+
+    awk '
+        function indent_of(line,    i, char) {
+            for (i = 1; i <= length(line); i++) {
+                char = substr(line, i, 1)
+                if (char != " ") {
+                    return i - 1
+                }
+            }
+            return length(line)
+        }
+
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        function unquote(value) {
+            if ((value ~ /^".*"$/) || (value ~ /^\047.*\047$/)) {
+                return substr(value, 2, length(value) - 2)
+            }
+            return value
+        }
+
+        function strip_shell_comment(value) {
+            sub(/(^|[[:space:]])#.*/, "", value)
+            return value
+        }
+
+        function emit(line_number, command) {
+            command = strip_shell_comment(command)
+            command = trim(command)
+            if (command == "" || command ~ /^#/) {
+                return
+            }
+            print line_number "\t" command
+        }
+
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            indent = indent_of(line)
+            stripped = trim(line)
+
+            if (in_run_block) {
+                if (stripped != "" && indent <= run_indent) {
+                    in_run_block = 0
+                } else {
+                    emit(NR, line)
+                    next
+                }
+            }
+
+            if (stripped ~ /^#/) {
+                next
+            }
+
+            if (line ~ /^[[:space:]]*(-[[:space:]]*)?run:[[:space:]]*/) {
+                value = line
+                sub(/^[[:space:]]*(-[[:space:]]*)?run:[[:space:]]*/, "", value)
+                value = trim(value)
+
+                if (value ~ /^[|>]/) {
+                    in_run_block = 1
+                    run_indent = indent
+                    next
+                }
+
+                emit(NR, unquote(value))
+            }
+        }
+    ' "$workflow"
+}
+
+workflow_uses_lines() {
+    local workflow="$1"
+
+    awk '
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        function unquote(value) {
+            if ((value ~ /^".*"$/) || (value ~ /^\047.*\047$/)) {
+                return substr(value, 2, length(value) - 2)
+            }
+            return value
+        }
+
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            stripped = trim(line)
+
+            if (stripped ~ /^#/) {
+                next
+            }
+
+            if (line ~ /^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*/) {
+                value = line
+                sub(/^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*/, "", value)
+                value = trim(value)
+                sub(/[[:space:]]+#.*/, "", value)
+                value = trim(value)
+                if (value != "") {
+                    print NR "\t" unquote(value)
+                }
+            }
+        }
+    ' "$workflow"
+}
+
+check_release_workflow_surface() {
+    local workflow="$repo_root/.github/workflows/release.yml"
+    [[ -f "$workflow" ]] || die ".github/workflows/release.yml not found"
+
+    mapfile -t patterns < <(workflow_tag_patterns)
+    [[ "${#patterns[@]}" == "1" ]] \
+        || die ".github/workflows/release.yml must declare exactly one release tag pattern"
+    [[ "${patterns[0]}" == "v*" ]] \
+        || die ".github/workflows/release.yml tag pattern must delegate v-prefixed tags to release-check validation"
+    ! grep -Eq '^    paths:' "$workflow" \
+        || die ".github/workflows/release.yml tag publication must not use paths filters"
+
+    local validation_line expensive_work_line checkout_line tag_ref_restore_line event_identity_verify_line annotated_tag_line main_ancestry_line repository_code_line
+    validation_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/release-check release \"$GITHUB_REF_NAME\"") { print $1; exit }')"
+    expensive_work_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /rustup toolchain install|cargo build --release/ { print $1; exit }')"
+    [[ -n "$validation_line" ]] && [[ -n "$expensive_work_line" ]] && [[ "$validation_line" -lt "$expensive_work_line" ]] \
+        || die ".github/workflows/release.yml must validate the release tag before expensive release work"
+
+    checkout_line="$(workflow_uses_lines "$workflow" | awk -F '\t' '$2 ~ /^actions\/checkout(@|$)/ { print $1; exit }')"
+    tag_ref_restore_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 == "git fetch --tags --force origin" { print $1; exit }')"
+    event_identity_verify_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '
+        $2 == "restored_commit=$(git rev-parse \"refs/tags/$GITHUB_REF_NAME^{commit}\")" {
+            saw_restored_commit = 1
+            next
+        }
+        saw_restored_commit && $2 == "if [ \"$restored_commit\" != \"$GITHUB_SHA\" ]; then" {
+            print $1
+            exit
+        }
+    ')"
+    annotated_tag_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git cat-file -t/ { print $1; exit }')"
+    main_ancestry_line="$(workflow_executable_lines "$workflow" | awk -F '\t' '$2 ~ /git merge-base --is-ancestor/ { print $1; exit }')"
+    repository_code_line="$(workflow_executable_lines "$workflow" | awk -F '\t' 'index($2, "./scripts/") || $2 ~ /cargo build/ { print $1; exit }')"
+
+    [[ -n "$tag_ref_restore_line" ]] \
+        || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
+    [[ -n "$checkout_line" ]] && [[ "$checkout_line" -lt "$tag_ref_restore_line" ]] \
+        || die ".github/workflows/release.yml must restore annotated tag refs after checkout and before checking tag type"
+    [[ -z "$annotated_tag_line" ]] || [[ "$tag_ref_restore_line" -lt "$annotated_tag_line" ]] \
+        || die ".github/workflows/release.yml must restore annotated tag refs before checking tag type"
+    [[ -n "$event_identity_verify_line" ]] && [[ "$tag_ref_restore_line" -lt "$event_identity_verify_line" ]] \
+        && { [[ -z "$annotated_tag_line" ]] || [[ "$event_identity_verify_line" -lt "$annotated_tag_line" ]]; } \
+        || die ".github/workflows/release.yml must verify the restored tag matches the triggering event before checking tag type"
+    [[ -n "$annotated_tag_line" ]] && [[ -n "$main_ancestry_line" ]] && [[ -n "$repository_code_line" ]] \
+        && [[ "$annotated_tag_line" -lt "$repository_code_line" ]] && [[ "$main_ancestry_line" -lt "$repository_code_line" ]] \
+        || die ".github/workflows/release.yml must establish tag trust before running repository code"
+}
+
 check_changelog_structure() {
     local changelog="$repo_root/CHANGELOG.md"
     [[ -f "$changelog" ]] || die "CHANGELOG.md not found"
@@ -273,6 +459,7 @@ run_metadata() {
     check_workspace_version_present
     check_workspace_crates_inherit_version
     check_cargo_lock_versions
+    check_release_workflow_surface
     check_changelog_structure
 }
 
@@ -304,10 +491,14 @@ run_release() {
     run_metadata
     check_release_version "$version"
     check_release_heading "$version"
-    [[ -n "$runa_bin" ]] || die "--runa-bin is required"
-    [[ -n "$runa_mcp_bin" ]] || die "--runa-mcp-bin is required"
-    check_binary "runa" "$version" "$runa_bin"
-    check_binary "runa-mcp" "$version" "$runa_mcp_bin"
+    if { [[ -n "$runa_bin" ]] && [[ -z "$runa_mcp_bin" ]]; } \
+        || { [[ -z "$runa_bin" ]] && [[ -n "$runa_mcp_bin" ]]; }; then
+        die "--runa-bin and --runa-mcp-bin must be supplied together"
+    fi
+    if [[ -n "$runa_bin" ]]; then
+        check_binary "runa" "$version" "$runa_bin"
+        check_binary "runa-mcp" "$version" "$runa_mcp_bin"
+    fi
 }
 
 main() {

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -474,11 +474,13 @@ run_release() {
         case "$1" in
             --runa-bin)
                 [[ "$#" -ge 2 ]] || die "--runa-bin requires a path"
+                [[ -n "$2" ]] || die "--runa-bin requires a non-empty path"
                 runa_bin="$2"
                 shift 2
                 ;;
             --runa-mcp-bin)
                 [[ "$#" -ge 2 ]] || die "--runa-mcp-bin requires a path"
+                [[ -n "$2" ]] || die "--runa-mcp-bin requires a non-empty path"
                 runa_mcp_bin="$2"
                 shift 2
                 ;;


### PR DESCRIPTION
## Summary

- Fixes release tag publication to trigger on `v*` and delegate exact release grammar to `scripts/release-check`.
- Restores annotated tag refs after checkout, verifies the restored tag commit matches `$GITHUB_SHA`, and keeps all git-only trust checks before repo code runs.
- Adds release workflow-shape validation plus regression coverage, and documents the updated post-release trust checks.

## Changes

- Updates `.github/workflows/release.yml` with the restored-tag and event-identity checks, source-only tag validation before Rust/toolchain work, and the ADR-0012 RC prerelease regex.
- Extends `scripts/release-check metadata` to enforce release workflow tag/filter/order invariants and allows `release TAG` to run source-only before binaries exist.
- Updates release-check and workspace-contract tests for the new substrate, including comment-resistant workflow parsing cases.
- Updates `CHANGELOG.md` and `RELEASING.md` for the user-visible release workflow fix.

## GitHub Issue(s)

Closes #156
Refs tesserine/commons#34

## Test plan

- `./scripts/release-check metadata`
- `cargo test -p runa-cli --test release_check`
- `cargo test -p runa-cli --test workspace_contract`
- `git diff --check`
- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy`
