### PR TITLE
Isolate Codex adapter MCP server overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Semantic Versioning.
   `./adapters/agent-claude-code.sh`; the old `examples/` adapter path is not
   retained as a wrapper or symlink.
 
+### Fixed
+
+- The Codex adapter now registers runa's MCP session server under an
+  invocation-scoped `mcp_servers` key, avoiding deep-merge collisions with an
+  operator's existing `mcp_servers.runa` Codex config entry.
+
 ## [0.2.0-rc.1] — 2026-06-08
 
 ### Added

--- a/adapters/agent-codex.sh
+++ b/adapters/agent-codex.sh
@@ -28,8 +28,10 @@ env_toml="$(
         jq -er '(.env // {}) | if type == "object" and all(.[]; type == "string") then to_entries | map((.key | @json) + " = " + (.value | @json)) | "{ " + join(", ") + " }" else error("RUNA_MCP_CONFIG.env must be a string object") end'
 )"
 
+server_name="runa_session_$$"
+
 exec codex exec \
-    -c "mcp_servers.runa.command=$command_toml" \
-    -c "mcp_servers.runa.args=$args_toml" \
-    -c "mcp_servers.runa.env=$env_toml" \
+    -c "mcp_servers.$server_name.command=$command_toml" \
+    -c "mcp_servers.$server_name.args=$args_toml" \
+    -c "mcp_servers.$server_name.env=$env_toml" \
     "$@"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,7 +92,9 @@ The supported runtime adapters live in `adapters/`: `agent-codex.sh` for Codex
 and `agent-claude-code.sh` for Claude Code. Point `[agent].command` at one of
 those scripts and pass runtime-specific options after the script path. The
 Codex adapter requires `jq` because Codex accepts external MCP servers through
-`-c mcp_servers.<name>.*` TOML overrides rather than a JSON config file.
+`-c mcp_servers.<name>.*` TOML overrides rather than a JSON config file. It
+registers each invocation under a process-scoped server name so an existing
+operator-defined `mcp_servers.runa` entry is left untouched.
 Migration note: older documentation used
 `./examples/agent-claude-code.sh` for Claude Code. That path no longer exists;
 repoint existing `[agent].command` values to

--- a/runa-cli/tests/step.rs
+++ b/runa-cli/tests/step.rs
@@ -1961,16 +1961,32 @@ fn codex_adapter_translates_runa_mcp_config_to_mcp_server_overrides() {
     let argv = read_nul_separated_args(&argv_capture);
     assert_eq!(argv[0], "exec");
     assert_eq!(argv[1], "-c");
-    assert!(argv[2].starts_with("mcp_servers.runa.command="));
     assert_eq!(argv[3], "-c");
-    assert!(argv[4].starts_with("mcp_servers.runa.args="));
     assert_eq!(argv[5], "-c");
-    assert!(argv[6].starts_with("mcp_servers.runa.env="));
     assert_eq!(argv[7..], ["--model", "gpt-test"]);
 
-    let command_toml = argv[2].strip_prefix("mcp_servers.runa.command=").unwrap();
-    let args_toml = argv[4].strip_prefix("mcp_servers.runa.args=").unwrap();
-    let env_toml = argv[6].strip_prefix("mcp_servers.runa.env=").unwrap();
+    let (command_key, command_toml) = argv[2].split_once('=').unwrap();
+    let server_name = command_key
+        .strip_prefix("mcp_servers.")
+        .unwrap()
+        .strip_suffix(".command")
+        .unwrap();
+    assert_ne!(server_name, "runa");
+    assert!(server_name.starts_with("runa_session_"));
+    assert!(
+        server_name["runa_session_".len()..]
+            .chars()
+            .all(|ch| ch.is_ascii_digit()),
+        "{server_name}"
+    );
+    let server_prefix = format!("mcp_servers.{server_name}");
+    assert_eq!(command_key, format!("{server_prefix}.command"));
+
+    let (args_key, args_toml) = argv[4].split_once('=').unwrap();
+    assert_eq!(args_key, format!("{server_prefix}.args"));
+    let (env_key, env_toml) = argv[6].split_once('=').unwrap();
+    assert_eq!(env_key, format!("{server_prefix}.env"));
+
     let command_value: toml::Value = toml::from_str(&format!("value = {command_toml}")).unwrap();
     let args_value: toml::Value = toml::from_str(&format!("value = {args_toml}")).unwrap();
     let env_value: toml::Value = toml::from_str(&format!("value = {env_toml}")).unwrap();


### PR DESCRIPTION
## Summary

Closes #186.

- Registers the Codex adapter's runa MCP server under a process-scoped `runa_session_<pid>` key instead of `mcp_servers.runa`.
- Tightens adapter coverage so the fake-Codex argv test rejects the fixed `runa` server key while preserving command, arg order, env entries, forwarded argv, and stdin prompt handling.
- Documents the invocation-scoped Codex MCP key and records the user-visible fix in the changelog.

## Verification

RED/GREEN:

- Added the isolated-server-key assertion, then ran `cargo test -p runa-cli --test step codex_adapter_translates_runa_mcp_config_to_mcp_server_overrides -- --nocapture` -> failed before the adapter change with `assertion left != right` where both sides were `"runa"`.
- After the adapter change, reran the same command -> passed.

Focused and full gates:

- `cargo test -p runa-cli --test step codex_adapter -- --nocapture` -> passed, 3 tests.
- `cargo fmt --check` -> passed.
- `cargo test --workspace` -> passed.
- `cargo clippy` -> passed.
- `git diff --check` -> passed.

Real Codex before/after (`codex-cli 0.133.0`, temporary `CODEX_HOME` with conflicting `[mcp_servers.runa]` HTTP preset):

- Negative control using old dotted overrides against `mcp_servers.runa.*` -> failed during config load with `Error loading config.toml: url is not supported for stdio in mcp_servers.runa`.
- Updated adapter with the same conflicting preset -> did not emit the config-load error; Codex emitted `thread.started` / `turn.started` JSON events and then reached the expected temp-home auth/runtime failure (`401 Unauthorized`).

## Acceptance self-review

- With a conflicting `[mcp_servers.runa]` preset, the old dotted override shape was verified to fail during real Codex config loading.
- The chosen mechanism is an invocation-scoped server key generated by the adapter (`runa_session_$$`), so the adapter does not deep-merge onto the operator's `mcp_servers.runa` entry.
- Real Codex validation showed the updated adapter passes config loading and reaches runtime/auth, rather than rejecting the mixed MCP config before `runa-mcp` can start.
- The adapter still forwards exactly the `{command,args,env}` from `RUNA_MCP_CONFIG` into Codex TOML overrides, and the regression test guards the generated key, command, args, env, forwarded argv, and stdin prompt behavior.
