### PR TITLE
feat(entry): cold-start scoped entry from a forge ticket reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Rust build artifacts
 /target
 
+# Local runa project state (this repo is a Rust project, not a runa-managed one)
+/.runa/
+
 # Editor swap files
 *.swp
 *.swo

--- a/.runa/config.toml
+++ b/.runa/config.toml
@@ -1,1 +1,0 @@
-methodology_path = "/tmp/tmp.w6WHrAHarW/method/manifest.toml"

--- a/.runa/config.toml
+++ b/.runa/config.toml
@@ -1,0 +1,1 @@
+methodology_path = "/tmp/tmp.w6WHrAHarW/method/manifest.toml"

--- a/.runa/state.toml
+++ b/.runa/state.toml
@@ -1,2 +1,0 @@
-initialized_at = "2026-06-12T06:26:17Z"
-runa_version = "0.2.0-rc.1"

--- a/.runa/state.toml
+++ b/.runa/state.toml
@@ -1,0 +1,2 @@
+initialized_at = "2026-06-12T06:26:17Z"
+runa_version = "0.2.0-rc.1"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,6 +33,8 @@ These are library capabilities exposed by libagent and consumed by both the CLI 
 
 7. **Scoped work-unit identity validation.** After workspace scan and before scoped readiness evaluation, `runa state`, `runa step`, `runa run`, and `runa go` validate that the supplied `--work-unit` exactly matches a recorded `work-unit` instance id when any are recorded. Invalid and malformed recorded roots still establish canonical ids. Valid tracker-backed roots also enforce instance-id/handle number agreement, duplicate tracker-root rejection, and agreement with the active forge deployment identity resolved from `.runa/config.toml` with `RUNA_FORGE_*` env overrides. With no recorded `work-unit` roots, scoped evaluation remains inert.
 
+   **Cold-start ticket entry.** `entry::resolve_ticket_reference` parses a `--ticket <REF>` into a tracker identity against the active deployment (no forge read; identity only). `entry::discover_acquisition_surface` derives the methodology's acquisition surface — the sole unscoped producer of the `work-unit` artifact — from the manifest alone. `entry::resolve_promise` matches the reference to a recorded `work-unit` by tracker identity. `SessionState::open_entry` opens a *promised scope* that pins that acquisition step (the reference substitutes its trigger) until `advance` resolves the promise and binds the session to the materialized work-unit; a reference that already resolves opens bound directly. `runa run --ticket` mirrors this in the cascade — `projection::project_entry_cascade` seeds the acquisition output so the dry-run shows `take` projected next.
+
 8. **Tracing bootstrap.** Both binaries bootstrap tracing with env/default settings before any config lookup, then reconfigure the shared subscriber from `config.toml` when logging settings are available. Tracing events always go to stderr; operator-facing command output stays on stdout.
 
 9. **Status and session evaluation.** `status::evaluate_protocols` is the shared readiness classification path used by CLI state reporting and MCP session readiness. `session::SessionState` layers current-step lifecycle state over that evaluator for scoped sessions: every public operation scans first, immediately revalidates the scoped work-unit identity for the session, readiness preserves an existing current step but may select the first ready step when none is active, exhausted work is reopened by the same relevant-input-change rule used by the live runner, and only `advance` retires the current step after postcondition enforcement, next-step validation, and execution-record persistence.
@@ -128,6 +130,19 @@ including invalid and malformed records. Valid tracker-backed roots receive the
 runtime checks that schema validation cannot express: id/handle number
 agreement, duplicate tracker identity detection, and active deployment
 agreement from config-resolved `RUNA_FORGE_*` atoms.
+
+### `entry.rs`
+
+Cold-start ticket entry. `resolve_ticket_reference` parses a forge ticket
+reference (bare number, `#<N>`, `owner/repo#<N>`, GitHub issue URL, or
+`sourcehut:<tracker_id>#<N>`) and resolves it to a `TicketRef` carrying the
+canonical tracker identity against the active deployment — identity only, never a
+forge read. `discover_acquisition_surface` derives the methodology's acquisition
+surface as the single unscoped protocol declaring `work-unit` among its outputs,
+naming the offending declarations when zero or many exist. `resolve_promise`
+matches a reference to the recorded `work-unit` instance of equal tracker
+identity (after tracker-consistency validation). `RUNA_ENTRY_TICKET` carries the
+ticket number to acquisition mechanics.
 
 ## runa-mcp Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Cold-start ticket entry: `runa run --ticket <REF>` and `runa go --ticket <REF>`
+  open a scoped session from a forge ticket reference (a bare number, `#<N>`,
+  `owner/repo#<N>`, a GitHub issue URL, or `sourcehut:<tracker_id>#<N>`) when no
+  `work-unit` artifact exists yet. The runtime resolves the reference to a tracker
+  identity — never reading ticket content — and serves the methodology's
+  acquisition surface (the sole unscoped producer of the `work-unit` artifact),
+  delivering the reference and `RUNA_ENTRY_TICKET` into the session. Once the
+  methodology materializes the `work-unit`, the session binds and the cascade
+  computes `take` next on it. A reference whose work-unit already exists degrades
+  to a normal scoped session; downstream of acquisition the two are
+  indistinguishable. `runa run --ticket --dry-run` projects the entry cascade and
+  emits a version `3` JSON envelope with a top-level `entry` object.
+  `runa-mcp --session --ticket <ref>` serves the same entry session surface.
+
 ### Changed
 
 - Durable transcript capture settings and scoped forge identity can now live in

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ aliases such as ticket numbers or partial ids are rejected and the diagnostic
 lists the available canonical ids. If no `work-unit` artifacts are recorded,
 scoped evaluation remains inert and accepts the caller-supplied id as before.
 
+To start scoped work from nothing but a tracker ticket, `runa run --ticket <REF>`
+and `runa go --ticket <REF>` open a cold-start session from a forge ticket
+reference (a bare number, `#<N>`, `owner/repo#<N>`, an issue URL, or
+`sourcehut:<tracker_id>#<N>`). The runtime resolves the reference to an identity
+and serves the methodology's acquisition surface; the methodology reads the
+ticket and materializes the `work-unit`, after which the session is
+indistinguishable from one opened on a recorded work-unit. The runtime performs
+no forge read of its own.
+
 ## Quick Start
 
 A methodology needs a manifest file, a JSON Schema for each artifact type, and an instruction file for each protocol. Here is a minimal example with one protocol that consumes a `spec` artifact and produces a `report`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -244,12 +244,27 @@ Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux
 ### `runa run`
 
 ```bash
-runa run [--dry-run] [--json] [--work-unit <ID>] [--agent-command -- <argv tokens>] [--config <PATH>]
+runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--agent-command -- <argv tokens>] [--config <PATH>]
 ```
 
 The cascade command. Walks the READY frontier repeatedly until quiescence instead of stopping after one execution.
 
 Without `--work-unit`, `run` considers only unscoped protocols. With `--work-unit <ID>`, it considers only scoped protocols for that exact delegated work unit.
+
+With `--ticket <REF>` (mutually exclusive with `--work-unit`), `run` opens a
+cold-start session from a forge ticket reference. Accepted forms are a bare
+number, `#<N>`, `owner/repo#<N>`, a GitHub issue URL, or
+`sourcehut:<tracker_id>#<N>`; the asserted deployment must match the active
+`[forge]` deployment, and a bare reference inherits it. When the referenced
+work-unit already exists, `run` behaves as `--work-unit <id>` on it. Otherwise
+the methodology's acquisition surface (the sole unscoped producer of the
+`work-unit` artifact) runs first — under `--dry-run` it is projected as the
+`current, entry` step with the acquired work-unit's `take` projected after it;
+live, it executes (the runtime delivers the reference and `RUNA_ENTRY_TICKET`,
+never the ticket's content), and the cascade then continues scoped on the
+materialized work-unit. The cold-start dry-run JSON envelope is version `3` and
+adds a top-level `entry` object (`reference`, `ticket_number`,
+`acquisition_protocol`, `resolved_work_unit`).
 
 When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 `work-unit` instance id, with the same rejection behavior described for
@@ -266,6 +281,7 @@ Without `--dry-run`, requires a Linux host plus an effective agent command. `run
 - `--dry-run` — Preview the projected cascade. Does not execute agents.
 - `--json` — Dry-run only. Emits version `2` and otherwise uses the same envelope structure as `runa step --json`, but `execution_plan` may contain multiple entries including projected downstream work.
 - `--work-unit <ID>` — Plan or execute only scoped protocols for the delegated work unit `<ID>`.
+- `--ticket <REF>` — Open a cold-start session from a forge ticket reference. Mutually exclusive with `--work-unit`. An unparseable reference or one that disagrees with the active deployment exits `2`; a manifest with no single unscoped `work-unit` producer exits `6`; acquisition that produces no matching work-unit exits `5`.
 - `--agent-command -- <argv tokens>` — Override `[agent].command` for this live `run` invocation. Pass the agent argv after `--` so hyphen-prefixed tokens are forwarded unchanged.
 
 **Exit codes** (`4` is live-only; dry-run still reflects current topology state, not the projection):
@@ -283,7 +299,7 @@ Without `--dry-run`, requires a Linux host plus an effective agent command. `run
 ### `runa go`
 
 ```bash
-runa go --work-unit <ID> [--config <PATH>]
+runa go (--work-unit <ID> | --ticket <REF>) [--config <PATH>]
 ```
 
 Advances one scoped interactive session tick. `go` evaluates the delegated work
@@ -291,6 +307,14 @@ unit, launches the configured agent with a `runa-mcp --session --work-unit
 <ID>` MCP config, and sends only a generic one-tick instruction on stdin. The
 agent retrieves the current protocol context through `next-protocol-context`,
 records outputs through the current output tools, calls `advance`, and stops.
+
+With `--ticket <REF>` (mutually exclusive with `--work-unit`; same reference
+grammar as `runa run --ticket`), `go` opens a cold-start session. When the
+referenced work-unit already exists, the tick proceeds as a normal bound session
+on it. Otherwise this tick is the acquisition step: `go` launches a
+`runa-mcp --session --ticket <REF>` config, the agent materializes the
+work-unit, the session binds, and `go` reports the acquired work-unit with `take`
+ready. Mode changes only who issues the verb at what cadence, never its meaning.
 
 `go` does not expose readiness, context, record, or approval as operator
 commands. Those remain the session surface mechanics inside `runa-mcp`; the
@@ -304,14 +328,17 @@ fails with exit `5`.
 
 **Flags:**
 
-- `--work-unit <ID>` — Required. Advance only scoped protocols for the
-  delegated work unit `<ID>`.
+- `--work-unit <ID>` — Advance only scoped protocols for the delegated work unit
+  `<ID>`. Required unless `--ticket` is given.
+- `--ticket <REF>` — Open the tick from a forge ticket reference (cold-start
+  entry). Mutually exclusive with `--work-unit`.
 
 **Exit codes:**
 
 | Code | Meaning |
 |------|---------|
 | 0 | The configured agent advanced one session step. |
+| 2 | Usage error, or a ticket reference that is unparseable or disagrees with the active deployment. |
 | 3 | No READY candidate and work remains blocked, waiting on prerequisites, or trapped in a cycle. |
 | 4 | No READY candidate and no actionable work remains because the in-scope outputs are already current. |
 | 5 | Work was attempted, but the agent failed or did not advance the selected session step. |
@@ -323,12 +350,12 @@ fails with exit `5`.
 
 ```bash
 runa-mcp --protocol <name> [--work-unit <name>]
-runa-mcp --session --work-unit <name>
+runa-mcp --session (--work-unit <name> | --ticket <ref>)
 ```
 
 In fixed-protocol mode, the server loads the project, scans the workspace, resolves the named protocol from the manifest, validates that its declared scope matches the presence or absence of `--work-unit`, validates canonical `work-unit` identity for scoped sessions, validates that its required output types can be served as MCP tools, and serves that protocol's output tools over stdio. Each output artifact type (`produces`, required output choice members, and viable `may_produce`) becomes one MCP tool. The tool input schema is the artifact type's JSON Schema with the `work_unit` field removed — the server injects `work_unit` automatically from the `--work-unit` argument.
 
-In session mode, phase 1 requires `--work-unit <name>` and serves one scoped work-unit session in a single MCP connection. The tool list always includes the driver tools `readiness`, `next-protocol-context`, and `advance`, plus the output tools for the current ready step. A current step is refused if any declared output type for that step would collide with one of those reserved driver tool names. Every driver verb rescans and revalidates the scoped work-unit identity before reporting, serving, or advancing. `readiness` reports the same status classification as `runa state` for the session scope, and selects the first non-exhausted ready step when the session has no current step. `next-protocol-context` verifies that the current step still satisfies readiness authority for its trigger and preconditions, and returns both the structured context and rendered prompt for the current step without advancing it. `advance` verifies that the current step still satisfies readiness authority for its trigger and preconditions, enforces postconditions for the current step, uses staged execution metadata to select and validate the next ready step, and only then persists that metadata and advances the session. Any driver verb that changes the current step emits `notifications/tools/list_changed` so caching MCP clients can rediscover the current step's output tools. Output tools validate and write artifacts exactly as in fixed-protocol mode; recording an output does not advance the session.
+In session mode, the server serves one scoped work-unit session in a single MCP connection, opened either with `--work-unit <name>` (a recorded work-unit) or `--ticket <ref>` (a forge ticket reference for cold-start entry). With `--ticket`, the session begins in a promised scope serving the methodology's acquisition surface; once the agent materializes the `work-unit`, `advance` binds the session to it and the tool list flips to the bound step's tools. The runtime resolves the reference to an identity only and performs no forge read. The tool list always includes the driver tools `readiness`, `next-protocol-context`, and `advance`, plus the output tools for the current ready step. A current step is refused if any declared output type for that step would collide with one of those reserved driver tool names. Every driver verb rescans and revalidates the scoped work-unit identity before reporting, serving, or advancing. `readiness` reports the same status classification as `runa state` for the session scope, and selects the first non-exhausted ready step when the session has no current step. `next-protocol-context` verifies that the current step still satisfies readiness authority for its trigger and preconditions, and returns both the structured context and rendered prompt for the current step without advancing it. `advance` verifies that the current step still satisfies readiness authority for its trigger and preconditions, enforces postconditions for the current step, uses staged execution metadata to select and validate the next ready step, and only then persists that metadata and advances the session. Any driver verb that changes the current step emits `notifications/tools/list_changed` so caching MCP clients can rediscover the current step's output tools. Output tools validate and write artifacts exactly as in fixed-protocol mode; recording an output does not advance the session.
 
 `runa step` currently continues to use fixed-protocol mode. `runa go` uses
 session mode. Neither command spawns `runa-mcp` directly. Before launching the

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -119,6 +119,36 @@ runtime deployment identity. The methodology still owns the `work-unit` schema
 and the semantics of the artifact content; runa owns only the scope identity
 checks described here.
 
+### Entry References and the Acquisition Surface
+
+A session may be opened from a forge ticket reference instead of a recorded
+`work-unit` instance id, via `runa run --ticket <REF>` or
+`runa go --ticket <REF>`. The accepted reference forms are a bare ticket number,
+`#<N>`, `owner/repo#<N>`, a GitHub issue URL, or `sourcehut:<tracker_id>#<N>`.
+runa parses the reference and normalizes it to a tracker identity
+(`github:<owner>/<name>:<N>` or `sourcehut:<tracker_id>:<N>`); a reference that
+asserts a deployment other than the active one is rejected, and a bare reference
+inherits the active deployment identity. **runa never reads ticket content** —
+the reference carries identity only, and the methodology performs all forge
+reads through its own mechanics. During entry, runa exports `RUNA_ENTRY_TICKET`
+(the ticket number) alongside the `RUNA_FORGE_*` atoms so those mechanics can
+resolve the ticket.
+
+The acquisition surface runa serves is the single unscoped protocol whose
+declared outputs (`produces`, `may_produce`, or required output choice members)
+include the `work-unit` artifact type. A manifest with zero or more than one
+such protocol does not support ticket entry; runa names the offending
+declarations.
+
+Entry substitutes only the acquisition protocol's trigger: the operator's
+reference is that step's activation condition. The protocol's preconditions,
+output validation, postconditions, execution recording, and scoped-identity
+checks all apply unchanged. The promised scope resolves to the unique valid
+`work-unit` instance whose tracker handle identity equals the reference
+identity. If that instance already exists when the session opens, no acquisition
+step runs; a session opened from a reference and a session opened from the
+materialized work-unit id are indistinguishable downstream of acquisition.
+
 ## What runa Does
 
 runa is an event-driven runtime. The CLI commands (init, scan, list, state, step, doctor) are windows into its state. The runtime itself is the monitoring loop.

--- a/docs/session-surface-contract.md
+++ b/docs/session-surface-contract.md
@@ -126,6 +126,34 @@ pause is explicitly requested — so that automation is the path and any
 human-in-the-cascade interruption is the deliberate exception. No such pause is
 specified now, and none is required.
 
+## Session Entry: the Promised Scope
+
+A session's scope is either **bound** — a recorded `work-unit` instance id — or
+**promised** — a forge ticket reference standing for a work-unit that does not
+yet exist. A promised scope is opened with `--ticket <REF>`. It is not a new
+verb and not a third mode: the operator still issues the single outer verb, and
+mode remains which cadence issues that verb (ADR-0015). Autonomous and
+interactive clients open a promised scope through the same surface with the same
+meaning.
+
+While the scope is promised, the select stage admits exactly one step: the
+methodology's acquisition surface — the single unscoped protocol that produces
+the `work-unit` artifact — evaluated unscoped. The operator's reference stands in
+for that step's trigger; its preconditions, output validation, and
+postconditions apply unchanged. Context construction delivers that protocol's
+instructions and validated inputs plus the entry reference; the runtime delivers
+the reference and nothing of the ticket's content, performing no forge read
+itself.
+
+The postcondition-gated commit of the acquisition step additionally **resolves
+the promise**: the session binds to the unique valid `work-unit` whose tracker
+identity equals the reference. An acquisition step that satisfies its protocol
+contract but materializes no matching work-unit does not advance. Once bound, the
+session is an ordinary scoped session; a session opened from a reference and one
+opened from the materialized work-unit id are indistinguishable downstream of
+acquisition. When the referenced work-unit already exists at open, no acquisition
+step runs and the session is bound immediately.
+
 ## Disposition-Authority Contract
 
 Authority over a lifecycle transition is conformance, not per-operation human

--- a/libagent/src/context.rs
+++ b/libagent/src/context.rs
@@ -47,6 +47,21 @@ pub struct ArtifactRefView {
     pub relationship: ArtifactRelationship,
 }
 
+/// The forge ticket reference an entry session was opened from.
+///
+/// Present only on the acquisition step of a session opened from a ticket
+/// reference. Carries the reference's identity, never the ticket's content —
+/// the runtime delivers the reference, the methodology performs the forge read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EntryDelivery {
+    /// Canonical operator-facing reference, e.g. `github:tesserine/runa#188`.
+    pub reference: String,
+    /// The ticket number.
+    pub ticket_number: u64,
+    /// Canonical tracker identity, e.g. `github:tesserine/runa:188`.
+    pub tracker_identity: String,
+}
+
 /// Artifact type names the agent is expected to produce for this protocol invocation.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ExpectedOutputs {
@@ -71,6 +86,8 @@ pub struct ContextInjection {
     pub instructions: String,
     pub inputs: Vec<ArtifactRef>,
     pub expected_outputs: ExpectedOutputs,
+    /// Present only on a ticket-entry acquisition step.
+    pub entry: Option<EntryDelivery>,
 }
 
 /// Serialization-safe view of [`ContextInjection`] that uses
@@ -82,6 +99,8 @@ pub struct ContextInjectionView {
     pub instructions: String,
     pub inputs: Vec<ArtifactRefView>,
     pub expected_outputs: ExpectedOutputs,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<EntryDelivery>,
 }
 
 /// Build the agent-facing context for a single protocol invocation.
@@ -121,6 +140,7 @@ pub fn build_context(
             may_produce: protocol.may_produce.clone(),
             required_output_choices: protocol.required_output_choices.clone(),
         },
+        entry: None,
     }
 }
 
@@ -135,6 +155,18 @@ pub fn render_context_prompt(context: &ContextInjection) -> String {
         Some(work_unit) => format!("# Protocol: {} (work_unit={work_unit})", context.protocol),
         None => format!("# Protocol: {}", context.protocol),
     });
+
+    if let Some(entry) = &context.entry {
+        sections.push("\n## Session entry".to_string());
+        sections.push(format!(
+            "This session was opened from forge ticket {} (ticket_number={}). \
+             No work-unit artifact exists yet for this ticket. The runtime has \
+             delivered only this reference; acquire the ticket according to the \
+             protocol instructions below and deliver your outputs through the \
+             listed output tools.",
+            entry.reference, entry.ticket_number
+        ));
+    }
 
     if !context.instructions.is_empty() {
         sections.push("\n## Protocol instructions".to_string());
@@ -312,6 +344,7 @@ impl From<&ContextInjection> for ContextInjectionView {
             instructions: context.instructions.clone(),
             inputs: context.inputs.iter().map(ArtifactRefView::from).collect(),
             expected_outputs: context.expected_outputs.clone(),
+            entry: context.entry.clone(),
         }
     }
 }
@@ -477,6 +510,7 @@ mod tests {
                 content_hash: "sha256:test".into(),
                 relationship: ArtifactRelationship::Requires,
             }],
+            entry: None,
             expected_outputs: ExpectedOutputs {
                 produces: vec!["implementation".into()],
                 may_produce: Vec::new(),
@@ -583,6 +617,7 @@ mod tests {
             work_unit: None,
             instructions: "# Follow the protocol\n".into(),
             inputs: Vec::new(),
+            entry: None,
             expected_outputs: ExpectedOutputs {
                 produces: vec!["implementation".into()],
                 may_produce: vec!["notes".into()],
@@ -601,12 +636,43 @@ mod tests {
     }
 
     #[test]
+    fn render_context_prompt_includes_entry_reference_before_instructions() {
+        let prompt = render_context_prompt(&ContextInjection {
+            protocol: "decompose".into(),
+            work_unit: None,
+            instructions: "# decompose\n".into(),
+            inputs: Vec::new(),
+            entry: Some(EntryDelivery {
+                reference: "github:tesserine/runa#188".into(),
+                ticket_number: 188,
+                tracker_identity: "github:tesserine/runa:188".into(),
+            }),
+            expected_outputs: ExpectedOutputs {
+                produces: vec!["work-unit".into()],
+                may_produce: Vec::new(),
+                required_output_choices: Vec::new(),
+            },
+        });
+
+        let entry_index = prompt
+            .find("## Session entry")
+            .expect("entry section present");
+        let instructions_index = prompt
+            .find("## Protocol instructions")
+            .expect("instructions section present");
+        assert!(entry_index < instructions_index);
+        assert!(prompt.contains("github:tesserine/runa#188"));
+        assert!(prompt.contains("ticket_number=188"));
+    }
+
+    #[test]
     fn render_context_prompt_includes_work_unit_in_heading() {
         let prompt = render_context_prompt(&ContextInjection {
             protocol: "implement".into(),
             work_unit: Some("wu-a".into()),
             instructions: String::new(),
             inputs: Vec::new(),
+            entry: None,
             expected_outputs: ExpectedOutputs {
                 produces: vec!["implementation".into()],
                 may_produce: Vec::new(),
@@ -631,6 +697,7 @@ mod tests {
                 content_hash: "sha256:test".into(),
                 relationship: ArtifactRelationship::Requires,
             }],
+            entry: None,
             expected_outputs: ExpectedOutputs {
                 produces: vec!["implementation".into()],
                 may_produce: Vec::new(),

--- a/libagent/src/context.rs
+++ b/libagent/src/context.rs
@@ -5,6 +5,7 @@
 //! delivered to agents during `runa step`. [`build_context`] gathers the
 //! artifacts; [`render_context_prompt`] turns the context into prose.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -142,6 +143,29 @@ pub fn build_context(
         },
         entry: None,
     }
+}
+
+/// Build the agent-facing context for execution, withholding untrusted optional
+/// inputs.
+///
+/// Like [`build_context`], but `accepts` inputs whose artifact type is in
+/// `affected_types` (changed or only partially scanned this cycle) are dropped —
+/// the agent must not act on optional context that may be stale or incomplete.
+/// Required (`requires`) inputs are always retained. This is the single context
+/// builder for every execution surface (`step`, session ticks, and ticket
+/// entry) so the trust filter cannot be applied inconsistently.
+pub fn build_execution_context(
+    protocol: &ProtocolDeclaration,
+    store: &ArtifactStore,
+    work_unit: Option<&str>,
+    affected_types: &HashSet<String>,
+) -> ContextInjection {
+    let mut context = build_context(protocol, store, work_unit);
+    context.inputs.retain(|input| {
+        input.relationship == ArtifactRelationship::Requires
+            || !affected_types.contains(input.artifact_type.as_str())
+    });
+    context
 }
 
 /// Render the agent-facing context as natural language prose.
@@ -355,6 +379,76 @@ mod tests {
     use crate::test_helpers::make_store;
     use serde_json::json;
     use std::path::Path;
+
+    fn require_accept_protocol() -> ProtocolDeclaration {
+        ProtocolDeclaration {
+            name: "implement".into(),
+            requires: vec!["constraints".into()],
+            accepts: vec!["notes".into()],
+            produces: Vec::new(),
+            may_produce: Vec::new(),
+            required_output_choices: Vec::new(),
+            scoped: false,
+            trigger: crate::TriggerCondition::OnArtifact {
+                name: "constraints".into(),
+            },
+            instructions: None,
+        }
+    }
+
+    #[test]
+    fn build_execution_context_withholds_accepts_from_affected_types() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = make_store(&tmp.path().join("store"), vec!["constraints", "notes"]);
+        store
+            .record(
+                "constraints",
+                "spec",
+                Path::new("c.json"),
+                &json!({"title": "c"}),
+            )
+            .unwrap();
+        store
+            .record("notes", "n", Path::new("n.json"), &json!({"title": "n"}))
+            .unwrap();
+        let protocol = require_accept_protocol();
+
+        // `notes` is untrusted this cycle: the optional input is withheld, the
+        // required `constraints` input is always kept.
+        let affected = HashSet::from(["notes".to_string()]);
+        let context = build_execution_context(&protocol, &store, None, &affected);
+        let types: Vec<&str> = context
+            .inputs
+            .iter()
+            .map(|input| input.artifact_type.as_str())
+            .collect();
+        assert_eq!(types, vec!["constraints"]);
+
+        // With nothing affected, the optional input is delivered.
+        let context = build_execution_context(&protocol, &store, None, &HashSet::new());
+        assert_eq!(context.inputs.len(), 2);
+    }
+
+    #[test]
+    fn build_execution_context_retains_required_input_even_when_affected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = make_store(&tmp.path().join("store"), vec!["constraints", "notes"]);
+        store
+            .record(
+                "constraints",
+                "spec",
+                Path::new("c.json"),
+                &json!({"title": "c"}),
+            )
+            .unwrap();
+        let protocol = require_accept_protocol();
+
+        // A required input is never withheld, even from an affected type.
+        let affected = HashSet::from(["constraints".to_string()]);
+        let context = build_execution_context(&protocol, &store, None, &affected);
+        assert_eq!(context.inputs.len(), 1);
+        assert_eq!(context.inputs[0].artifact_type, "constraints");
+    }
 
     #[test]
     fn build_context_collects_required_and_accepted_inputs() {

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -10,13 +10,16 @@
 //! The runtime never reads ticket content. A reference carries identity only;
 //! the methodology performs all forge reads through its own mechanics.
 
+use std::collections::HashSet;
 use std::fmt;
 
+use crate::enforcement::{EnforcementError, enforce_preconditions};
 use crate::model::ProtocolDeclaration;
 use crate::scoped_identity::{
     ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
     validate_tracker_consistency,
 };
+use crate::selection::protocol_scan_incomplete_types;
 use crate::store::ArtifactStore;
 
 /// Artifact type the runtime treats as the scope-identity seed. The acquisition
@@ -317,6 +320,53 @@ pub fn discover_acquisition_surface(
     }
 }
 
+/// Why a cold-start acquisition is not admissible, if it is not.
+///
+/// Mirrors the canonical readiness gates ([`crate::classify_candidates`]) with
+/// the trigger substituted by the operator's reference: a missing/invalid
+/// required input, or an input type left untrusted by a partial scan.
+#[derive(Debug)]
+pub enum AcquisitionBlock {
+    Precondition(EnforcementError),
+    ScanIncomplete(Vec<String>),
+}
+
+impl fmt::Display for AcquisitionBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AcquisitionBlock::Precondition(error) => write!(f, "{error}"),
+            AcquisitionBlock::ScanIncomplete(types) => write!(
+                f,
+                "acquisition input artifact type(s) {} were only partially scanned",
+                types.join(", ")
+            ),
+        }
+    }
+}
+
+/// The single admission gate for a cold-start acquisition — the one place that
+/// enumerates the readiness gates entry must honor, so the session, projection,
+/// and CLI entry surfaces cannot drift apart.
+///
+/// Entry substitutes only the acquisition protocol's trigger (the operator's
+/// ticket reference stands in for it). Every other gate the canonical readiness
+/// path applies still holds: its `requires` preconditions, and scan trust over
+/// its input types. Currentness is intentionally omitted — the reference forces
+/// a fresh acquisition for this ticket regardless of unrelated outputs. The
+/// acquisition is always unscoped, so `work_unit` is `None`.
+pub fn check_acquisition_admissible(
+    acquisition: &ProtocolDeclaration,
+    store: &ArtifactStore,
+    partially_scanned_types: &HashSet<String>,
+) -> Result<(), AcquisitionBlock> {
+    enforce_preconditions(acquisition, store, None).map_err(AcquisitionBlock::Precondition)?;
+    let incomplete = protocol_scan_incomplete_types(acquisition, partially_scanned_types);
+    if !incomplete.is_empty() {
+        return Err(AcquisitionBlock::ScanIncomplete(incomplete));
+    }
+    Ok(())
+}
+
 /// Resolve a ticket reference to the materialized `work-unit` instance.
 ///
 /// Returns the instance id whose tracker handle identity equals the reference,
@@ -482,6 +532,63 @@ mod tests {
                 "expected '{raw}' to be rejected"
             );
         }
+    }
+
+    fn acquisition_protocol(requires: &[&str]) -> ProtocolDeclaration {
+        ProtocolDeclaration {
+            name: "decompose".into(),
+            requires: requires.iter().map(|value| value.to_string()).collect(),
+            accepts: Vec::new(),
+            produces: vec![WORK_UNIT_ARTIFACT_TYPE.to_string()],
+            may_produce: Vec::new(),
+            required_output_choices: Vec::new(),
+            scoped: false,
+            trigger: TriggerCondition::OnArtifact {
+                name: "request".into(),
+            },
+            instructions: None,
+        }
+    }
+
+    #[test]
+    fn acquisition_admissible_when_preconditions_met_and_scan_complete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::test_helpers::make_store(&tmp.path().join("store"), vec!["work-unit"]);
+        let acquisition = acquisition_protocol(&[]);
+
+        assert!(check_acquisition_admissible(&acquisition, &store, &HashSet::new()).is_ok());
+    }
+
+    #[test]
+    fn acquisition_blocked_when_required_input_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::test_helpers::make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit"],
+        );
+        let acquisition = acquisition_protocol(&["request"]);
+
+        assert!(matches!(
+            check_acquisition_admissible(&acquisition, &store, &HashSet::new()),
+            Err(AcquisitionBlock::Precondition(_))
+        ));
+    }
+
+    #[test]
+    fn acquisition_blocked_when_input_partially_scanned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::test_helpers::make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit"],
+        );
+        let acquisition = acquisition_protocol(&[]);
+        // The trigger input `request` was only partially scanned.
+        let partials = HashSet::from(["request".to_string()]);
+
+        assert!(matches!(
+            check_acquisition_admissible(&acquisition, &store, &partials),
+            Err(AcquisitionBlock::ScanIncomplete(types)) if types == vec!["request".to_string()]
+        ));
     }
 
     #[test]

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -323,16 +323,25 @@ pub fn discover_acquisition_surface(
 /// or `None` when no such instance exists yet (cold store). Tracker-handle
 /// consistency is enforced first, so a `ScopedWorkUnitError` here signals a
 /// malformed or conflicting recorded work-unit rather than a missing one.
+///
+/// A `None` result authorizes cold-start acquisition, so it must be trustworthy:
+/// when the `work-unit` type was only partially scanned (an unreadable instance
+/// file could hide a matching or duplicate root), resolution fails with
+/// [`ScopedWorkUnitError::WorkUnitScanIncomplete`] rather than falling through to
+/// acquisition and risking duplicate work for an existing ticket.
 pub fn resolve_promise(
     store: &ArtifactStore,
     identity: &ResolvedForgeIdentity,
     ticket: &TicketRef,
 ) -> Result<Option<String>, ScopedWorkUnitError> {
     validate_tracker_consistency(store, identity)?;
-    Ok(find_work_unit_by_tracker_identity(
-        store,
-        &ticket.tracker_identity,
-    ))
+    match find_work_unit_by_tracker_identity(store, &ticket.tracker_identity) {
+        Some(instance_id) => Ok(Some(instance_id)),
+        None if store.has_any_scan_gap_for_type(WORK_UNIT_ARTIFACT_TYPE) => {
+            Err(ScopedWorkUnitError::WorkUnitScanIncomplete)
+        }
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]
@@ -473,6 +482,63 @@ mod tests {
                 "expected '{raw}' to be rejected"
             );
         }
+    }
+
+    #[test]
+    fn resolve_promise_blocks_on_work_unit_scan_gap_without_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store =
+            crate::test_helpers::make_store(&tmp.path().join("store"), vec!["work-unit"]);
+        // An unreadable work-unit file leaves the type only partially scanned, so
+        // a no-match result is untrustworthy and must not authorize cold-start.
+        store.mark_instance_scan_gap("work-unit", "hidden");
+        let identity = github_identity("tesserine", "runa");
+        let ticket = resolve_ticket_reference("14", &identity).unwrap();
+
+        assert_eq!(
+            resolve_promise(&store, &identity, &ticket),
+            Err(ScopedWorkUnitError::WorkUnitScanIncomplete)
+        );
+    }
+
+    #[test]
+    fn resolve_promise_returns_none_when_scan_complete_and_no_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::test_helpers::make_store(&tmp.path().join("store"), vec!["work-unit"]);
+        let identity = github_identity("tesserine", "runa");
+        let ticket = resolve_ticket_reference("14", &identity).unwrap();
+
+        assert_eq!(resolve_promise(&store, &identity, &ticket), Ok(None));
+    }
+
+    #[test]
+    fn resolve_promise_returns_match_despite_scan_gap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store =
+            crate::test_helpers::make_store(&tmp.path().join("store"), vec!["work-unit"]);
+        let artifact = serde_json::json!({
+            "title": "Cold start",
+            "handle": {
+                "forge_tag": "github",
+                "url": "https://github.com/tesserine/runa/issues/14",
+                "number": 14
+            }
+        });
+        let path = tmp.path().join("work-unit-14.json");
+        std::fs::write(&path, artifact.to_string()).unwrap();
+        store
+            .record_with_timestamp("work-unit", "work-unit-14", &path, &artifact, 1)
+            .unwrap();
+        // A gap on an unrelated hidden instance must not suppress the found match
+        // — re-entry still binds.
+        store.mark_instance_scan_gap("work-unit", "hidden");
+        let identity = github_identity("tesserine", "runa");
+        let ticket = resolve_ticket_reference("14", &identity).unwrap();
+
+        assert_eq!(
+            resolve_promise(&store, &identity, &ticket),
+            Ok(Some("work-unit-14".to_string()))
+        );
     }
 
     #[test]

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -1,0 +1,533 @@
+//! Cold-start entry from a forge ticket reference.
+//!
+//! The scoped pipeline activates on a `work-unit` artifact, but the natural
+//! developer entry is a ticket reference — "start on runa#14". This module
+//! supplies the runtime half: parsing a forge ticket reference into a tracker
+//! identity, discovering the methodology's acquisition surface, and resolving
+//! the reference to the materialized `work-unit` instance once acquisition has
+//! produced it.
+//!
+//! The runtime never reads ticket content. A reference carries identity only;
+//! the methodology performs all forge reads through its own mechanics.
+
+use std::fmt;
+
+use crate::model::ProtocolDeclaration;
+use crate::scoped_identity::{
+    ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
+    validate_tracker_consistency,
+};
+use crate::store::ArtifactStore;
+
+/// Artifact type the runtime treats as the scope-identity seed. The acquisition
+/// surface is the sole unscoped protocol that produces this type.
+pub const WORK_UNIT_ARTIFACT_TYPE: &str = "work-unit";
+
+/// Environment atom carrying the entry ticket number to acquisition mechanics.
+pub const RUNA_ENTRY_TICKET: &str = "RUNA_ENTRY_TICKET";
+
+/// A forge ticket reference resolved against the active deployment identity.
+///
+/// `tracker_identity` is the canonical match key (`github:<owner>/<name>:<n>`
+/// or `sourcehut:<tracker_id>:<n>`), identical to what a recorded work-unit
+/// handle yields. `display` is the operator-facing rendering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TicketRef {
+    pub number: u64,
+    pub tracker_identity: String,
+    pub display: String,
+}
+
+/// What the operator asserted in the reference, before deployment resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AssertedForge {
+    /// Bare number or `#N`: forge identity comes wholly from the deployment.
+    None,
+    /// `owner/repo#N` or a GitHub issue URL.
+    Github { owner: String, name: String },
+    /// `sourcehut:<tracker_id>#N`.
+    Sourcehut { tracker_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedReference {
+    number: u64,
+    asserted: AssertedForge,
+}
+
+/// Errors raised while opening a session from a forge ticket reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryError {
+    /// The reference string does not parse as a supported ticket form.
+    InvalidReference { supplied: String },
+    /// A required deployment-identity atom is absent for this reference form.
+    MissingDeploymentIdentity { variable: &'static str },
+    /// The reference asserts a forge deployment other than the active one.
+    DeploymentDisagreement {
+        reference_identity: String,
+        active_identity: String,
+    },
+    /// No unscoped protocol declares the `work-unit` artifact as an output.
+    NoAcquisitionSurface { scoped_producers: Vec<String> },
+    /// More than one unscoped protocol declares the `work-unit` artifact.
+    AmbiguousAcquisitionSurface { candidates: Vec<String> },
+    /// Acquisition completed its contract but materialized no matching work-unit.
+    Unresolved { reference: String },
+}
+
+impl fmt::Display for EntryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EntryError::InvalidReference { supplied } => write!(
+                f,
+                "'{supplied}' is not a recognized forge ticket reference; expected a ticket number, 'owner/repo#N', a forge issue URL, or 'sourcehut:<tracker_id>#N'"
+            ),
+            EntryError::MissingDeploymentIdentity { variable } => write!(
+                f,
+                "ticket reference omits forge identity and required deployment atom '{variable}' is unset"
+            ),
+            EntryError::DeploymentDisagreement {
+                reference_identity,
+                active_identity,
+            } => write!(
+                f,
+                "ticket reference names {reference_identity}, which disagrees with active deployment {active_identity}"
+            ),
+            EntryError::NoAcquisitionSurface { scoped_producers } => {
+                if scoped_producers.is_empty() {
+                    write!(
+                        f,
+                        "methodology declares no unscoped producer of '{WORK_UNIT_ARTIFACT_TYPE}'; cold-start ticket entry is unavailable"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "methodology declares no unscoped producer of '{WORK_UNIT_ARTIFACT_TYPE}'; cold-start ticket entry is unavailable (scoped producers: {})",
+                        scoped_producers.join(", ")
+                    )
+                }
+            }
+            EntryError::AmbiguousAcquisitionSurface { candidates } => write!(
+                f,
+                "more than one unscoped protocol produces '{WORK_UNIT_ARTIFACT_TYPE}' ({}); cold-start ticket entry requires a single acquisition surface",
+                candidates.join(", ")
+            ),
+            EntryError::Unresolved { reference } => write!(
+                f,
+                "acquisition from ticket {reference} completed but produced no '{WORK_UNIT_ARTIFACT_TYPE}' matching the reference"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EntryError {}
+
+/// Parse and resolve a forge ticket reference against the active deployment.
+///
+/// The grammar accepts a bare number, `#N`, `owner/repo#N`, a GitHub issue URL,
+/// or `sourcehut:<tracker_id>#N`. An asserted forge identity must agree with the
+/// active deployment; a bare reference inherits the deployment identity. No
+/// forge access occurs — only the reference string and the resolved identity.
+pub fn resolve_ticket_reference(
+    raw: &str,
+    identity: &ResolvedForgeIdentity,
+) -> Result<TicketRef, EntryError> {
+    let parsed = parse_ticket_reference(raw)?;
+    bind_reference_identity(&parsed, identity)
+}
+
+fn parse_ticket_reference(raw: &str) -> Result<ParsedReference, EntryError> {
+    let trimmed = raw.trim();
+    let invalid = || EntryError::InvalidReference {
+        supplied: raw.to_string(),
+    };
+
+    if let Some(rest) = trimmed.strip_prefix("https://github.com/") {
+        let (repository, tail) = rest.split_once("/issues/").ok_or_else(invalid)?;
+        let (owner, name) = repository.split_once('/').ok_or_else(invalid)?;
+        let number = parse_number(tail).ok_or_else(invalid)?;
+        if owner.is_empty() || name.is_empty() {
+            return Err(invalid());
+        }
+        return Ok(ParsedReference {
+            number,
+            asserted: AssertedForge::Github {
+                owner: owner.to_string(),
+                name: name.to_string(),
+            },
+        });
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("sourcehut:") {
+        let (tracker_id, tail) = rest.split_once('#').ok_or_else(invalid)?;
+        let number = parse_number(tail).ok_or_else(invalid)?;
+        if tracker_id.is_empty() {
+            return Err(invalid());
+        }
+        return Ok(ParsedReference {
+            number,
+            asserted: AssertedForge::Sourcehut {
+                tracker_id: tracker_id.to_string(),
+            },
+        });
+    }
+
+    if let Some((repository, tail)) = trimmed.split_once('#')
+        && !repository.is_empty()
+    {
+        let (owner, name) = repository.split_once('/').ok_or_else(invalid)?;
+        let number = parse_number(tail).ok_or_else(invalid)?;
+        if owner.is_empty() || name.is_empty() {
+            return Err(invalid());
+        }
+        return Ok(ParsedReference {
+            number,
+            asserted: AssertedForge::Github {
+                owner: owner.to_string(),
+                name: name.to_string(),
+            },
+        });
+    }
+
+    let number = parse_number(trimmed.strip_prefix('#').unwrap_or(trimmed)).ok_or_else(invalid)?;
+    Ok(ParsedReference {
+        number,
+        asserted: AssertedForge::None,
+    })
+}
+
+fn parse_number(value: &str) -> Option<u64> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    value.parse().ok().filter(|number| *number > 0)
+}
+
+fn bind_reference_identity(
+    parsed: &ParsedReference,
+    identity: &ResolvedForgeIdentity,
+) -> Result<TicketRef, EntryError> {
+    let number = parsed.number;
+    match &parsed.asserted {
+        AssertedForge::Github { owner, name } => {
+            require_forge(identity, "github")?;
+            let active = require_atom(identity.owner.as_deref(), "RUNA_FORGE_OWNER")?;
+            let active_name = require_atom(identity.name.as_deref(), "RUNA_FORGE_NAME")?;
+            if owner != active || name != active_name {
+                return Err(EntryError::DeploymentDisagreement {
+                    reference_identity: format!("github:{owner}/{name}"),
+                    active_identity: format!("github:{active}/{active_name}"),
+                });
+            }
+            Ok(github_ticket(owner, name, number))
+        }
+        AssertedForge::Sourcehut { tracker_id } => {
+            require_forge(identity, "sourcehut")?;
+            let active = require_atom(identity.tracker_id.as_deref(), "RUNA_FORGE_TRACKER_ID")?;
+            if tracker_id != active {
+                return Err(EntryError::DeploymentDisagreement {
+                    reference_identity: format!("sourcehut:{tracker_id}"),
+                    active_identity: format!("sourcehut:{active}"),
+                });
+            }
+            Ok(sourcehut_ticket(tracker_id, number))
+        }
+        AssertedForge::None => match identity.forge_type.as_str() {
+            "sourcehut" => {
+                let tracker_id =
+                    require_atom(identity.tracker_id.as_deref(), "RUNA_FORGE_TRACKER_ID")?;
+                Ok(sourcehut_ticket(tracker_id, number))
+            }
+            _ => {
+                let owner = require_atom(identity.owner.as_deref(), "RUNA_FORGE_OWNER")?;
+                let name = require_atom(identity.name.as_deref(), "RUNA_FORGE_NAME")?;
+                Ok(github_ticket(owner, name, number))
+            }
+        },
+    }
+}
+
+fn require_forge(identity: &ResolvedForgeIdentity, expected: &str) -> Result<(), EntryError> {
+    if identity.forge_type == expected {
+        return Ok(());
+    }
+    Err(EntryError::DeploymentDisagreement {
+        reference_identity: expected.to_string(),
+        active_identity: identity.forge_type.clone(),
+    })
+}
+
+fn require_atom<'a>(value: Option<&'a str>, variable: &'static str) -> Result<&'a str, EntryError> {
+    value
+        .filter(|value| !value.is_empty())
+        .ok_or(EntryError::MissingDeploymentIdentity { variable })
+}
+
+fn github_ticket(owner: &str, name: &str, number: u64) -> TicketRef {
+    TicketRef {
+        number,
+        tracker_identity: format!("github:{owner}/{name}:{number}"),
+        display: format!("github:{owner}/{name}#{number}"),
+    }
+}
+
+fn sourcehut_ticket(tracker_id: &str, number: u64) -> TicketRef {
+    TicketRef {
+        number,
+        tracker_identity: format!("sourcehut:{tracker_id}:{number}"),
+        display: format!("sourcehut:{tracker_id}#{number}"),
+    }
+}
+
+/// Discover the single unscoped protocol that produces the `work-unit` artifact.
+///
+/// This is the surface the runtime serves so acquisition can deliver its
+/// materialized work-unit. The derivation is methodology-neutral: it names no
+/// protocol, only the runtime-owned scope-identity artifact type.
+pub fn discover_acquisition_surface(
+    protocols: &[ProtocolDeclaration],
+) -> Result<&ProtocolDeclaration, EntryError> {
+    let producers: Vec<&ProtocolDeclaration> = protocols
+        .iter()
+        .filter(|protocol| {
+            protocol
+                .output_artifact_types()
+                .any(|artifact_type| artifact_type == WORK_UNIT_ARTIFACT_TYPE)
+        })
+        .collect();
+    let unscoped: Vec<&ProtocolDeclaration> = producers
+        .iter()
+        .copied()
+        .filter(|protocol| !protocol.scoped)
+        .collect();
+
+    match unscoped.as_slice() {
+        [surface] => Ok(surface),
+        [] => Err(EntryError::NoAcquisitionSurface {
+            scoped_producers: producers
+                .iter()
+                .filter(|protocol| protocol.scoped)
+                .map(|protocol| protocol.name.clone())
+                .collect(),
+        }),
+        many => Err(EntryError::AmbiguousAcquisitionSurface {
+            candidates: many.iter().map(|protocol| protocol.name.clone()).collect(),
+        }),
+    }
+}
+
+/// Resolve a ticket reference to the materialized `work-unit` instance.
+///
+/// Returns the instance id whose tracker handle identity equals the reference,
+/// or `None` when no such instance exists yet (cold store). Tracker-handle
+/// consistency is enforced first, so a `ScopedWorkUnitError` here signals a
+/// malformed or conflicting recorded work-unit rather than a missing one.
+pub fn resolve_promise(
+    store: &ArtifactStore,
+    identity: &ResolvedForgeIdentity,
+    ticket: &TicketRef,
+) -> Result<Option<String>, ScopedWorkUnitError> {
+    validate_tracker_consistency(store, identity)?;
+    Ok(find_work_unit_by_tracker_identity(
+        store,
+        &ticket.tracker_identity,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::TriggerCondition;
+
+    fn github_identity(owner: &str, name: &str) -> ResolvedForgeIdentity {
+        ResolvedForgeIdentity {
+            forge_type: "github".to_string(),
+            owner: Some(owner.to_string()),
+            name: Some(name.to_string()),
+            tracker_id: None,
+        }
+    }
+
+    fn sourcehut_identity(tracker_id: &str) -> ResolvedForgeIdentity {
+        ResolvedForgeIdentity {
+            forge_type: "sourcehut".to_string(),
+            owner: None,
+            name: None,
+            tracker_id: Some(tracker_id.to_string()),
+        }
+    }
+
+    fn protocol(name: &str, produces: &[&str], scoped: bool) -> ProtocolDeclaration {
+        ProtocolDeclaration {
+            name: name.into(),
+            requires: Vec::new(),
+            accepts: Vec::new(),
+            produces: produces.iter().map(|value| value.to_string()).collect(),
+            may_produce: Vec::new(),
+            required_output_choices: Vec::new(),
+            scoped,
+            trigger: TriggerCondition::OnArtifact {
+                name: "seed".into(),
+            },
+            instructions: None,
+        }
+    }
+
+    #[test]
+    fn bare_number_inherits_github_deployment() {
+        let ticket =
+            resolve_ticket_reference("188", &github_identity("tesserine", "runa")).unwrap();
+        assert_eq!(ticket.number, 188);
+        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:188");
+        assert_eq!(ticket.display, "github:tesserine/runa#188");
+    }
+
+    #[test]
+    fn hash_number_inherits_deployment() {
+        let ticket =
+            resolve_ticket_reference("#14", &github_identity("tesserine", "runa")).unwrap();
+        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:14");
+    }
+
+    #[test]
+    fn owner_repo_form_matches_active_deployment() {
+        let ticket =
+            resolve_ticket_reference("tesserine/runa#14", &github_identity("tesserine", "runa"))
+                .unwrap();
+        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:14");
+    }
+
+    #[test]
+    fn github_url_form_parses() {
+        let ticket = resolve_ticket_reference(
+            "https://github.com/tesserine/runa/issues/188",
+            &github_identity("tesserine", "runa"),
+        )
+        .unwrap();
+        assert_eq!(ticket.number, 188);
+        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:188");
+    }
+
+    #[test]
+    fn owner_repo_form_rejects_foreign_deployment() {
+        let error = resolve_ticket_reference(
+            "tesserine/groundwork#14",
+            &github_identity("tesserine", "runa"),
+        )
+        .unwrap_err();
+        assert!(matches!(error, EntryError::DeploymentDisagreement { .. }));
+    }
+
+    #[test]
+    fn sourcehut_form_matches_active_tracker() {
+        let ticket = resolve_ticket_reference("sourcehut:4#9", &sourcehut_identity("4")).unwrap();
+        assert_eq!(ticket.tracker_identity, "sourcehut:4:9");
+        assert_eq!(ticket.display, "sourcehut:4#9");
+    }
+
+    #[test]
+    fn sourcehut_form_rejects_github_deployment() {
+        let error =
+            resolve_ticket_reference("sourcehut:4#9", &github_identity("tesserine", "runa"))
+                .unwrap_err();
+        assert!(matches!(error, EntryError::DeploymentDisagreement { .. }));
+    }
+
+    #[test]
+    fn bare_number_under_sourcehut_inherits_tracker() {
+        let ticket = resolve_ticket_reference("9", &sourcehut_identity("4")).unwrap();
+        assert_eq!(ticket.tracker_identity, "sourcehut:4:9");
+    }
+
+    #[test]
+    fn missing_owner_atom_is_rejected() {
+        let identity = ResolvedForgeIdentity {
+            forge_type: "github".to_string(),
+            owner: None,
+            name: Some("runa".to_string()),
+            tracker_id: None,
+        };
+        let error = resolve_ticket_reference("14", &identity).unwrap_err();
+        assert!(matches!(
+            error,
+            EntryError::MissingDeploymentIdentity {
+                variable: "RUNA_FORGE_OWNER"
+            }
+        ));
+    }
+
+    #[test]
+    fn garbage_reference_is_rejected() {
+        for raw in [
+            "",
+            "not-a-ticket",
+            "#",
+            "0",
+            "owner/repo#",
+            "owner#3",
+            "#abc",
+        ] {
+            assert!(
+                resolve_ticket_reference(raw, &github_identity("tesserine", "runa")).is_err(),
+                "expected '{raw}' to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn discovers_sole_unscoped_producer() {
+        let protocols = vec![
+            protocol("decompose", &["work-unit"], false),
+            protocol("take", &["claim"], true),
+        ];
+        let surface = discover_acquisition_surface(&protocols).unwrap();
+        assert_eq!(surface.name, "decompose");
+    }
+
+    #[test]
+    fn rejects_when_only_scoped_producer_exists() {
+        let protocols = vec![protocol("take", &["work-unit"], true)];
+        let error = discover_acquisition_surface(&protocols).unwrap_err();
+        assert!(matches!(
+            error,
+            EntryError::NoAcquisitionSurface { scoped_producers } if scoped_producers == vec!["take".to_string()]
+        ));
+    }
+
+    #[test]
+    fn rejects_when_no_producer_exists() {
+        let protocols = vec![protocol("plan", &["plan-doc"], false)];
+        assert!(matches!(
+            discover_acquisition_surface(&protocols),
+            Err(EntryError::NoAcquisitionSurface { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_ambiguous_unscoped_producers() {
+        let protocols = vec![
+            protocol("decompose", &["work-unit"], false),
+            protocol("intake", &["work-unit"], false),
+        ];
+        let error = discover_acquisition_surface(&protocols).unwrap_err();
+        assert!(matches!(
+            error,
+            EntryError::AmbiguousAcquisitionSurface { candidates } if candidates.len() == 2
+        ));
+    }
+
+    #[test]
+    fn discovers_producer_via_required_output_choice() {
+        let mut protocol = protocol("decompose", &[], false);
+        protocol.required_output_choices = vec![crate::model::RequiredOutputChoice {
+            name: "delivery".into(),
+            members: vec!["work-unit".into(), "deferral".into()],
+        }];
+        let protocols = vec![protocol];
+        assert_eq!(
+            discover_acquisition_surface(&protocols).unwrap().name,
+            "decompose"
+        );
+    }
+}

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -19,7 +19,7 @@ use crate::scoped_identity::{
     ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
     validate_tracker_consistency,
 };
-use crate::selection::protocol_scan_incomplete_types;
+use crate::selection::precondition_scan_incomplete_types;
 use crate::store::ArtifactStore;
 
 /// Artifact type the runtime treats as the scope-identity seed. The acquisition
@@ -351,16 +351,18 @@ impl fmt::Display for AcquisitionBlock {
 /// Entry substitutes only the acquisition protocol's trigger (the operator's
 /// ticket reference stands in for it). Every other gate the canonical readiness
 /// path applies still holds: its `requires` preconditions, and scan trust over
-/// its input types. Currentness is intentionally omitted — the reference forces
-/// a fresh acquisition for this ticket regardless of unrelated outputs. The
-/// acquisition is always unscoped, so `work_unit` is `None`.
+/// those required inputs. Scan gaps on a trigger-only artifact type are ignored
+/// — the reference replaces the trigger, so that artifact is never consulted.
+/// Currentness is intentionally omitted — the reference forces a fresh
+/// acquisition regardless of unrelated outputs. The acquisition is always
+/// unscoped, so `work_unit` is `None`.
 pub fn check_acquisition_admissible(
     acquisition: &ProtocolDeclaration,
     store: &ArtifactStore,
     partially_scanned_types: &HashSet<String>,
 ) -> Result<(), AcquisitionBlock> {
     enforce_preconditions(acquisition, store, None).map_err(AcquisitionBlock::Precondition)?;
-    let incomplete = protocol_scan_incomplete_types(acquisition, partially_scanned_types);
+    let incomplete = precondition_scan_incomplete_types(acquisition, partially_scanned_types);
     if !incomplete.is_empty() {
         return Err(AcquisitionBlock::ScanIncomplete(incomplete));
     }
@@ -575,20 +577,44 @@ mod tests {
     }
 
     #[test]
-    fn acquisition_blocked_when_input_partially_scanned() {
+    fn acquisition_blocked_when_required_input_partially_scanned() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = crate::test_helpers::make_store(
+        let mut store = crate::test_helpers::make_store(
             &tmp.path().join("store"),
             vec!["request", "work-unit"],
         );
-        let acquisition = acquisition_protocol(&[]);
-        // The trigger input `request` was only partially scanned.
+        // A valid `request` satisfies preconditions...
+        store
+            .record(
+                "request",
+                "good",
+                std::path::Path::new("good.json"),
+                &serde_json::json!({"title": "good"}),
+            )
+            .unwrap();
+        // ...but `request` is a required input that was only partially scanned.
+        let acquisition = acquisition_protocol(&["request"]);
         let partials = HashSet::from(["request".to_string()]);
 
         assert!(matches!(
             check_acquisition_admissible(&acquisition, &store, &partials),
             Err(AcquisitionBlock::ScanIncomplete(types)) if types == vec!["request".to_string()]
         ));
+    }
+
+    #[test]
+    fn acquisition_admissible_when_only_substituted_trigger_partially_scanned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::test_helpers::make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit"],
+        );
+        // `request` is only the trigger (not required). The ticket replaces the
+        // trigger, so a partial scan of `request` must not block acquisition.
+        let acquisition = acquisition_protocol(&[]);
+        let partials = HashSet::from(["request".to_string()]);
+
+        assert!(check_acquisition_admissible(&acquisition, &store, &partials).is_ok());
     }
 
     #[test]

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -74,6 +74,9 @@ pub enum EntryError {
     NoAcquisitionSurface { scoped_producers: Vec<String> },
     /// More than one unscoped protocol declares the `work-unit` artifact.
     AmbiguousAcquisitionSurface { candidates: Vec<String> },
+    /// A bare reference cannot inherit an active forge type that is neither
+    /// `github` nor `sourcehut`.
+    UnsupportedForge { forge_type: String },
     /// Acquisition completed its contract but materialized no matching work-unit.
     Unresolved { reference: String },
 }
@@ -114,6 +117,10 @@ impl fmt::Display for EntryError {
                 f,
                 "more than one unscoped protocol produces '{WORK_UNIT_ARTIFACT_TYPE}' ({}); cold-start ticket entry requires a single acquisition surface",
                 candidates.join(", ")
+            ),
+            EntryError::UnsupportedForge { forge_type } => write!(
+                f,
+                "active forge type '{forge_type}' is not supported for a bare ticket reference; use an explicit 'owner/repo#N' (github) or 'sourcehut:<tracker_id>#N' form, or set a supported RUNA_FORGE_TYPE"
             ),
             EntryError::Unresolved { reference } => write!(
                 f,
@@ -237,16 +244,19 @@ fn bind_reference_identity(
             Ok(sourcehut_ticket(tracker_id, number))
         }
         AssertedForge::None => match identity.forge_type.as_str() {
+            "github" => {
+                let owner = require_atom(identity.owner.as_deref(), "RUNA_FORGE_OWNER")?;
+                let name = require_atom(identity.name.as_deref(), "RUNA_FORGE_NAME")?;
+                Ok(github_ticket(owner, name, number))
+            }
             "sourcehut" => {
                 let tracker_id =
                     require_atom(identity.tracker_id.as_deref(), "RUNA_FORGE_TRACKER_ID")?;
                 Ok(sourcehut_ticket(tracker_id, number))
             }
-            _ => {
-                let owner = require_atom(identity.owner.as_deref(), "RUNA_FORGE_OWNER")?;
-                let name = require_atom(identity.name.as_deref(), "RUNA_FORGE_NAME")?;
-                Ok(github_ticket(owner, name, number))
-            }
+            other => Err(EntryError::UnsupportedForge {
+                forge_type: other.to_string(),
+            }),
         },
     }
 }
@@ -515,6 +525,22 @@ mod tests {
             EntryError::MissingDeploymentIdentity {
                 variable: "RUNA_FORGE_OWNER"
             }
+        ));
+    }
+
+    #[test]
+    fn bare_reference_on_unsupported_forge_is_rejected() {
+        // A typo or future custom forge type must not silently bind as GitHub.
+        let identity = ResolvedForgeIdentity {
+            forge_type: "gitlab".to_string(),
+            owner: Some("tesserine".to_string()),
+            name: Some("runa".to_string()),
+            tracker_id: None,
+        };
+
+        assert!(matches!(
+            resolve_ticket_reference("14", &identity),
+            Err(EntryError::UnsupportedForge { forge_type }) if forge_type == "gitlab"
         ));
     }
 

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -20,6 +20,7 @@
 pub(crate) mod completion;
 pub mod context;
 pub mod enforcement;
+pub mod entry;
 pub mod graph;
 pub mod logging;
 pub mod manifest;
@@ -42,6 +43,10 @@ pub use enforcement::{
     ArtifactFailure, EnforcementError, Phase, Relationship, enforce_postconditions,
     enforce_preconditions,
 };
+pub use entry::{
+    EntryError, RUNA_ENTRY_TICKET, TicketRef, discover_acquisition_surface, resolve_promise,
+    resolve_ticket_reference,
+};
 pub use graph::{CycleError, DependencyGraph, GraphError};
 pub use logging::{LoggingError, ResolvedLoggingConfig, configure_tracing, resolve_logging_config};
 pub use manifest::ManifestError;
@@ -53,14 +58,17 @@ pub use project::{
     Config, ForgeConfig, LoadedProject, LogFormat, LoggingConfig, ProjectError, State,
     TranscriptConfig,
 };
-pub use projection::{ProjectionCandidate, ProjectionClass, project_cascade};
+pub use projection::{
+    ProjectionCandidate, ProjectionClass, project_cascade, project_entry_cascade,
+};
 pub use scan::{
     ArtifactRef, InvalidArtifact, MalformedArtifact, PartiallyScannedType, ScanError, ScanResult,
     UnreadableArtifact, scan,
 };
 pub use scoped_identity::{
-    ResolvedForgeIdentity, ScopedWorkUnitError, resolve_forge_environment, resolve_forge_identity,
-    validate_scoped_work_unit, validate_scoped_work_unit_with_identity,
+    ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
+    resolve_forge_environment, resolve_forge_identity, validate_scoped_work_unit,
+    validate_scoped_work_unit_with_identity, validate_tracker_consistency,
 };
 pub use selection::{
     Candidate, CandidateKey, CandidateStatus, ClassifiedCandidate, EvaluationScope,

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -75,7 +75,8 @@ pub use selection::{
     EvaluationTopology, ScanTrust, WaitingReason, classify_candidates,
     collect_unsatisfied_conditions, discover_ready_candidates, protocol_execution_input_snapshot,
     protocol_execution_record, protocol_relevant_input_types, protocol_relevant_inputs_changed,
-    refresh_exhausted_candidates_after_scan, resolve_evaluation_topology,
+    protocol_scan_incomplete_types, refresh_exhausted_candidates_after_scan,
+    resolve_evaluation_topology,
 };
 pub use session::{
     AdvanceOutcome, CurrentStep, SESSION_ADVANCE_RECEIPT_ENV, SessionError, SessionReadiness,

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -73,9 +73,10 @@ pub use scoped_identity::{
 pub use selection::{
     Candidate, CandidateKey, CandidateStatus, ClassifiedCandidate, EvaluationScope,
     EvaluationTopology, ScanTrust, WaitingReason, classify_candidates,
-    collect_unsatisfied_conditions, discover_ready_candidates, protocol_execution_input_snapshot,
-    protocol_execution_record, protocol_relevant_input_types, protocol_relevant_inputs_changed,
-    refresh_exhausted_candidates_after_scan, resolve_evaluation_topology,
+    collect_unsatisfied_conditions, discover_ready_candidates, protocol_entry_execution_record,
+    protocol_execution_input_snapshot, protocol_execution_record, protocol_relevant_input_types,
+    protocol_relevant_inputs_changed, refresh_exhausted_candidates_after_scan,
+    resolve_evaluation_topology,
 };
 pub use session::{
     AdvanceOutcome, CurrentStep, SESSION_ADVANCE_RECEIPT_ENV, SessionError, SessionReadiness,

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -44,8 +44,8 @@ pub use enforcement::{
     enforce_preconditions,
 };
 pub use entry::{
-    EntryError, RUNA_ENTRY_TICKET, TicketRef, discover_acquisition_surface, resolve_promise,
-    resolve_ticket_reference,
+    AcquisitionBlock, EntryError, RUNA_ENTRY_TICKET, TicketRef, check_acquisition_admissible,
+    discover_acquisition_surface, resolve_promise, resolve_ticket_reference,
 };
 pub use graph::{CycleError, DependencyGraph, GraphError};
 pub use logging::{LoggingError, ResolvedLoggingConfig, configure_tracing, resolve_logging_config};
@@ -75,8 +75,7 @@ pub use selection::{
     EvaluationTopology, ScanTrust, WaitingReason, classify_candidates,
     collect_unsatisfied_conditions, discover_ready_candidates, protocol_execution_input_snapshot,
     protocol_execution_record, protocol_relevant_input_types, protocol_relevant_inputs_changed,
-    protocol_scan_incomplete_types, refresh_exhausted_candidates_after_scan,
-    resolve_evaluation_topology,
+    refresh_exhausted_candidates_after_scan, resolve_evaluation_topology,
 };
 pub use session::{
     AdvanceOutcome, CurrentStep, SESSION_ADVANCE_RECEIPT_ENV, SessionError, SessionReadiness,

--- a/libagent/src/projection.rs
+++ b/libagent/src/projection.rs
@@ -159,15 +159,15 @@ pub fn project_entry_cascade(
     let Some(acquisition_protocol) = protocol_map.get(acquisition.protocol_name.as_str()) else {
         return plan;
     };
-    // Entry substitutes only the trigger; preconditions and scan trust still
-    // gate. When the acquisition's requires are unmet or an input type was only
-    // partially scanned, nothing projects from it.
-    if !preconditions_satisfied(
+    // Entry substitutes only the trigger; the canonical admission gate
+    // (preconditions + scan trust) still applies. When it blocks, nothing
+    // projects from the acquisition.
+    if crate::entry::check_acquisition_admissible(
         acquisition_protocol,
-        &projection,
-        acquisition.work_unit.as_deref(),
-    ) || !protocol_scan_incomplete_types(acquisition_protocol, partially_scanned_types)
-        .is_empty()
+        store,
+        partially_scanned_types,
+    )
+    .is_err()
     {
         return plan;
     }

--- a/libagent/src/projection.rs
+++ b/libagent/src/projection.rs
@@ -159,13 +159,16 @@ pub fn project_entry_cascade(
     let Some(acquisition_protocol) = protocol_map.get(acquisition.protocol_name.as_str()) else {
         return plan;
     };
-    // Entry substitutes only the trigger; preconditions still gate. When the
-    // acquisition's requires are unmet, nothing projects from it.
+    // Entry substitutes only the trigger; preconditions and scan trust still
+    // gate. When the acquisition's requires are unmet or an input type was only
+    // partially scanned, nothing projects from it.
     if !preconditions_satisfied(
         acquisition_protocol,
         &projection,
         acquisition.work_unit.as_deref(),
-    ) {
+    ) || !protocol_scan_incomplete_types(acquisition_protocol, partially_scanned_types)
+        .is_empty()
+    {
         return plan;
     }
     let acquisition_key =
@@ -976,6 +979,60 @@ mod tests {
         assert_eq!(plan[1].protocol_name, "take");
         assert_eq!(plan[1].work_unit.as_deref(), Some("work-unit-14"));
         assert_eq!(plan[1].projection, ProjectionClass::Projected);
+    }
+
+    #[test]
+    fn entry_cascade_projects_nothing_when_acquisition_input_partially_scanned() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit", "claim"],
+        );
+        // A valid request exists, so preconditions are satisfied...
+        store
+            .record(
+                "request",
+                "good",
+                Path::new("good.json"),
+                &json!({"title":"good"}),
+            )
+            .unwrap();
+
+        let decompose = protocol(
+            "decompose",
+            &["request"],
+            &["work-unit"],
+            TriggerCondition::OnArtifact {
+                name: "request".into(),
+            },
+        );
+        let mut take = protocol(
+            "take",
+            &["work-unit"],
+            &["claim"],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        take.scoped = true;
+        let protocols = vec![decompose, take];
+
+        // ...but `request` was only partially scanned, so the acquisition is
+        // untrusted and nothing projects.
+        let partials = HashSet::from(["request".to_string()]);
+        let plan = project_entry_cascade(
+            &protocols,
+            &store,
+            &["decompose", "take"],
+            &Candidate {
+                protocol_name: "decompose".into(),
+                work_unit: None,
+            },
+            "work-unit-14",
+            &partials,
+        );
+
+        assert!(plan.is_empty());
     }
 
     #[test]

--- a/libagent/src/projection.rs
+++ b/libagent/src/projection.rs
@@ -132,6 +132,104 @@ pub fn project_cascade(
     plan
 }
 
+/// Project the cascade for a cold-start ticket entry.
+///
+/// The `acquisition` candidate is the operator-activated entry step: its
+/// trigger is the ticket reference, so it is emitted [`ProjectionClass::Current`]
+/// and its assumed `work-unit` output seeds the projection. Everything reachable
+/// from there under the promised scope is [`ProjectionClass::Projected`] — this
+/// makes `take` observably next on the acquired work-unit without running any
+/// agent. `promised_scope` is the provisional scope id (e.g. `work-unit-<N>`);
+/// the projected `work-unit` is unpartitioned, so a scoped `take` sees it.
+pub fn project_entry_cascade(
+    protocols: &[ProtocolDeclaration],
+    store: &ArtifactStore,
+    topological_order: &[&str],
+    acquisition: &Candidate,
+    promised_scope: &str,
+    partially_scanned_types: &HashSet<String>,
+) -> Vec<ProjectionCandidate> {
+    let protocol_map: HashMap<&str, &ProtocolDeclaration> = protocols
+        .iter()
+        .map(|protocol| (protocol.name.as_str(), protocol))
+        .collect();
+    let mut projection = ProjectionState::new(store, partially_scanned_types);
+    let mut plan = Vec::new();
+
+    let Some(acquisition_protocol) = protocol_map.get(acquisition.protocol_name.as_str()) else {
+        return plan;
+    };
+    // Entry substitutes only the trigger; preconditions still gate. When the
+    // acquisition's requires are unmet, nothing projects from it.
+    if !preconditions_satisfied(
+        acquisition_protocol,
+        &projection,
+        acquisition.work_unit.as_deref(),
+    ) {
+        return plan;
+    }
+    let acquisition_key =
+        candidate_key(&acquisition.protocol_name, acquisition.work_unit.as_deref());
+    plan.push(ProjectionCandidate {
+        protocol_name: acquisition.protocol_name.clone(),
+        work_unit: acquisition.work_unit.clone(),
+        projection: ProjectionClass::Current,
+    });
+    let execution_record = projection
+        .protocol_execution_record(acquisition_protocol, acquisition.work_unit.as_deref());
+    projection.record_protocol_outputs(
+        acquisition_protocol,
+        acquisition.work_unit.as_deref(),
+        execution_record,
+    );
+
+    let scope = EvaluationScope::Scoped(promised_scope);
+    let mut exhausted = HashSet::from([acquisition_key]);
+
+    while let Some(next) =
+        discover_ready_candidates_projection(protocols, &projection, topological_order, scope)
+            .into_iter()
+            .find(|candidate| {
+                !exhausted.contains(&candidate_key(
+                    &candidate.protocol_name,
+                    candidate.work_unit.as_deref(),
+                ))
+            })
+    {
+        let key = candidate_key(&next.protocol_name, next.work_unit.as_deref());
+        plan.push(ProjectionCandidate {
+            protocol_name: next.protocol_name.clone(),
+            work_unit: next.work_unit.clone(),
+            projection: ProjectionClass::Projected,
+        });
+        exhausted.insert(key);
+
+        let protocol = protocol_map
+            .get(next.protocol_name.as_str())
+            .expect("projected protocol must exist");
+        let execution_record =
+            projection.protocol_execution_record(protocol, next.work_unit.as_deref());
+        let changes = projection.record_protocol_outputs(
+            protocol,
+            next.work_unit.as_deref(),
+            execution_record,
+        );
+        exhausted.retain(|candidate| {
+            if candidate
+                == &candidate_key(&acquisition.protocol_name, acquisition.work_unit.as_deref())
+            {
+                return true;
+            }
+            let protocol = protocol_map
+                .get(candidate.protocol_name.as_str())
+                .expect("projected protocol must exist");
+            !changes_affect_candidate(protocol, candidate.work_unit.as_deref(), &changes)
+        });
+    }
+
+    plan
+}
+
 fn discover_ready_candidates_projection(
     protocols: &[ProtocolDeclaration],
     projection: &ProjectionState<'_>,
@@ -660,6 +758,106 @@ mod tests {
             trigger,
             instructions: None,
         }
+    }
+
+    #[test]
+    fn entry_cascade_projects_take_after_acquisition() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit", "claim"],
+        );
+
+        let decompose = protocol(
+            "decompose",
+            &[],
+            &["work-unit"],
+            TriggerCondition::OnArtifact {
+                name: "request".into(),
+            },
+        );
+        let mut take = protocol(
+            "take",
+            &["work-unit"],
+            &["claim"],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        take.scoped = true;
+        let protocols = vec![decompose, take];
+
+        let plan = project_entry_cascade(
+            &protocols,
+            &store,
+            &["decompose", "take"],
+            &Candidate {
+                protocol_name: "decompose".into(),
+                work_unit: None,
+            },
+            "work-unit-14",
+            &HashSet::new(),
+        );
+
+        assert_eq!(
+            plan,
+            vec![
+                ProjectionCandidate {
+                    protocol_name: "decompose".into(),
+                    work_unit: None,
+                    projection: ProjectionClass::Current,
+                },
+                ProjectionCandidate {
+                    protocol_name: "take".into(),
+                    work_unit: Some("work-unit-14".into()),
+                    projection: ProjectionClass::Projected,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn entry_cascade_projects_nothing_when_acquisition_preconditions_unmet() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit", "claim"],
+        );
+
+        // decompose requires `request`, which is absent: entry substitutes the
+        // trigger only, so the unmet precondition blocks the whole projection.
+        let decompose = protocol(
+            "decompose",
+            &["request"],
+            &["work-unit"],
+            TriggerCondition::OnArtifact {
+                name: "request".into(),
+            },
+        );
+        let mut take = protocol(
+            "take",
+            &["work-unit"],
+            &["claim"],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        take.scoped = true;
+        let protocols = vec![decompose, take];
+
+        let plan = project_entry_cascade(
+            &protocols,
+            &store,
+            &["decompose", "take"],
+            &Candidate {
+                protocol_name: "decompose".into(),
+                work_unit: None,
+            },
+            "work-unit-14",
+            &HashSet::new(),
+        );
+
+        assert!(plan.is_empty());
     }
 
     #[test]

--- a/libagent/src/projection.rs
+++ b/libagent/src/projection.rs
@@ -182,6 +182,21 @@ pub fn project_entry_cascade(
         acquisition.work_unit.as_deref(),
         execution_record,
     );
+    // discover_acquisition_surface guarantees `work-unit` is an output, but it
+    // may be declared via may_produce or a required choice — which the generic
+    // recording above does not project from a cold store. Seed it explicitly so
+    // the scoped follow-ups (take) project, matching live behavior.
+    if !acquisition_protocol
+        .produces
+        .iter()
+        .any(|artifact_type| artifact_type == crate::entry::WORK_UNIT_ARTIFACT_TYPE)
+    {
+        projection.project_seed_output(
+            &acquisition_key,
+            crate::entry::WORK_UNIT_ARTIFACT_TYPE,
+            acquisition.work_unit.as_deref(),
+        );
+    }
 
     let scope = EvaluationScope::Scoped(promised_scope);
     let mut exhausted = HashSet::from([acquisition_key]);
@@ -531,6 +546,45 @@ impl<'a> ProjectionState<'a> {
         changes
     }
 
+    /// Project a single named output for `producer`, replacing any prior
+    /// projection of the same `(artifact_type, producer, work_unit)`.
+    ///
+    /// Used to seed the acquisition's `work-unit` in entry projection when the
+    /// surface declares it via `may_produce` or a required output choice, which
+    /// [`record_protocol_outputs`](Self::record_protocol_outputs) does not
+    /// project from a cold store.
+    fn project_seed_output(
+        &mut self,
+        producer: &CandidateKey,
+        artifact_type: &str,
+        work_unit: Option<&str>,
+    ) {
+        let scoped_work_unit = work_unit.map(str::to_owned);
+        self.projected_outputs.retain(|output| {
+            !(output.artifact_type == artifact_type
+                && &output.producer == producer
+                && output.work_unit == scoped_work_unit)
+        });
+        let timestamp_ms = self.next_timestamp_ms;
+        self.projected_outputs.push(ProjectedOutput {
+            artifact_type: artifact_type.to_string(),
+            work_unit: scoped_work_unit,
+            producer: producer.clone(),
+            input: ExecutionInput {
+                instance_id: projected_instance_id(producer, artifact_type),
+                content_hash: raw_content_hash(
+                    format!(
+                        "{}:{}:{:?}:{}",
+                        producer.protocol_name, artifact_type, producer.work_unit, timestamp_ms
+                    )
+                    .as_bytes(),
+                ),
+            },
+            timestamp_ms,
+        });
+        self.next_timestamp_ms += 1;
+    }
+
     fn projected_protocol_output_types(
         &self,
         protocol: &ProtocolDeclaration,
@@ -814,6 +868,114 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn entry_cascade_projects_take_when_acquisition_uses_may_produce() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp.path().join("store"), vec!["work-unit", "claim"]);
+
+        // The acquisition declares work-unit via may_produce (the groundwork
+        // shape), which generic output recording does not project.
+        let mut decompose = protocol(
+            "decompose",
+            &[],
+            &[],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        decompose.may_produce = vec!["work-unit".into()];
+        let mut take = protocol(
+            "take",
+            &["work-unit"],
+            &["claim"],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        take.scoped = true;
+        let protocols = vec![decompose, take];
+
+        let plan = project_entry_cascade(
+            &protocols,
+            &store,
+            &["decompose", "take"],
+            &Candidate {
+                protocol_name: "decompose".into(),
+                work_unit: None,
+            },
+            "work-unit-14",
+            &HashSet::new(),
+        );
+
+        assert_eq!(
+            plan,
+            vec![
+                ProjectionCandidate {
+                    protocol_name: "decompose".into(),
+                    work_unit: None,
+                    projection: ProjectionClass::Current,
+                },
+                ProjectionCandidate {
+                    protocol_name: "take".into(),
+                    work_unit: Some("work-unit-14".into()),
+                    projection: ProjectionClass::Projected,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn entry_cascade_projects_take_when_acquisition_uses_required_choice() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(
+            &tmp.path().join("store"),
+            vec!["work-unit", "deferral", "claim"],
+        );
+
+        // The acquisition declares work-unit via a required output choice; no
+        // member is recorded cold, so generic recording projects nothing.
+        let mut decompose = protocol(
+            "decompose",
+            &[],
+            &[],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        decompose.required_output_choices = vec![RequiredOutputChoice {
+            name: "delivery".into(),
+            members: vec!["work-unit".into(), "deferral".into()],
+        }];
+        let mut take = protocol(
+            "take",
+            &["work-unit"],
+            &["claim"],
+            TriggerCondition::OnArtifact {
+                name: "work-unit".into(),
+            },
+        );
+        take.scoped = true;
+        let protocols = vec![decompose, take];
+
+        let plan = project_entry_cascade(
+            &protocols,
+            &store,
+            &["decompose", "take"],
+            &Candidate {
+                protocol_name: "decompose".into(),
+                work_unit: None,
+            },
+            "work-unit-14",
+            &HashSet::new(),
+        );
+
+        assert_eq!(plan.len(), 2, "{plan:?}");
+        assert_eq!(plan[0].protocol_name, "decompose");
+        assert_eq!(plan[1].protocol_name, "take");
+        assert_eq!(plan[1].work_unit.as_deref(), Some("work-unit-14"));
+        assert_eq!(plan[1].projection, ProjectionClass::Projected);
     }
 
     #[test]

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -144,6 +144,48 @@ pub fn validate_scoped_work_unit(
     validate_scoped_work_unit_with_identity(store, supplied, &identity)
 }
 
+/// Enforce tracker-handle consistency across all recorded `work-unit` instances
+/// without requiring a supplied canonical id.
+///
+/// Used during promised-scope entry, where the session has a forge ticket
+/// reference rather than a recorded instance id. Runs the same content checks as
+/// [`validate_scoped_work_unit_with_identity`] (tracker-number agreement,
+/// duplicate-root rejection, deployment-identity agreement) over the store.
+pub fn validate_tracker_consistency(
+    store: &ArtifactStore,
+    identity: &ResolvedForgeIdentity,
+) -> Result<(), ScopedWorkUnitError> {
+    validate_tracker_content(store, identity)
+}
+
+/// Find the valid `work-unit` instance whose tracker handle identity equals
+/// `target` (e.g. `github:owner/name:14`), if any.
+///
+/// Reads handles from the local store only; performs no forge access. Returns
+/// the first match in store iteration order; callers run
+/// [`validate_tracker_consistency`] first to reject duplicate tracker roots, so
+/// at most one instance can match a given identity in a consistent store.
+pub fn find_work_unit_by_tracker_identity(store: &ArtifactStore, target: &str) -> Option<String> {
+    for (instance_id, state) in store.instances_of("work-unit", None) {
+        if !matches!(state.status, ValidationStatus::Valid) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&state.path) else {
+            continue;
+        };
+        let Ok(data) = serde_json::from_str::<Value>(&content) else {
+            continue;
+        };
+        let Some(handle) = data.get("handle").and_then(Value::as_object) else {
+            continue;
+        };
+        if tracker_identity(handle).as_deref() == Some(target) {
+            return Some(instance_id.to_string());
+        }
+    }
+    None
+}
+
 pub fn resolve_forge_identity(config: &ForgeConfig) -> ResolvedForgeIdentity {
     ResolvedForgeIdentity {
         forge_type: resolve_atom(RUNA_FORGE_TYPE, config.forge_type.as_deref())

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -86,6 +86,7 @@ pub enum ScopedWorkUnitError {
         handle_identity: String,
         active_identity: String,
     },
+    WorkUnitScanIncomplete,
 }
 
 impl fmt::Display for ScopedWorkUnitError {
@@ -129,6 +130,10 @@ impl fmt::Display for ScopedWorkUnitError {
             } => write!(
                 f,
                 "work-unit instance '{instance_id}' belongs to {handle_identity}, which disagrees with active deployment {active_identity}"
+            ),
+            ScopedWorkUnitError::WorkUnitScanIncomplete => write!(
+                f,
+                "the 'work-unit' artifact type was only partially scanned; the ticket cannot be resolved without complete work-unit scan trust"
             ),
         }
     }

--- a/libagent/src/selection.rs
+++ b/libagent/src/selection.rs
@@ -557,6 +557,38 @@ pub fn protocol_execution_record(
     }
 }
 
+/// Build an execution record for an acquisition opened from a ticket reference.
+///
+/// The operator's reference substitutes the protocol's trigger, which is often
+/// unsatisfied at entry time, so [`protocol_execution_record`] would register no
+/// trigger freshness inputs and the persisted record could falsely mark a later
+/// normal activation as current. This variant registers the protocol's full
+/// trigger freshness inputs as if the trigger were satisfied (plus `requires`),
+/// so a subsequent activation re-fires when its real trigger artifact changes.
+pub fn protocol_entry_execution_record(
+    protocol: &ProtocolDeclaration,
+    store: &ArtifactStore,
+    work_unit: Option<&str>,
+) -> ExecutionRecord {
+    let mut freshness_inputs = HashMap::new();
+    collect_satisfied_execution_record_inputs(&protocol.trigger, &mut freshness_inputs, &|_| true);
+    for name in &protocol.requires {
+        record_freshness_input(
+            &mut freshness_inputs,
+            name.as_str(),
+            FreshnessInputMode::ValidOnly,
+        );
+    }
+    let input_modes: BTreeMap<_, _> = freshness_inputs.into_iter().collect();
+    let inputs =
+        execution_input_snapshot_for_freshness_inputs(store, input_modes.iter(), work_unit);
+
+    ExecutionRecord {
+        input_modes,
+        inputs,
+    }
+}
+
 // --- Trigger trust evaluation (moved from runa-cli/src/commands/protocol_eval.rs) ---
 
 struct TriggerEvaluation {
@@ -1178,6 +1210,35 @@ mod tests {
         let inputs = protocol_execution_record_inputs(&protocol, &store, None, &HashSet::new());
 
         assert_eq!(inputs.get("request"), Some(&FreshnessInputMode::ValidOnly));
+    }
+
+    #[test]
+    fn entry_execution_record_registers_trigger_freshness_despite_unsatisfied_trigger() {
+        let tmp = TempDir::new().unwrap();
+        // No `request` exists: the trigger is unsatisfied, as in a ticket entry.
+        let store = make_store(&tmp.path().join("s"), vec!["request", "work-unit"]);
+        let acquisition = make_protocol(
+            "decompose",
+            &[],
+            &[],
+            &["work-unit"],
+            &[],
+            TriggerCondition::OnArtifact {
+                name: "request".into(),
+            },
+        );
+
+        // The satisfied-only record omits the trigger type — the bug that lets a
+        // later normal activation be falsely treated as current.
+        let satisfied_only = protocol_execution_record(&acquisition, &store, None, &HashSet::new());
+        assert!(!satisfied_only.input_modes.contains_key("request"));
+
+        // The entry record registers the trigger freshness baseline regardless.
+        let entry = protocol_entry_execution_record(&acquisition, &store, None);
+        assert_eq!(
+            entry.input_modes.get("request"),
+            Some(&FreshnessInputMode::ValidOnly)
+        );
     }
 
     #[test]

--- a/libagent/src/selection.rs
+++ b/libagent/src/selection.rs
@@ -995,8 +995,12 @@ fn trigger_scan_incomplete_failures(
     types
 }
 
-/// Collect scan-incomplete types from requires and produces.
-fn precondition_scan_incomplete_types(
+/// Collect scan-incomplete types from `requires` only (not trigger types).
+///
+/// Used by the normal readiness path for trigger-unsatisfied protocols, and by
+/// ticket entry — where the reference substitutes the trigger, so only the
+/// acquisition's required inputs still need scan trust.
+pub(crate) fn precondition_scan_incomplete_types(
     protocol: &ProtocolDeclaration,
     partially_scanned_types: &HashSet<String>,
 ) -> Vec<String> {

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -396,15 +396,12 @@ impl SessionState {
             .clone()
             .ok_or(SessionError::NoCurrentStep)?;
         let protocol = self.protocol(&current_step.protocol)?;
-        let mut context =
-            crate::context::build_context(protocol, &self.loaded.store, self.context_work_unit());
-        context.inputs.retain(|input| {
-            input.relationship == crate::context::ArtifactRelationship::Requires
-                || !reconciled
-                    .scan_findings
-                    .affected_types
-                    .contains(input.artifact_type.as_str())
-        });
+        let mut context = crate::context::build_execution_context(
+            protocol,
+            &self.loaded.store,
+            self.context_work_unit(),
+            &reconciled.scan_findings.affected_types,
+        );
         if let SessionScope::Promised { ticket, .. } = &self.scope {
             context.entry = Some(crate::context::EntryDelivery {
                 reference: ticket.display.clone(),

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -21,6 +21,10 @@ pub enum SessionError {
     CurrentStepNotReady(String),
     CurrentStepUnservable(String),
     Precondition(crate::EnforcementError),
+    ScanIncomplete {
+        protocol: String,
+        types: Vec<String>,
+    },
     Postcondition(crate::EnforcementError),
     Record(crate::StoreError),
 }
@@ -50,6 +54,11 @@ impl fmt::Display for SessionError {
                 write!(f, "current session step cannot be served: {message}")
             }
             SessionError::Precondition(err) => write!(f, "{err}"),
+            SessionError::ScanIncomplete { protocol, types } => write!(
+                f,
+                "acquisition protocol '{protocol}' cannot be served: input artifact type(s) {} were only partially scanned",
+                types.join(", ")
+            ),
             SessionError::Postcondition(err) => write!(f, "{err}"),
             SessionError::Record(err) => write!(f, "{err}"),
         }
@@ -70,7 +79,8 @@ impl std::error::Error for SessionError {
             | SessionError::NoCurrentStep
             | SessionError::CurrentStepMissing(_)
             | SessionError::CurrentStepNotReady(_)
-            | SessionError::CurrentStepUnservable(_) => None,
+            | SessionError::CurrentStepUnservable(_)
+            | SessionError::ScanIncomplete { .. } => None,
         }
     }
 }
@@ -167,10 +177,7 @@ pub struct SessionTransition<T> {
 #[derive(Clone)]
 enum SessionScope {
     Bound(String),
-    Promised {
-        ticket: crate::TicketRef,
-        acquisition: String,
-    },
+    Promised { ticket: crate::TicketRef },
 }
 
 pub struct SessionState {
@@ -191,6 +198,16 @@ impl From<&CurrentStep> for crate::CandidateKey {
     fn from(step: &CurrentStep) -> Self {
         Self::new(&step.protocol, step.work_unit.as_deref())
     }
+}
+
+/// The set of artifact type names that were only partially scanned (some
+/// entries unreadable), used to gate readiness on scan trust.
+fn partially_scanned_set(scan_result: &crate::ScanResult) -> HashSet<String> {
+    scan_result
+        .partially_scanned_types
+        .iter()
+        .map(|partial| partial.artifact_type.clone())
+        .collect()
 }
 
 impl SessionState {
@@ -251,55 +268,60 @@ impl SessionState {
     where
         F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
     {
-        let loaded = crate::project::load(&working_dir, config_override)?;
-        let acquisition = crate::discover_acquisition_surface(&loaded.manifest.protocols)?
-            .name
-            .clone();
-        let mut session = Self {
-            working_dir,
-            loaded,
-            scope: SessionScope::Promised {
-                ticket,
-                acquisition,
-            },
-            current_step: None,
-            exhausted: HashSet::new(),
-        };
+        let mut loaded = crate::project::load(&working_dir, config_override)?;
+        let scan_result = crate::scan(&loaded.workspace_dir, &mut loaded.store)?;
+        let scan_findings = crate::collect_scan_findings(&scan_result, &loaded.workspace_dir);
+        let identity = crate::resolve_forge_identity(&loaded.config.forge);
 
-        let scan_result = session.scan_workspace()?;
-        session.refresh_exhaustion_after_scan(&scan_result);
-        let identity = crate::resolve_forge_identity(&session.loaded.config.forge);
-        let scan_findings =
-            crate::collect_scan_findings(&scan_result, &session.loaded.workspace_dir);
-
-        // Re-entry: if the work-unit already exists, degrade to a bound session.
-        let resolved = match &session.scope {
-            SessionScope::Promised { ticket, .. } => {
-                crate::resolve_promise(&session.loaded.store, &identity, ticket)?
-            }
-            SessionScope::Bound(_) => None,
-        };
-
-        if let Some(work_unit) = resolved {
-            crate::validate_scoped_work_unit_with_identity(
-                &session.loaded.store,
-                &work_unit,
-                &identity,
-            )?;
-            session.scope = SessionScope::Bound(work_unit);
+        // Resolve the promise first. Re-entry (the work-unit already exists)
+        // degrades to an ordinary bound session and needs no acquisition surface;
+        // only a cold start requires one.
+        if let Some(work_unit) = crate::resolve_promise(&loaded.store, &identity, &ticket)? {
+            crate::validate_scoped_work_unit_with_identity(&loaded.store, &work_unit, &identity)?;
+            let mut session = Self {
+                working_dir,
+                loaded,
+                scope: SessionScope::Bound(work_unit),
+                current_step: None,
+                exhausted: HashSet::new(),
+            };
+            session.refresh_exhaustion_after_scan(&scan_result);
             let evaluated = session.evaluate(&scan_findings);
             let next_step = session.select_next(&evaluated, &scan_findings, &session.exhausted)?;
             session.current_step = session.validate_selected_step(next_step, validate_step)?;
             return Ok(session);
         }
 
-        // Cold: pin the acquisition step. The reference substitutes only the
-        // protocol's trigger; its preconditions still gate.
-        crate::validate_tracker_consistency(&session.loaded.store, &identity)?;
-        let acquisition_name = session.acquisition_protocol()?.to_string();
+        // Cold start: the acquisition surface is required.
+        crate::validate_tracker_consistency(&loaded.store, &identity)?;
+        let acquisition_name = crate::discover_acquisition_surface(&loaded.manifest.protocols)?
+            .name
+            .clone();
+        let mut session = Self {
+            working_dir,
+            loaded,
+            scope: SessionScope::Promised { ticket },
+            current_step: None,
+            exhausted: HashSet::new(),
+        };
+        session.refresh_exhaustion_after_scan(&scan_result);
+
+        // The reference substitutes only the acquisition's trigger; its
+        // preconditions and scan-trust gates still apply, exactly as normal
+        // readiness would block a protocol with unmet inputs or a partial scan.
         let acquisition = session.protocol(&acquisition_name)?;
         crate::enforce_preconditions(acquisition, &session.loaded.store, None)
             .map_err(SessionError::Precondition)?;
+        let incomplete = crate::protocol_scan_incomplete_types(
+            acquisition,
+            &partially_scanned_set(&scan_result),
+        );
+        if !incomplete.is_empty() {
+            return Err(SessionError::ScanIncomplete {
+                protocol: acquisition_name,
+                types: incomplete,
+            });
+        }
         let provenance_snapshot = crate::protocol_execution_record(
             acquisition,
             &session.loaded.store,
@@ -570,15 +592,26 @@ impl SessionState {
                 .clone()
                 .ok_or(SessionError::NoCurrentStep)?;
             // The operator's reference stands in for the acquisition step's
-            // trigger, but its preconditions still gate. A bound step uses the
-            // normal readiness check; a promised step enforces the acquisition
-            // protocol's preconditions directly.
+            // trigger, but its preconditions and scan-trust gates still apply. A
+            // bound step uses the normal readiness check; a promised step
+            // enforces the acquisition protocol's preconditions and scan trust
+            // directly.
             if matches!(self.scope, SessionScope::Bound(_)) {
                 self.ensure_current_step_can_complete(&current_step, &evaluated)?;
             } else {
                 let protocol = self.protocol(&current_step.protocol)?;
                 crate::enforce_preconditions(protocol, &self.loaded.store, None)
                     .map_err(SessionError::Precondition)?;
+                let incomplete = crate::protocol_scan_incomplete_types(
+                    protocol,
+                    &partially_scanned_set(&scan_result),
+                );
+                if !incomplete.is_empty() {
+                    return Err(SessionError::ScanIncomplete {
+                        protocol: current_step.protocol.clone(),
+                        types: incomplete,
+                    });
+                }
             }
         }
         Ok(ReconciledScan {
@@ -615,13 +648,6 @@ impl SessionState {
         match &self.scope {
             SessionScope::Bound(work_unit) => Some(work_unit),
             SessionScope::Promised { .. } => None,
-        }
-    }
-
-    fn acquisition_protocol(&self) -> Result<&str, SessionError> {
-        match &self.scope {
-            SessionScope::Promised { acquisition, .. } => Ok(acquisition),
-            SessionScope::Bound(_) => Err(SessionError::NoCurrentStep),
         }
     }
 
@@ -921,6 +947,48 @@ trigger = {{ type = "on_artifact", name = "work-unit" }}
             ],
             &["decompose", "take"],
         );
+        scaffold_entry_project(dir, &manifest_path, materialize)
+    }
+
+    /// A methodology whose only protocol is the scoped `take` — there is no
+    /// unscoped `work-unit` producer, so a cold start has no acquisition surface.
+    fn write_take_only_entry_project(dir: &Path, materialize: bool) -> PathBuf {
+        let manifest_path = crate::test_helpers::write_methodology(
+            dir,
+            r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[artifact_types]]
+name = "claim"
+
+[[protocols]]
+name = "take"
+requires = ["work-unit"]
+produces = ["claim"]
+scoped = true
+trigger = { type = "on_artifact", name = "work-unit" }
+"#,
+            &[
+                (
+                    "work-unit",
+                    r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+                ),
+                (
+                    "claim",
+                    r#"{"type":"object","required":["work_unit","scope"],"properties":{"work_unit":{"type":"string"},"scope":{"type":"string"}}}"#,
+                ),
+            ],
+            &["take"],
+        );
+        scaffold_entry_project(dir, &manifest_path, materialize)
+    }
+
+    /// Write `.runa/{config,state}.toml` and the workspace for an entry project,
+    /// optionally materializing the work-unit for ticket 14.
+    fn scaffold_entry_project(dir: &Path, manifest_path: &Path, materialize: bool) -> PathBuf {
         let project_dir = dir.join("project");
         fs::create_dir(&project_dir).unwrap();
         let runa_dir = project_dir.join(".runa");
@@ -976,6 +1044,39 @@ trigger = {{ type = "on_artifact", name = "work-unit" }}
         assert_eq!(step.protocol, "decompose");
         assert_eq!(step.work_unit, None);
         assert!(matches!(session.scope, SessionScope::Promised { .. }));
+    }
+
+    #[test]
+    fn open_entry_re_entry_binds_without_acquisition_surface() {
+        let dir = tempfile::tempdir().unwrap();
+        // No unscoped work-unit producer exists, but the work-unit is already
+        // recorded: re-entry must degrade to a bound session rather than fail on
+        // acquisition-surface discovery.
+        let project_dir = write_take_only_entry_project(dir.path(), true);
+
+        let session =
+            SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(())).unwrap();
+
+        let step = session.current_step().expect("bound session selects take");
+        assert_eq!(step.protocol, "take");
+        assert!(matches!(session.scope, SessionScope::Bound(_)));
+    }
+
+    #[test]
+    fn open_entry_cold_without_acquisition_surface_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // No work-unit recorded and no acquisition surface: a cold start has no
+        // way to acquire, so discovery fails.
+        let project_dir = write_take_only_entry_project(dir.path(), false);
+
+        let result = SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(()));
+
+        assert!(matches!(
+            result,
+            Err(SessionError::Entry(
+                crate::EntryError::NoAcquisitionSurface { .. }
+            ))
+        ));
     }
 
     #[test]

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -326,12 +326,11 @@ impl SessionState {
         ) {
             return Err(session_error_from_block(block, acquisition_name));
         }
-        let provenance_snapshot = crate::protocol_execution_record(
-            acquisition,
-            &session.loaded.store,
-            None,
-            &scan_findings.affected_types,
-        );
+        // The ticket substitutes the trigger, so record the full trigger
+        // freshness baseline; otherwise a later normal activation of this
+        // acquisition could be falsely treated as current.
+        let provenance_snapshot =
+            crate::protocol_entry_execution_record(acquisition, &session.loaded.store, None);
         let step = CurrentStep {
             protocol: acquisition_name,
             work_unit: None,
@@ -775,12 +774,19 @@ impl SessionState {
             return Ok(());
         };
         let protocol = self.protocol(&current.protocol)?;
-        let provenance_snapshot = crate::protocol_execution_record(
-            protocol,
-            &self.loaded.store,
-            current.work_unit.as_deref(),
-            &scan_findings.affected_types,
-        );
+        // A promised acquisition's trigger is substituted by the ticket, so it
+        // records the full trigger freshness baseline rather than the
+        // satisfied-only set, keeping later normal activations honest.
+        let provenance_snapshot = if matches!(self.scope, SessionScope::Promised { .. }) {
+            crate::protocol_entry_execution_record(protocol, &self.loaded.store, None)
+        } else {
+            crate::protocol_execution_record(
+                protocol,
+                &self.loaded.store,
+                current.work_unit.as_deref(),
+                &scan_findings.affected_types,
+            )
+        };
         if let Some(current_step) = &mut self.current_step {
             current_step.provenance_snapshot = Some(provenance_snapshot);
         }

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -210,6 +210,16 @@ fn partially_scanned_set(scan_result: &crate::ScanResult) -> HashSet<String> {
         .collect()
 }
 
+/// Map a canonical acquisition-admission block onto the session error surface.
+fn session_error_from_block(block: crate::AcquisitionBlock, protocol: String) -> SessionError {
+    match block {
+        crate::AcquisitionBlock::Precondition(error) => SessionError::Precondition(error),
+        crate::AcquisitionBlock::ScanIncomplete(types) => {
+            SessionError::ScanIncomplete { protocol, types }
+        }
+    }
+}
+
 impl SessionState {
     pub fn open(
         working_dir: PathBuf,
@@ -306,21 +316,15 @@ impl SessionState {
         };
         session.refresh_exhaustion_after_scan(&scan_result);
 
-        // The reference substitutes only the acquisition's trigger; its
-        // preconditions and scan-trust gates still apply, exactly as normal
-        // readiness would block a protocol with unmet inputs or a partial scan.
+        // The reference substitutes only the acquisition's trigger; the canonical
+        // admission gate (preconditions + scan trust) still applies.
         let acquisition = session.protocol(&acquisition_name)?;
-        crate::enforce_preconditions(acquisition, &session.loaded.store, None)
-            .map_err(SessionError::Precondition)?;
-        let incomplete = crate::protocol_scan_incomplete_types(
+        if let Err(block) = crate::check_acquisition_admissible(
             acquisition,
+            &session.loaded.store,
             &partially_scanned_set(&scan_result),
-        );
-        if !incomplete.is_empty() {
-            return Err(SessionError::ScanIncomplete {
-                protocol: acquisition_name,
-                types: incomplete,
-            });
+        ) {
+            return Err(session_error_from_block(block, acquisition_name));
         }
         let provenance_snapshot = crate::protocol_execution_record(
             acquisition,
@@ -593,24 +597,21 @@ impl SessionState {
                 .ok_or(SessionError::NoCurrentStep)?;
             // The operator's reference stands in for the acquisition step's
             // trigger, but its preconditions and scan-trust gates still apply. A
-            // bound step uses the normal readiness check; a promised step
-            // enforces the acquisition protocol's preconditions and scan trust
-            // directly.
+            // bound step uses the normal readiness check; a promised step uses
+            // the canonical acquisition-admission gate.
             if matches!(self.scope, SessionScope::Bound(_)) {
                 self.ensure_current_step_can_complete(&current_step, &evaluated)?;
             } else {
                 let protocol = self.protocol(&current_step.protocol)?;
-                crate::enforce_preconditions(protocol, &self.loaded.store, None)
-                    .map_err(SessionError::Precondition)?;
-                let incomplete = crate::protocol_scan_incomplete_types(
+                if let Err(block) = crate::check_acquisition_admissible(
                     protocol,
+                    &self.loaded.store,
                     &partially_scanned_set(&scan_result),
-                );
-                if !incomplete.is_empty() {
-                    return Err(SessionError::ScanIncomplete {
-                        protocol: current_step.protocol.clone(),
-                        types: incomplete,
-                    });
+                ) {
+                    return Err(session_error_from_block(
+                        block,
+                        current_step.protocol.clone(),
+                    ));
                 }
             }
         }

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -164,6 +164,7 @@ pub struct SessionTransition<T> {
 /// surface, evaluated unscoped — and resolves to a `Bound` scope when that step
 /// materializes the work-unit. Downstream of binding the two are
 /// indistinguishable.
+#[derive(Clone)]
 enum SessionScope {
     Bound(String),
     Promised {
@@ -468,10 +469,15 @@ impl SessionState {
 
         // A promised scope binds here: acquisition has produced the work-unit,
         // and the session becomes an ordinary bound scoped session for the next
-        // step. On failure the staged execution record is restored.
+        // step. Binding must precede selection (select_next needs the bound
+        // scope to find the next scoped step), so capture the prior scope and
+        // restore it — along with the staged execution record — on any failure,
+        // leaving a retried tick still representing the promised entry.
+        let previous_scope = self.scope.clone();
         if matches!(self.scope, SessionScope::Promised { .. })
             && let Err(error) = self.bind_promise()
         {
+            // bind_promise mutates scope only on success, so no scope restore.
             self.loaded.store.restore_execution_record(
                 &completed_step.protocol,
                 completed_step.work_unit.as_deref(),
@@ -494,6 +500,7 @@ impl SessionState {
                     completed_step.work_unit.as_deref(),
                     previous_record,
                 );
+                self.scope = previous_scope;
                 return Err(error);
             }
         };
@@ -505,6 +512,7 @@ impl SessionState {
                     completed_step.work_unit.as_deref(),
                     previous_record,
                 );
+                self.scope = previous_scope;
                 return Err(error);
             }
         };
@@ -514,6 +522,7 @@ impl SessionState {
                 completed_step.work_unit.as_deref(),
                 previous_record,
             );
+            self.scope = previous_scope;
             return Err(SessionError::Record(error));
         }
 
@@ -1020,6 +1029,45 @@ trigger = {{ type = "on_artifact", name = "work-unit" }}
             Some("take")
         );
         assert!(matches!(session.scope, SessionScope::Bound(_)));
+    }
+
+    #[test]
+    fn advance_restores_promised_scope_when_post_bind_commit_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_entry_project(dir.path(), false);
+        let mut session =
+            SessionState::open_entry(project_dir.clone(), None, ticket_14(), |_, _| Ok(()))
+                .unwrap();
+
+        // Acquisition materializes the work-unit, so bind_promise succeeds; the
+        // selector then fails, exercising a post-bind rollback path.
+        write_acquired_work_unit(&project_dir.join(".runa/workspace"));
+
+        let advance = session.advance_with_selector_and_validator(
+            |_session, _evaluated, _scan_findings, _exhausted| {
+                Err(SessionError::CurrentStepMissing("synthetic".to_string()))
+            },
+            |_next_protocol, _store| Ok(()),
+        );
+
+        assert!(advance.is_err(), "advance unexpectedly succeeded");
+        // The promised scope must be restored, not left bound, so a retried tick
+        // still represents the entry.
+        assert!(
+            matches!(session.scope, SessionScope::Promised { .. }),
+            "scope was not restored to Promised after a failed commit"
+        );
+        assert_eq!(
+            session.current_step().map(|step| step.protocol.as_str()),
+            Some("decompose")
+        );
+        assert!(
+            session
+                .store()
+                .execution_record("decompose", None)
+                .is_none()
+        );
+        assert_no_execution_record(&project_dir, "decompose");
     }
 
     #[test]

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -14,11 +14,13 @@ pub enum SessionError {
     Project(crate::ProjectError),
     Scan(crate::ScanError),
     WorkUnitScope(crate::ScopedWorkUnitError),
+    Entry(crate::EntryError),
     MissingWorkUnit,
     NoCurrentStep,
     CurrentStepMissing(String),
     CurrentStepNotReady(String),
     CurrentStepUnservable(String),
+    Precondition(crate::EnforcementError),
     Postcondition(crate::EnforcementError),
     Record(crate::StoreError),
 }
@@ -29,6 +31,7 @@ impl fmt::Display for SessionError {
             SessionError::Project(err) => write!(f, "{err}"),
             SessionError::Scan(err) => write!(f, "{err}"),
             SessionError::WorkUnitScope(err) => write!(f, "{err}"),
+            SessionError::Entry(err) => write!(f, "{err}"),
             SessionError::MissingWorkUnit => write!(f, "--session requires --work-unit"),
             SessionError::NoCurrentStep => write!(f, "session has no current ready step"),
             SessionError::CurrentStepMissing(protocol) => {
@@ -46,6 +49,7 @@ impl fmt::Display for SessionError {
             SessionError::CurrentStepUnservable(message) => {
                 write!(f, "current session step cannot be served: {message}")
             }
+            SessionError::Precondition(err) => write!(f, "{err}"),
             SessionError::Postcondition(err) => write!(f, "{err}"),
             SessionError::Record(err) => write!(f, "{err}"),
         }
@@ -58,6 +62,8 @@ impl std::error::Error for SessionError {
             SessionError::Project(err) => Some(err),
             SessionError::Scan(err) => Some(err),
             SessionError::WorkUnitScope(err) => Some(err),
+            SessionError::Entry(err) => Some(err),
+            SessionError::Precondition(err) => Some(err),
             SessionError::Postcondition(err) => Some(err),
             SessionError::Record(err) => Some(err),
             SessionError::MissingWorkUnit
@@ -84,6 +90,12 @@ impl From<crate::ScanError> for SessionError {
 impl From<crate::ScopedWorkUnitError> for SessionError {
     fn from(err: crate::ScopedWorkUnitError) -> Self {
         SessionError::WorkUnitScope(err)
+    }
+}
+
+impl From<crate::EntryError> for SessionError {
+    fn from(err: crate::EntryError) -> Self {
+        SessionError::Entry(err)
     }
 }
 
@@ -145,10 +157,25 @@ pub struct SessionTransition<T> {
     pub current_step_changed: bool,
 }
 
+/// A session's scope: a recorded work-unit (`Bound`) or a forge ticket
+/// reference standing for a work-unit not yet materialized (`Promised`).
+///
+/// A promised scope admits exactly one step — the methodology's acquisition
+/// surface, evaluated unscoped — and resolves to a `Bound` scope when that step
+/// materializes the work-unit. Downstream of binding the two are
+/// indistinguishable.
+enum SessionScope {
+    Bound(String),
+    Promised {
+        ticket: crate::TicketRef,
+        acquisition: String,
+    },
+}
+
 pub struct SessionState {
     working_dir: PathBuf,
     pub loaded: crate::LoadedProject,
-    work_unit: String,
+    scope: SessionScope,
     current_step: Option<CurrentStep>,
     exhausted: HashSet<crate::CandidateKey>,
 }
@@ -193,7 +220,7 @@ impl SessionState {
         let mut session = Self {
             working_dir,
             loaded,
-            work_unit,
+            scope: SessionScope::Bound(work_unit),
             current_step: None,
             exhausted: HashSet::new(),
         };
@@ -204,6 +231,86 @@ impl SessionState {
             &session.exhausted,
         )?;
         session.current_step = session.validate_selected_step(next_step, validate_step)?;
+        Ok(session)
+    }
+
+    /// Open a session from a forge ticket reference.
+    ///
+    /// When the referenced work-unit already exists, the session opens bound to
+    /// it — indistinguishable from [`open`](Self::open). Otherwise the session
+    /// opens in a promised scope pinned to the methodology's acquisition
+    /// surface; the reference is that step's activation, and the agent's
+    /// acquisition materializes the work-unit, which [`advance`] then binds.
+    pub fn open_entry<F>(
+        working_dir: PathBuf,
+        config_override: Option<&Path>,
+        ticket: crate::TicketRef,
+        validate_step: F,
+    ) -> Result<Self, SessionError>
+    where
+        F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
+    {
+        let loaded = crate::project::load(&working_dir, config_override)?;
+        let acquisition = crate::discover_acquisition_surface(&loaded.manifest.protocols)?
+            .name
+            .clone();
+        let mut session = Self {
+            working_dir,
+            loaded,
+            scope: SessionScope::Promised {
+                ticket,
+                acquisition,
+            },
+            current_step: None,
+            exhausted: HashSet::new(),
+        };
+
+        let scan_result = session.scan_workspace()?;
+        session.refresh_exhaustion_after_scan(&scan_result);
+        let identity = crate::resolve_forge_identity(&session.loaded.config.forge);
+        let scan_findings =
+            crate::collect_scan_findings(&scan_result, &session.loaded.workspace_dir);
+
+        // Re-entry: if the work-unit already exists, degrade to a bound session.
+        let resolved = match &session.scope {
+            SessionScope::Promised { ticket, .. } => {
+                crate::resolve_promise(&session.loaded.store, &identity, ticket)?
+            }
+            SessionScope::Bound(_) => None,
+        };
+
+        if let Some(work_unit) = resolved {
+            crate::validate_scoped_work_unit_with_identity(
+                &session.loaded.store,
+                &work_unit,
+                &identity,
+            )?;
+            session.scope = SessionScope::Bound(work_unit);
+            let evaluated = session.evaluate(&scan_findings);
+            let next_step = session.select_next(&evaluated, &scan_findings, &session.exhausted)?;
+            session.current_step = session.validate_selected_step(next_step, validate_step)?;
+            return Ok(session);
+        }
+
+        // Cold: pin the acquisition step. The reference substitutes only the
+        // protocol's trigger; its preconditions still gate.
+        crate::validate_tracker_consistency(&session.loaded.store, &identity)?;
+        let acquisition_name = session.acquisition_protocol()?.to_string();
+        let acquisition = session.protocol(&acquisition_name)?;
+        crate::enforce_preconditions(acquisition, &session.loaded.store, None)
+            .map_err(SessionError::Precondition)?;
+        let provenance_snapshot = crate::protocol_execution_record(
+            acquisition,
+            &session.loaded.store,
+            None,
+            &scan_findings.affected_types,
+        );
+        let step = CurrentStep {
+            protocol: acquisition_name,
+            work_unit: None,
+            provenance_snapshot: Some(provenance_snapshot),
+        };
+        session.current_step = session.validate_selected_step(Some(step), validate_step)?;
         Ok(session)
     }
 
@@ -264,7 +371,7 @@ impl SessionState {
             .ok_or(SessionError::NoCurrentStep)?;
         let protocol = self.protocol(&current_step.protocol)?;
         let mut context =
-            crate::context::build_context(protocol, &self.loaded.store, Some(&self.work_unit));
+            crate::context::build_context(protocol, &self.loaded.store, self.context_work_unit());
         context.inputs.retain(|input| {
             input.relationship == crate::context::ArtifactRelationship::Requires
                 || !reconciled
@@ -272,6 +379,13 @@ impl SessionState {
                     .affected_types
                     .contains(input.artifact_type.as_str())
         });
+        if let SessionScope::Promised { ticket, .. } = &self.scope {
+            context.entry = Some(crate::context::EntryDelivery {
+                reference: ticket.display.clone(),
+                ticket_number: ticket.number,
+                tracker_identity: ticket.tracker_identity.clone(),
+            });
+        }
         let rendered = render_context_prompt(&context);
         self.refresh_current_provenance_snapshot(&reconciled.scan_findings)?;
         Ok((context, rendered))
@@ -352,6 +466,20 @@ impl SessionState {
             &reconciled.scan_result,
         );
 
+        // A promised scope binds here: acquisition has produced the work-unit,
+        // and the session becomes an ordinary bound scoped session for the next
+        // step. On failure the staged execution record is restored.
+        if matches!(self.scope, SessionScope::Promised { .. })
+            && let Err(error) = self.bind_promise()
+        {
+            self.loaded.store.restore_execution_record(
+                &completed_step.protocol,
+                completed_step.work_unit.as_deref(),
+                previous_record,
+            );
+            return Err(error);
+        }
+
         let evaluated = self.evaluate(&reconciled.scan_findings);
         let next_step = match select_next(
             self,
@@ -412,11 +540,18 @@ impl SessionState {
     ) -> Result<ReconciledScan, SessionError> {
         let scan_result = self.scan_workspace()?;
         let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
-        crate::validate_scoped_work_unit_with_identity(
-            &self.loaded.store,
-            &self.work_unit,
-            &identity,
-        )?;
+        match &self.scope {
+            SessionScope::Bound(work_unit) => {
+                crate::validate_scoped_work_unit_with_identity(
+                    &self.loaded.store,
+                    work_unit,
+                    &identity,
+                )?;
+            }
+            SessionScope::Promised { .. } => {
+                crate::validate_tracker_consistency(&self.loaded.store, &identity)?;
+            }
+        }
         self.refresh_exhaustion_after_scan(&scan_result);
         let scan_findings = crate::collect_scan_findings(&scan_result, &self.loaded.workspace_dir);
         let evaluated = self.evaluate(&scan_findings);
@@ -425,7 +560,17 @@ impl SessionState {
                 .current_step
                 .clone()
                 .ok_or(SessionError::NoCurrentStep)?;
-            self.ensure_current_step_can_complete(&current_step, &evaluated)?;
+            // The operator's reference stands in for the acquisition step's
+            // trigger, but its preconditions still gate. A bound step uses the
+            // normal readiness check; a promised step enforces the acquisition
+            // protocol's preconditions directly.
+            if matches!(self.scope, SessionScope::Bound(_)) {
+                self.ensure_current_step_can_complete(&current_step, &evaluated)?;
+            } else {
+                let protocol = self.protocol(&current_step.protocol)?;
+                crate::enforce_preconditions(protocol, &self.loaded.store, None)
+                    .map_err(SessionError::Precondition)?;
+            }
         }
         Ok(ReconciledScan {
             scan_result,
@@ -446,8 +591,56 @@ impl SessionState {
             &self.loaded,
             &self.working_dir,
             scan_findings,
-            crate::EvaluationScope::Scoped(&self.work_unit),
+            self.evaluation_scope(),
         )
+    }
+
+    fn evaluation_scope(&self) -> crate::EvaluationScope<'_> {
+        match &self.scope {
+            SessionScope::Bound(work_unit) => crate::EvaluationScope::Scoped(work_unit),
+            SessionScope::Promised { .. } => crate::EvaluationScope::Unscoped,
+        }
+    }
+
+    fn context_work_unit(&self) -> Option<&str> {
+        match &self.scope {
+            SessionScope::Bound(work_unit) => Some(work_unit),
+            SessionScope::Promised { .. } => None,
+        }
+    }
+
+    fn acquisition_protocol(&self) -> Result<&str, SessionError> {
+        match &self.scope {
+            SessionScope::Promised { acquisition, .. } => Ok(acquisition),
+            SessionScope::Bound(_) => Err(SessionError::NoCurrentStep),
+        }
+    }
+
+    /// Resolve a promised scope to the materialized work-unit and bind it.
+    ///
+    /// No-op when already bound. Errors when acquisition produced no matching
+    /// work-unit ([`EntryError::Unresolved`]) or the recorded work-unit fails
+    /// scoped-identity validation.
+    fn bind_promise(&mut self) -> Result<(), SessionError> {
+        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let ticket = match &self.scope {
+            SessionScope::Promised { ticket, .. } => ticket.clone(),
+            SessionScope::Bound(_) => return Ok(()),
+        };
+        match crate::resolve_promise(&self.loaded.store, &identity, &ticket)? {
+            Some(work_unit) => {
+                crate::validate_scoped_work_unit_with_identity(
+                    &self.loaded.store,
+                    &work_unit,
+                    &identity,
+                )?;
+                self.scope = SessionScope::Bound(work_unit);
+                Ok(())
+            }
+            None => Err(SessionError::Entry(crate::EntryError::Unresolved {
+                reference: ticket.display,
+            })),
+        }
     }
 
     fn select_next(
@@ -652,6 +845,200 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     fn write_session_project(dir: &Path) -> PathBuf {
         write_session_project_with_work_unit(dir, true)
+    }
+
+    /// A methodology with an unscoped acquisition surface (`decompose` produces
+    /// `work-unit`) and a scoped `take`, plus a GitHub forge deployment. When
+    /// `materialize` is set, a matching `work-unit` for ticket 14 is present.
+    fn write_entry_project(dir: &Path, materialize: bool) -> PathBuf {
+        write_entry_project_with_acquisition_requires(dir, materialize, false)
+    }
+
+    /// `acquisition_requires_request` declares an unmet `requires` on the
+    /// acquisition surface so its preconditions block at cold-start entry.
+    fn write_entry_project_with_acquisition_requires(
+        dir: &Path,
+        materialize: bool,
+        acquisition_requires_request: bool,
+    ) -> PathBuf {
+        let decompose_requires = if acquisition_requires_request {
+            "requires = [\"request\"]\n"
+        } else {
+            ""
+        };
+        let manifest = format!(
+            r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[artifact_types]]
+name = "request"
+
+[[artifact_types]]
+name = "claim"
+
+[[protocols]]
+name = "decompose"
+{decompose_requires}produces = ["work-unit"]
+scoped = false
+trigger = {{ type = "on_artifact", name = "request" }}
+
+[[protocols]]
+name = "take"
+requires = ["work-unit"]
+produces = ["claim"]
+scoped = true
+trigger = {{ type = "on_artifact", name = "work-unit" }}
+"#
+        );
+        let manifest_path = crate::test_helpers::write_methodology(
+            dir,
+            &manifest,
+            &[
+                (
+                    "work-unit",
+                    r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+                ),
+                (
+                    "request",
+                    r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+                ),
+                (
+                    "claim",
+                    r#"{"type":"object","required":["work_unit","scope"],"properties":{"work_unit":{"type":"string"},"scope":{"type":"string"}}}"#,
+                ),
+            ],
+            &["decompose", "take"],
+        );
+        let project_dir = dir.join("project");
+        fs::create_dir(&project_dir).unwrap();
+        let runa_dir = project_dir.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        let manifest_path = fs::canonicalize(manifest_path).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
+            format!(
+                "methodology_path = {:?}\n\n[forge]\ntype = \"github\"\nowner = \"tesserine\"\nname = \"runa\"\n",
+                manifest_path.display().to_string()
+            ),
+        )
+        .unwrap();
+        fs::write(
+            runa_dir.join("state.toml"),
+            "initialized_at = \"2026-06-11T00:00:00Z\"\nruna_version = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let workspace = project_dir.join(".runa/workspace");
+        fs::create_dir_all(workspace.join("work-unit")).unwrap();
+        if materialize {
+            write_acquired_work_unit(&workspace);
+        }
+        project_dir
+    }
+
+    fn write_acquired_work_unit(workspace: &Path) {
+        fs::create_dir_all(workspace.join("work-unit")).unwrap();
+        fs::write(
+            workspace.join("work-unit/work-unit-14-cold-start.json"),
+            r#"{"title":"Cold start","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}"#,
+        )
+        .unwrap();
+    }
+
+    fn ticket_14() -> crate::TicketRef {
+        crate::TicketRef {
+            number: 14,
+            tracker_identity: "github:tesserine/runa:14".to_string(),
+            display: "github:tesserine/runa#14".to_string(),
+        }
+    }
+
+    #[test]
+    fn open_entry_cold_pins_acquisition_step() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_entry_project(dir.path(), false);
+
+        let session =
+            SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(())).unwrap();
+
+        let step = session.current_step().expect("acquisition step pinned");
+        assert_eq!(step.protocol, "decompose");
+        assert_eq!(step.work_unit, None);
+        assert!(matches!(session.scope, SessionScope::Promised { .. }));
+    }
+
+    #[test]
+    fn open_entry_blocks_when_acquisition_preconditions_unmet() {
+        let dir = tempfile::tempdir().unwrap();
+        // decompose requires an absent `request`; entry substitutes only the
+        // trigger, so the unmet precondition must still block.
+        let project_dir = write_entry_project_with_acquisition_requires(dir.path(), false, true);
+
+        let result = SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(()));
+
+        assert!(matches!(result, Err(SessionError::Precondition(_))));
+    }
+
+    #[test]
+    fn open_entry_binds_immediately_when_work_unit_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_entry_project(dir.path(), true);
+
+        let session =
+            SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(())).unwrap();
+
+        let step = session.current_step().expect("bound session selects take");
+        assert_eq!(step.protocol, "take");
+        assert_eq!(step.work_unit.as_deref(), Some("work-unit-14-cold-start"));
+        assert!(matches!(session.scope, SessionScope::Bound(_)));
+    }
+
+    #[test]
+    fn advance_from_acquisition_binds_and_selects_take() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_entry_project(dir.path(), false);
+        let mut session =
+            SessionState::open_entry(project_dir.clone(), None, ticket_14(), |_, _| Ok(()))
+                .unwrap();
+
+        // The acquisition agent materializes the work-unit.
+        write_acquired_work_unit(&project_dir.join(".runa/workspace"));
+
+        let advance = session
+            .advance_with_validator(|_, _| Ok(()))
+            .expect("advance binds the promised scope");
+
+        assert_eq!(advance.payload.completed_step.protocol, "decompose");
+        assert_eq!(
+            advance
+                .payload
+                .next_step
+                .as_ref()
+                .map(|s| s.protocol.as_str()),
+            Some("take")
+        );
+        assert!(matches!(session.scope, SessionScope::Bound(_)));
+    }
+
+    #[test]
+    fn advance_without_materialized_work_unit_is_unresolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_entry_project(dir.path(), false);
+        let mut session =
+            SessionState::open_entry(project_dir.clone(), None, ticket_14(), |_, _| Ok(()))
+                .unwrap();
+
+        let advance = session.advance_with_validator(|_, _| Ok(()));
+
+        assert!(matches!(
+            advance,
+            Err(SessionError::Postcondition(_))
+                | Err(SessionError::Entry(crate::EntryError::Unresolved { .. }))
+        ));
+        assert!(matches!(session.scope, SessionScope::Promised { .. }));
+        assert_no_execution_record(&project_dir, "decompose");
     }
 
     #[test]

--- a/libagent/src/store.rs
+++ b/libagent/src/store.rs
@@ -590,6 +590,21 @@ impl ArtifactStore {
         self.persist_execution_records()
     }
 
+    /// Remove the execution record for `(protocol, work_unit)` and persist.
+    ///
+    /// Used to roll back a recorded step whose downstream commit did not hold —
+    /// e.g. a cold-start acquisition that produced an artifact but did not bind
+    /// the promised ticket. A no-op when no such record exists.
+    pub fn clear_execution_record(
+        &mut self,
+        protocol: &str,
+        work_unit: Option<&str>,
+    ) -> Result<(), StoreError> {
+        self.execution_records
+            .remove(&(protocol.to_string(), work_unit.map(str::to_owned)));
+        self.persist_execution_records()
+    }
+
     pub(crate) fn stage_execution_record(
         &mut self,
         protocol: &str,

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -8,7 +8,9 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
-use libagent::{Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanResult, TicketRef};
+use libagent::{
+    Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanFindings, ScanResult, TicketRef,
+};
 
 use crate::commands::CommandError;
 use crate::commands::step::{PlannedEntry, StepError, resolved_runtime_env};
@@ -76,13 +78,20 @@ pub(crate) fn promised_scope_token(ticket: &TicketRef) -> String {
 ///
 /// The entry's trigger is the ticket reference; its context carries the
 /// reference (and nothing of the ticket's content) plus the acquisition
-/// protocol's own instructions and inputs.
+/// protocol's own instructions and inputs — withholding optional inputs from
+/// untrusted (changed or partially scanned) types, exactly as normal execution.
 pub(crate) fn acquisition_planned_entry(
     loaded: &LoadedProject,
     acquisition: &ProtocolDeclaration,
     ticket: &TicketRef,
+    scan_findings: &ScanFindings,
 ) -> PlannedEntry {
-    let mut context = libagent::context::build_context(acquisition, &loaded.store, None);
+    let mut context = libagent::context::build_execution_context(
+        acquisition,
+        &loaded.store,
+        None,
+        &scan_findings.affected_types,
+    );
     context.entry = Some(libagent::context::EntryDelivery {
         reference: ticket.display.clone(),
         ticket_number: ticket.number,

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -5,14 +5,44 @@
 //! the acquisition step the runtime serves. All forge identity logic lives in
 //! libagent; this module only adapts it to the CLI's plan/execution types.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
-use libagent::{Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanFindings, TicketRef};
+use libagent::{
+    Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanFindings, ScanResult, TicketRef,
+};
 
 use crate::commands::CommandError;
 use crate::commands::step::{PlannedEntry, StepError, resolved_runtime_env};
 use crate::project::LoadedProject;
+
+/// Why a cold-start acquisition cannot be served, if it cannot.
+///
+/// Entry substitutes only the acquisition's trigger; its `requires`
+/// preconditions and scan-trust gates still apply, exactly as normal readiness
+/// would block a protocol. Returns `None` when the acquisition is servable.
+pub(crate) fn acquisition_block_reason(
+    loaded: &LoadedProject,
+    acquisition: &ProtocolDeclaration,
+    scan_result: &ScanResult,
+) -> Option<String> {
+    if let Err(error) = libagent::enforce_preconditions(acquisition, &loaded.store, None) {
+        return Some(error.to_string());
+    }
+    let partially_scanned: HashSet<String> = scan_result
+        .partially_scanned_types
+        .iter()
+        .map(|partial| partial.artifact_type.clone())
+        .collect();
+    let incomplete = libagent::protocol_scan_incomplete_types(acquisition, &partially_scanned);
+    if !incomplete.is_empty() {
+        return Some(format!(
+            "acquisition input artifact type(s) {} were only partially scanned",
+            incomplete.join(", ")
+        ));
+    }
+    None
+}
 
 /// Parse and resolve a ticket reference against the project's forge deployment.
 pub(crate) fn resolve_reference(

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -26,22 +26,14 @@ pub(crate) fn acquisition_block_reason(
     acquisition: &ProtocolDeclaration,
     scan_result: &ScanResult,
 ) -> Option<String> {
-    if let Err(error) = libagent::enforce_preconditions(acquisition, &loaded.store, None) {
-        return Some(error.to_string());
-    }
     let partially_scanned: HashSet<String> = scan_result
         .partially_scanned_types
         .iter()
         .map(|partial| partial.artifact_type.clone())
         .collect();
-    let incomplete = libagent::protocol_scan_incomplete_types(acquisition, &partially_scanned);
-    if !incomplete.is_empty() {
-        return Some(format!(
-            "acquisition input artifact type(s) {} were only partially scanned",
-            incomplete.join(", ")
-        ));
-    }
-    None
+    libagent::check_acquisition_admissible(acquisition, &loaded.store, &partially_scanned)
+        .err()
+        .map(|block| block.to_string())
 }
 
 /// Parse and resolve a ticket reference against the project's forge deployment.

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -8,9 +8,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
-use libagent::{
-    Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanFindings, ScanResult, TicketRef,
-};
+use libagent::{Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanResult, TicketRef};
 
 use crate::commands::CommandError;
 use crate::commands::step::{PlannedEntry, StepError, resolved_runtime_env};
@@ -83,7 +81,6 @@ pub(crate) fn acquisition_planned_entry(
     loaded: &LoadedProject,
     acquisition: &ProtocolDeclaration,
     ticket: &TicketRef,
-    scan_findings: &ScanFindings,
 ) -> PlannedEntry {
     let mut context = libagent::context::build_context(acquisition, &loaded.store, None);
     context.entry = Some(libagent::context::EntryDelivery {
@@ -96,11 +93,13 @@ pub(crate) fn acquisition_planned_entry(
         work_unit: None,
         trigger: "ticket_entry".to_string(),
         context,
-        execution_record: libagent::protocol_execution_record(
+        // The ticket substitutes the trigger, so record the full trigger
+        // freshness baseline; a satisfied-only record would falsely suppress a
+        // later normal activation of this acquisition.
+        execution_record: libagent::protocol_entry_execution_record(
             acquisition,
             &loaded.store,
             None,
-            &scan_findings.affected_types,
         ),
     }
 }

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -1,0 +1,98 @@
+//! Cold-start ticket entry wiring shared by `go` and `run`.
+//!
+//! These helpers parse a forge ticket reference, resolve it against recorded
+//! work-units, discover the methodology's acquisition surface, and synthesize
+//! the acquisition step the runtime serves. All forge identity logic lives in
+//! libagent; this module only adapts it to the CLI's plan/execution types.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use libagent::{Config, ProtocolDeclaration, ResolvedForgeIdentity, ScanFindings, TicketRef};
+
+use crate::commands::CommandError;
+use crate::commands::step::{PlannedEntry, StepError, resolved_runtime_env};
+use crate::project::LoadedProject;
+
+/// Parse and resolve a ticket reference against the project's forge deployment.
+pub(crate) fn resolve_reference(
+    loaded: &LoadedProject,
+    raw: &str,
+) -> Result<(TicketRef, ResolvedForgeIdentity), StepError> {
+    let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+    let ticket =
+        libagent::resolve_ticket_reference(raw, &identity).map_err(StepError::TicketReference)?;
+    Ok((ticket, identity))
+}
+
+/// Resolve the reference to an already-recorded work-unit (re-entry), or `None`
+/// when the work-unit does not exist yet (cold start).
+pub(crate) fn resolve_existing(
+    loaded: &LoadedProject,
+    identity: &ResolvedForgeIdentity,
+    ticket: &TicketRef,
+) -> Result<Option<String>, StepError> {
+    libagent::resolve_promise(&loaded.store, identity, ticket)
+        .map_err(CommandError::from)
+        .map_err(StepError::from)
+}
+
+/// The methodology's acquisition surface — the sole unscoped producer of the
+/// `work-unit` artifact — cloned for plan construction.
+pub(crate) fn acquisition_surface(
+    loaded: &LoadedProject,
+) -> Result<ProtocolDeclaration, StepError> {
+    libagent::discover_acquisition_surface(&loaded.manifest.protocols)
+        .cloned()
+        .map_err(StepError::TicketReference)
+}
+
+/// The provisional scope id used in projections before the work-unit exists.
+pub(crate) fn promised_scope_token(ticket: &TicketRef) -> String {
+    format!("work-unit-{}", ticket.number)
+}
+
+/// Build the synthesized acquisition planned entry for a cold ticket entry.
+///
+/// The entry's trigger is the ticket reference; its context carries the
+/// reference (and nothing of the ticket's content) plus the acquisition
+/// protocol's own instructions and inputs.
+pub(crate) fn acquisition_planned_entry(
+    loaded: &LoadedProject,
+    acquisition: &ProtocolDeclaration,
+    ticket: &TicketRef,
+    scan_findings: &ScanFindings,
+) -> PlannedEntry {
+    let mut context = libagent::context::build_context(acquisition, &loaded.store, None);
+    context.entry = Some(libagent::context::EntryDelivery {
+        reference: ticket.display.clone(),
+        ticket_number: ticket.number,
+        tracker_identity: ticket.tracker_identity.clone(),
+    });
+    PlannedEntry {
+        protocol: acquisition.name.clone(),
+        work_unit: None,
+        trigger: "ticket_entry".to_string(),
+        context,
+        execution_record: libagent::protocol_execution_record(
+            acquisition,
+            &loaded.store,
+            None,
+            &scan_findings.affected_types,
+        ),
+    }
+}
+
+/// Runtime env for an entry step: the forge atoms plus the entry ticket number.
+pub(crate) fn entry_runtime_env(
+    working_dir: &Path,
+    config: &Config,
+    ticket: &TicketRef,
+) -> BTreeMap<String, String> {
+    let mut env = resolved_runtime_env(working_dir, config);
+    env.insert(
+        libagent::RUNA_ENTRY_TICKET.to_string(),
+        ticket.number.to_string(),
+    );
+    env
+}

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -80,9 +80,11 @@ fn run_ticket(
     config_override: Option<&Path>,
     ticket: &str,
 ) -> Result<StepOutcome, StepError> {
-    let (loaded, _scan_result) = super::load_and_scan(working_dir, config_override)?;
+    let (loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
     let (ticket_ref, identity) = entry::resolve_reference(&loaded, ticket)?;
 
+    // Re-entry (the work-unit already exists) degrades to a bound session and
+    // needs no acquisition surface — resolve before discovering it.
     if let Some(work_unit) = entry::resolve_existing(&loaded, &identity, &ticket_ref)? {
         println!(
             "Ticket {} resolves to recorded work-unit {work_unit}",
@@ -93,9 +95,9 @@ fn run_ticket(
 
     let acquisition = entry::acquisition_surface(&loaded)?;
 
-    // Entry substitutes only the trigger; the acquisition's preconditions still
-    // gate. Block before launching the agent when they are unmet.
-    if libagent::enforce_preconditions(&acquisition, &loaded.store, None).is_err() {
+    // Entry substitutes only the trigger; the acquisition's preconditions and
+    // scan trust still gate. Block before launching the agent when unmet.
+    if entry::acquisition_block_reason(&loaded, &acquisition, &scan_result).is_some() {
         println!("No READY protocols.");
         return Ok(StepOutcome::Blocked);
     }

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -4,10 +4,10 @@ use std::io;
 use std::path::Path;
 
 use crate::commands::step::{
-    ExecutionOptions, PlanEntry, StepError, StepOutcome, build_session_mcp_config, execute_entry,
-    locate_runa_mcp,
+    ExecutionOptions, PlanEntry, StepError, StepOutcome, build_session_mcp_config,
+    build_session_ticket_mcp_config, execute_entry, locate_runa_mcp,
 };
-use crate::commands::{CommandError, protocol_eval};
+use crate::commands::{CommandError, entry, protocol_eval};
 
 fn configured_agent_command(
     working_dir: &Path,
@@ -57,6 +57,157 @@ fn session_advance_receipt_matches(
 }
 
 pub fn run(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+    work_unit: Option<&str>,
+    ticket: Option<&str>,
+) -> Result<StepOutcome, StepError> {
+    match (work_unit, ticket) {
+        (Some(work_unit), _) => run_bound(working_dir, config_override, work_unit),
+        (None, Some(ticket)) => run_ticket(working_dir, config_override, ticket),
+        (None, None) => unreachable!("clap requires --work-unit or --ticket"),
+    }
+}
+
+/// Advance a session opened from a forge ticket reference by one tick.
+///
+/// Re-entry (the work-unit already exists) degrades to a normal bound tick.
+/// Otherwise this tick is the acquisition step: the runtime serves the
+/// methodology's acquisition surface, the agent materializes the work-unit, and
+/// the session binds — leaving `take` ready on the acquired work-unit.
+fn run_ticket(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+    ticket: &str,
+) -> Result<StepOutcome, StepError> {
+    let agent_command = configured_agent_command(working_dir, config_override)?;
+    let (loaded, _scan_result) = super::load_and_scan(working_dir, config_override)?;
+    let (ticket_ref, identity) = entry::resolve_reference(&loaded, ticket)?;
+
+    if let Some(work_unit) = entry::resolve_existing(&loaded, &identity, &ticket_ref)? {
+        println!(
+            "Ticket {} resolves to recorded work-unit {work_unit}",
+            ticket_ref.display
+        );
+        return run_bound(working_dir, config_override, &work_unit);
+    }
+
+    let acquisition = entry::acquisition_surface(&loaded)?;
+
+    // Entry substitutes only the trigger; the acquisition's preconditions still
+    // gate. Block before launching the agent when they are unmet.
+    if libagent::enforce_preconditions(&acquisition, &loaded.store, None).is_err() {
+        println!("No READY protocols.");
+        return Ok(StepOutcome::Blocked);
+    }
+
+    let config_path = crate::project::resolve_config(working_dir, config_override)
+        .map_err(CommandError::from)
+        .map_err(StepError::from)?;
+    let runtime_env = entry::entry_runtime_env(working_dir, &loaded.config, &ticket_ref);
+    let transcript_settings =
+        libagent::transcript::resolve_transcript_settings(working_dir, &loaded.config.transcript);
+    let mcp_binary = locate_runa_mcp()?;
+    let receipt_dir = tempfile::Builder::new()
+        .prefix("runa-go-advance-")
+        .tempdir()
+        .map_err(|source| receipt_io_error("session_advance_receipt_create", source))?;
+    let receipt_path = receipt_dir.path().join("advance.json");
+    let receipt_path_env = receipt_path.to_string_lossy().into_owned();
+    let mut mcp_config = build_session_ticket_mcp_config(
+        &mcp_binary.to_string_lossy(),
+        working_dir,
+        &config_path,
+        ticket,
+        &runtime_env,
+    );
+    mcp_config.env.insert(
+        libagent::SESSION_ADVANCE_RECEIPT_ENV.to_string(),
+        receipt_path_env.clone(),
+    );
+    let plan_entry = PlanEntry {
+        protocol: "go".to_string(),
+        work_unit: None,
+        trigger: "ticket_entry".to_string(),
+        mcp_config,
+        context: libagent::context::ContextInjection {
+            protocol: "go".to_string(),
+            work_unit: None,
+            instructions: tick_prompt().to_string(),
+            inputs: Vec::new(),
+            entry: None,
+            expected_outputs: libagent::context::ExpectedOutputs {
+                produces: Vec::new(),
+                may_produce: Vec::new(),
+                required_output_choices: Vec::new(),
+            },
+        },
+        execution_record: libagent::ExecutionRecord {
+            input_modes: BTreeMap::new(),
+            inputs: Default::default(),
+        },
+    };
+
+    execute_entry(
+        working_dir,
+        &agent_command,
+        &plan_entry,
+        ExecutionOptions {
+            extra_env: runtime_env
+                .into_iter()
+                .chain([(
+                    libagent::SESSION_ADVANCE_RECEIPT_ENV.to_string(),
+                    receipt_path_env,
+                )])
+                .collect(),
+            transcript_settings: Some(transcript_settings),
+            ..ExecutionOptions::default()
+        },
+    )?;
+
+    if !session_advance_receipt_matches(&receipt_path, &acquisition.name, None)? {
+        return Err(StepError::SessionDidNotAdvance {
+            protocol: acquisition.name.clone(),
+            work_unit: None,
+        });
+    }
+
+    let mut loaded = crate::project::load(working_dir, config_override)
+        .map_err(CommandError::from)
+        .map_err(StepError::from)?;
+    let scan_result =
+        libagent::scan(&loaded.workspace_dir, &mut loaded.store).map_err(|source| {
+            StepError::PostExecutionScan {
+                protocol: acquisition.name.clone(),
+                work_unit: None,
+                source,
+            }
+        })?;
+    let work_unit = entry::resolve_existing(&loaded, &identity, &ticket_ref)?.ok_or_else(|| {
+        StepError::TicketReference(libagent::EntryError::Unresolved {
+            reference: ticket_ref.display.clone(),
+        })
+    })?;
+
+    let scope = libagent::EvaluationScope::Scoped(&work_unit);
+    let refreshed =
+        crate::commands::step::evaluate_execution_state(&loaded, working_dir, &scan_result, scope);
+
+    println!(
+        "Acquired work-unit {work_unit} from ticket {}",
+        ticket_ref.display
+    );
+    println!();
+    protocol_eval::print_group("READY", &refreshed.evaluated.ready);
+    println!();
+    protocol_eval::print_group("BLOCKED", &refreshed.evaluated.blocked);
+    println!();
+    protocol_eval::print_group("WAITING", &refreshed.evaluated.waiting);
+
+    Ok(StepOutcome::Success)
+}
+
+fn run_bound(
     working_dir: &Path,
     config_override: Option<&Path>,
     work_unit: &str,
@@ -121,6 +272,7 @@ pub fn run(
             work_unit: Some(work_unit.to_string()),
             instructions: tick_prompt().to_string(),
             inputs: Vec::new(),
+            entry: None,
             expected_outputs: libagent::context::ExpectedOutputs {
                 produces: Vec::new(),
                 may_produce: Vec::new(),

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -80,7 +80,6 @@ fn run_ticket(
     config_override: Option<&Path>,
     ticket: &str,
 ) -> Result<StepOutcome, StepError> {
-    let agent_command = configured_agent_command(working_dir, config_override)?;
     let (loaded, _scan_result) = super::load_and_scan(working_dir, config_override)?;
     let (ticket_ref, identity) = entry::resolve_reference(&loaded, ticket)?;
 
@@ -101,6 +100,10 @@ fn run_ticket(
         return Ok(StepOutcome::Blocked);
     }
 
+    // The agent is required only once the ticket and acquisition surface are
+    // validated, so a bad reference or unsupported manifest reports its own
+    // error class rather than a missing-agent config failure.
+    let agent_command = configured_agent_command(working_dir, config_override)?;
     let config_path = crate::project::resolve_config(working_dir, config_override)
         .map_err(CommandError::from)
         .map_err(StepError::from)?;

--- a/runa-cli/src/commands/mod.rs
+++ b/runa-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ use libagent::ScanResult;
 use crate::project::{self, LoadedProject, ProjectError};
 
 pub mod doctor;
+pub mod entry;
 pub mod go;
 pub mod init;
 pub mod list;

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -500,11 +500,11 @@ pub fn run(
             );
         }
         // Entry substitutes only the trigger; the acquisition's preconditions
-        // still gate. Block before launching the agent when they are unmet.
+        // and scan trust still gate. Block before launching the agent when unmet.
         let acquisition = entry::acquisition_surface(&loaded).map_err(RunError::from)?;
-        if let Err(blocked) = libagent::enforce_preconditions(&acquisition, &loaded.store, None) {
+        if let Some(reason) = entry::acquisition_block_reason(&loaded, &acquisition, &scan_result) {
             println!("Run outcome: {}", RunOutcome::QuiescentBlocked.label());
-            println!("{blocked}");
+            println!("{reason}");
             return Ok(RunOutcome::QuiescentBlocked);
         }
         let agent_command = resolve_agent_command(
@@ -761,12 +761,10 @@ fn run_ticket_dry_run(
     json_output: bool,
 ) -> Result<RunOutcome, RunError> {
     let acquisition = entry::acquisition_surface(loaded).map_err(RunError::from)?;
-    // Entry substitutes only the trigger; the acquisition's preconditions still
-    // gate. When they are unmet the cascade projects nothing and the outcome is
-    // blocked.
-    let precondition_failure = libagent::enforce_preconditions(&acquisition, &loaded.store, None)
-        .err()
-        .map(|error| error.to_string());
+    // Entry substitutes only the trigger; the acquisition's preconditions and
+    // scan trust still gate. When unmet the cascade projects nothing and the
+    // outcome is blocked.
+    let block_reason = entry::acquisition_block_reason(loaded, &acquisition, scan_result);
     let scan_findings = libagent::collect_scan_findings(scan_result, &loaded.workspace_dir);
     let config_path = crate::project::resolve_config(working_dir, config_override)
         .map_err(CommandError::from)
@@ -879,7 +877,7 @@ fn run_ticket_dry_run(
             ticket_ref.display, acquisition.name
         );
         println!();
-        if let Some(reason) = &precondition_failure {
+        if let Some(reason) = &block_reason {
             println!("Execution plan: none (acquisition blocked)");
             println!();
             println!("{reason}");
@@ -902,7 +900,7 @@ fn run_ticket_dry_run(
         }
     }
 
-    if precondition_failure.is_some() {
+    if block_reason.is_some() {
         Ok(RunOutcome::QuiescentBlocked)
     } else {
         Ok(RunOutcome::AllComplete)

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -518,6 +518,7 @@ pub fn run(
             working_dir,
             config_override,
             &mut loaded,
+            &scan_result,
             &ticket_ref,
             &identity,
             &agent_command,
@@ -778,7 +779,8 @@ fn run_ticket_dry_run(
     let runtime_env = entry::entry_runtime_env(working_dir, &loaded.config, ticket_ref);
     let preview_command = preview_runa_mcp_command();
 
-    let entry_planned = entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref);
+    let entry_planned =
+        entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref, &scan_findings);
     let concrete = build_plan_entries(
         vec![entry_planned],
         &preview_command,
@@ -917,12 +919,15 @@ fn acquire_ticket(
     working_dir: &Path,
     config_override: Option<&Path>,
     loaded: &mut crate::project::LoadedProject,
+    scan_result: &libagent::ScanResult,
     ticket_ref: &libagent::TicketRef,
     identity: &libagent::ResolvedForgeIdentity,
     agent_command: &[String],
 ) -> Result<(String, libagent::ScanResult), RunError> {
     let acquisition = entry::acquisition_surface(loaded).map_err(RunError::from)?;
-    let entry_planned = entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref);
+    let scan_findings = libagent::collect_scan_findings(scan_result, &loaded.workspace_dir);
+    let entry_planned =
+        entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref, &scan_findings);
     let config_path = crate::project::resolve_config(working_dir, config_override)
         .map_err(CommandError::from)
         .map_err(StepError::from)

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::path::Path;
 use std::process;
@@ -12,12 +12,12 @@ use serde::{Serialize, Serializer};
 use tracing::info;
 
 use super::CommandError;
-use crate::commands::protocol_eval;
 use crate::commands::step::{
     ExecutionOptions, ExecutionState, McpServerConfig, PlanEntry, PlannedEntry, StepError,
     build_plan_entries, evaluate_execution_state, execute_entry, locate_runa_mcp,
     preview_runa_mcp_command,
 };
+use crate::commands::{entry, protocol_eval};
 use crate::exit_codes::ExitCode;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,6 +137,25 @@ struct RunJson<'a> {
     scan_warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cycle: Option<Vec<String>>,
+    execution_plan: Vec<RunPlanJson>,
+    protocols: Vec<protocol_eval::ProtocolJson>,
+}
+
+#[derive(Serialize)]
+struct EntryJson {
+    reference: String,
+    ticket_number: u64,
+    acquisition_protocol: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_work_unit: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RunEntryJson<'a> {
+    version: u32,
+    methodology: &'a str,
+    entry: EntryJson,
+    scan_warnings: Vec<String>,
     execution_plan: Vec<RunPlanJson>,
     protocols: Vec<protocol_eval::ProtocolJson>,
 }
@@ -343,8 +362,8 @@ fn execute_and_reconcile(
     config_path: &Path,
     mcp_command: &str,
     next_entry: PlannedEntry,
+    runtime_env: &BTreeMap<String, String>,
 ) -> Result<ReconcileOutcome, StepError> {
-    let runtime_env = crate::commands::step::resolved_runtime_env(working_dir, &loaded.config);
     let transcript_settings =
         libagent::transcript::resolve_transcript_settings(working_dir, &loaded.config.transcript);
     let execution_entry = build_plan_entries(
@@ -352,7 +371,7 @@ fn execute_and_reconcile(
         mcp_command,
         working_dir,
         config_path,
-        &runtime_env,
+        runtime_env,
     )
     .into_iter()
     .next()
@@ -364,7 +383,7 @@ fn execute_and_reconcile(
         &execution_entry,
         ExecutionOptions {
             isolate_process_group: true,
-            extra_env: runtime_env,
+            extra_env: runtime_env.clone(),
             transcript_settings: Some(transcript_settings),
         },
     )?;
@@ -429,12 +448,14 @@ fn refresh_state_after_scan(
     evaluate_execution_state(loaded, working_dir, scan_result, scope)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     working_dir: &Path,
     config_override: Option<&Path>,
     dry_run: bool,
     json_output: bool,
     work_unit: Option<&str>,
+    ticket: Option<&str>,
     cli_agent_command_present: bool,
     cli_agent_command_argv: &[String],
 ) -> Result<RunOutcome, RunError> {
@@ -445,10 +466,105 @@ pub fn run(
     let (mut loaded, scan_result) = super::load_and_scan(working_dir, config_override)
         .map_err(StepError::from)
         .map_err(RunError::from)?;
-    super::validate_scoped_work_unit(&loaded, work_unit)
+
+    if let Some(raw) = ticket {
+        let (ticket_ref, identity) =
+            entry::resolve_reference(&loaded, raw).map_err(RunError::from)?;
+
+        // Re-entry: the work-unit already exists — behave as `--work-unit <id>`.
+        if let Some(work_unit) =
+            entry::resolve_existing(&loaded, &identity, &ticket_ref).map_err(RunError::from)?
+        {
+            return run_with_scope(
+                working_dir,
+                config_override,
+                dry_run,
+                json_output,
+                loaded,
+                scan_result,
+                Some(work_unit),
+                cli_agent_command_present,
+                cli_agent_command_argv,
+            );
+        }
+
+        // Cold: project the entry cascade, or execute acquisition then cascade.
+        if dry_run {
+            return run_ticket_dry_run(
+                &loaded,
+                working_dir,
+                config_override,
+                &scan_result,
+                &ticket_ref,
+                json_output,
+            );
+        }
+        // Entry substitutes only the trigger; the acquisition's preconditions
+        // still gate. Block before launching the agent when they are unmet.
+        let acquisition = entry::acquisition_surface(&loaded).map_err(RunError::from)?;
+        if let Err(blocked) = libagent::enforce_preconditions(&acquisition, &loaded.store, None) {
+            println!("Run outcome: {}", RunOutcome::QuiescentBlocked.label());
+            println!("{blocked}");
+            return Ok(RunOutcome::QuiescentBlocked);
+        }
+        let agent_command = resolve_agent_command(
+            working_dir,
+            config_override,
+            cli_agent_command_present,
+            cli_agent_command_argv,
+        )?;
+        let (work_unit, scan_result) = acquire_ticket(
+            working_dir,
+            config_override,
+            &mut loaded,
+            &scan_result,
+            &ticket_ref,
+            &identity,
+            &agent_command,
+        )?;
+        return run_with_scope(
+            working_dir,
+            config_override,
+            dry_run,
+            json_output,
+            loaded,
+            scan_result,
+            Some(work_unit),
+            cli_agent_command_present,
+            cli_agent_command_argv,
+        );
+    }
+
+    run_with_scope(
+        working_dir,
+        config_override,
+        dry_run,
+        json_output,
+        loaded,
+        scan_result,
+        work_unit.map(str::to_owned),
+        cli_agent_command_present,
+        cli_agent_command_argv,
+    )
+}
+
+/// Execute the cascade for a fixed scope (a delegated work-unit or unscoped).
+#[allow(clippy::too_many_arguments)]
+fn run_with_scope(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+    dry_run: bool,
+    json_output: bool,
+    mut loaded: crate::project::LoadedProject,
+    scan_result: libagent::ScanResult,
+    work_unit: Option<String>,
+    cli_agent_command_present: bool,
+    cli_agent_command_argv: &[String],
+) -> Result<RunOutcome, RunError> {
+    super::validate_scoped_work_unit(&loaded, work_unit.as_deref())
         .map_err(StepError::from)
         .map_err(RunError::from)?;
-    let scope = match work_unit {
+    let scope = match work_unit.as_deref() {
         Some(work_unit) => libagent::EvaluationScope::Scoped(work_unit),
         None => libagent::EvaluationScope::Unscoped,
     };
@@ -538,6 +654,7 @@ pub fn run(
         .to_string_lossy()
         .into_owned();
     let interrupts = InterruptState::install()?;
+    let runtime_env = crate::commands::step::resolved_runtime_env(working_dir, &loaded.config);
     let mut exhausted = HashSet::new();
     let mut failed = HashSet::new();
     let mut executed_any = false;
@@ -570,6 +687,7 @@ pub fn run(
             &config_path,
             &mcp_command,
             next_entry,
+            &runtime_env,
         ) {
             Ok(ReconcileOutcome::Succeeded {
                 scan_result,
@@ -628,6 +746,227 @@ pub fn run(
             Err(err) => return Err(RunError::from(err)),
         }
     }
+}
+
+/// Project the cold-start ticket entry cascade without executing any agent.
+///
+/// The acquisition step is `current`; the work-unit it would produce seeds the
+/// projection so `take` appears next on the acquired work-unit.
+fn run_ticket_dry_run(
+    loaded: &crate::project::LoadedProject,
+    working_dir: &Path,
+    config_override: Option<&Path>,
+    scan_result: &libagent::ScanResult,
+    ticket_ref: &libagent::TicketRef,
+    json_output: bool,
+) -> Result<RunOutcome, RunError> {
+    let acquisition = entry::acquisition_surface(loaded).map_err(RunError::from)?;
+    // Entry substitutes only the trigger; the acquisition's preconditions still
+    // gate. When they are unmet the cascade projects nothing and the outcome is
+    // blocked.
+    let precondition_failure = libagent::enforce_preconditions(&acquisition, &loaded.store, None)
+        .err()
+        .map(|error| error.to_string());
+    let scan_findings = libagent::collect_scan_findings(scan_result, &loaded.workspace_dir);
+    let config_path = crate::project::resolve_config(working_dir, config_override)
+        .map_err(CommandError::from)
+        .map_err(StepError::from)
+        .map_err(RunError::from)?;
+    let runtime_env = entry::entry_runtime_env(working_dir, &loaded.config, ticket_ref);
+    let preview_command = preview_runa_mcp_command();
+
+    let entry_planned =
+        entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref, &scan_findings);
+    let concrete = build_plan_entries(
+        vec![entry_planned],
+        &preview_command,
+        working_dir,
+        &config_path,
+        &runtime_env,
+    )
+    .into_iter()
+    .next()
+    .expect("single planned entry must produce one execution entry");
+
+    let graph = libagent::DependencyGraph::build(&loaded.manifest.protocols).ok();
+    let fallback: Vec<&str> = loaded
+        .manifest
+        .protocols
+        .iter()
+        .map(|protocol| protocol.name.as_str())
+        .collect();
+    let topological_order: Vec<&str> = match &graph {
+        Some(graph) => graph.topological_order_excluding(&HashSet::new()),
+        None => fallback,
+    };
+    let promised_scope = entry::promised_scope_token(ticket_ref);
+    let projected = libagent::project_entry_cascade(
+        &loaded.manifest.protocols,
+        &loaded.store,
+        &topological_order,
+        &libagent::Candidate {
+            protocol_name: acquisition.name.clone(),
+            work_unit: None,
+        },
+        &promised_scope,
+        &scan_findings.affected_types,
+    );
+
+    let protocol_map: std::collections::HashMap<&str, &libagent::ProtocolDeclaration> = loaded
+        .manifest
+        .protocols
+        .iter()
+        .map(|protocol| (protocol.name.as_str(), protocol))
+        .collect();
+    let execution_plan: Vec<RunPlanJson> = projected
+        .into_iter()
+        .map(|candidate| match candidate.projection {
+            libagent::ProjectionClass::Current => RunPlanJson {
+                protocol: concrete.protocol.clone(),
+                work_unit: concrete.work_unit.clone(),
+                trigger: concrete.trigger.clone(),
+                projection: ProjectionKind::Current,
+                mcp_config: Some(concrete.mcp_config.clone()),
+                context: Some(concrete.context.clone()),
+            },
+            libagent::ProjectionClass::Projected => {
+                let trigger = protocol_map
+                    .get(candidate.protocol_name.as_str())
+                    .expect("projected protocol must exist in manifest")
+                    .trigger
+                    .to_string();
+                RunPlanJson {
+                    protocol: candidate.protocol_name,
+                    work_unit: candidate.work_unit,
+                    trigger,
+                    projection: ProjectionKind::Projected,
+                    mcp_config: None,
+                    context: None,
+                }
+            }
+        })
+        .collect();
+
+    let unscoped_state = evaluate_execution_state(
+        loaded,
+        working_dir,
+        scan_result,
+        libagent::EvaluationScope::Unscoped,
+    );
+
+    if json_output {
+        let payload = RunEntryJson {
+            version: 3,
+            methodology: &loaded.manifest.name,
+            entry: EntryJson {
+                reference: ticket_ref.display.clone(),
+                ticket_number: ticket_ref.number,
+                acquisition_protocol: acquisition.name.clone(),
+                resolved_work_unit: None,
+            },
+            scan_warnings: scan_findings.warnings.clone(),
+            execution_plan,
+            protocols: unscoped_state.evaluated.json_protocols(),
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).map_err(RunError::Json)?
+        );
+    } else {
+        println!("Methodology: {}", loaded.manifest.name);
+        println!(
+            "Entry: ticket {} (acquisition: {})",
+            ticket_ref.display, acquisition.name
+        );
+        println!();
+        if let Some(reason) = &precondition_failure {
+            println!("Execution plan: none (acquisition blocked)");
+            println!();
+            println!("{reason}");
+        } else {
+            println!("Execution plan:");
+            for (index, plan_entry) in execution_plan.iter().enumerate() {
+                let projection = match plan_entry.projection {
+                    ProjectionKind::Current => "current, entry",
+                    ProjectionKind::Projected => "projected",
+                };
+                match &plan_entry.work_unit {
+                    Some(work_unit) => println!(
+                        "  {}. {} (work_unit={work_unit}) [{projection}]",
+                        index + 1,
+                        plan_entry.protocol
+                    ),
+                    None => println!("  {}. {} [{projection}]", index + 1, plan_entry.protocol),
+                }
+            }
+        }
+    }
+
+    if precondition_failure.is_some() {
+        Ok(RunOutcome::QuiescentBlocked)
+    } else {
+        Ok(RunOutcome::AllComplete)
+    }
+}
+
+/// Execute the cold-start acquisition step and resolve the materialized
+/// work-unit. Returns the bound work-unit id and the post-acquisition scan.
+fn acquire_ticket(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+    loaded: &mut crate::project::LoadedProject,
+    scan_result: &libagent::ScanResult,
+    ticket_ref: &libagent::TicketRef,
+    identity: &libagent::ResolvedForgeIdentity,
+    agent_command: &[String],
+) -> Result<(String, libagent::ScanResult), RunError> {
+    let acquisition = entry::acquisition_surface(loaded).map_err(RunError::from)?;
+    let scan_findings = libagent::collect_scan_findings(scan_result, &loaded.workspace_dir);
+    let entry_planned =
+        entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref, &scan_findings);
+    let config_path = crate::project::resolve_config(working_dir, config_override)
+        .map_err(CommandError::from)
+        .map_err(StepError::from)
+        .map_err(RunError::from)?;
+    let mcp_command = locate_runa_mcp()
+        .map_err(RunError::from)?
+        .to_string_lossy()
+        .into_owned();
+    let runtime_env = entry::entry_runtime_env(working_dir, &loaded.config, ticket_ref);
+
+    let post_scan = match execute_and_reconcile(
+        working_dir,
+        loaded,
+        agent_command,
+        &config_path,
+        &mcp_command,
+        entry_planned,
+        &runtime_env,
+    )? {
+        ReconcileOutcome::Succeeded { scan_result, .. } => scan_result,
+        ReconcileOutcome::PostconditionFailure { .. } => {
+            return Err(RunError::from(StepError::TicketReference(
+                libagent::EntryError::Unresolved {
+                    reference: ticket_ref.display.clone(),
+                },
+            )));
+        }
+    };
+
+    println!(
+        "Executed: {} (entry from ticket {})",
+        acquisition.name, ticket_ref.display
+    );
+    let work_unit = entry::resolve_existing(loaded, identity, ticket_ref)
+        .map_err(RunError::from)?
+        .ok_or_else(|| {
+            RunError::from(StepError::TicketReference(
+                libagent::EntryError::Unresolved {
+                    reference: ticket_ref.display.clone(),
+                },
+            ))
+        })?;
+    Ok((work_unit, post_scan))
 }
 
 #[cfg(test)]

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -483,6 +483,7 @@ pub fn run(
                 loaded,
                 scan_result,
                 Some(work_unit),
+                false,
                 cli_agent_command_present,
                 cli_agent_command_argv,
             );
@@ -517,11 +518,12 @@ pub fn run(
             working_dir,
             config_override,
             &mut loaded,
-            &scan_result,
             &ticket_ref,
             &identity,
             &agent_command,
         )?;
+        // Acquisition already executed; carry that into the downstream outcome
+        // so a quiescent post-acquisition scope reports success, not nothing-ready.
         return run_with_scope(
             working_dir,
             config_override,
@@ -530,6 +532,7 @@ pub fn run(
             loaded,
             scan_result,
             Some(work_unit),
+            true,
             cli_agent_command_present,
             cli_agent_command_argv,
         );
@@ -543,6 +546,7 @@ pub fn run(
         loaded,
         scan_result,
         work_unit.map(str::to_owned),
+        false,
         cli_agent_command_present,
         cli_agent_command_argv,
     )
@@ -558,6 +562,7 @@ fn run_with_scope(
     mut loaded: crate::project::LoadedProject,
     scan_result: libagent::ScanResult,
     work_unit: Option<String>,
+    prior_execution: bool,
     cli_agent_command_present: bool,
     cli_agent_command_argv: &[String],
 ) -> Result<RunOutcome, RunError> {
@@ -644,7 +649,7 @@ fn run_with_scope(
     )?;
     let mut state = initial_state;
     if state.planned_entries.is_empty() {
-        let outcome = classify_live_outcome(&state.evaluated, false, false);
+        let outcome = classify_live_outcome(&state.evaluated, false, prior_execution);
         println!("Run outcome: {}", outcome.label());
         return Ok(outcome);
     }
@@ -657,7 +662,7 @@ fn run_with_scope(
     let runtime_env = crate::commands::step::resolved_runtime_env(working_dir, &loaded.config);
     let mut exhausted = HashSet::new();
     let mut failed = HashSet::new();
-    let mut executed_any = false;
+    let mut executed_any = prior_execution;
 
     loop {
         let next_entry = state.planned_entries.clone().into_iter().find(|entry| {
@@ -773,8 +778,7 @@ fn run_ticket_dry_run(
     let runtime_env = entry::entry_runtime_env(working_dir, &loaded.config, ticket_ref);
     let preview_command = preview_runa_mcp_command();
 
-    let entry_planned =
-        entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref, &scan_findings);
+    let entry_planned = entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref);
     let concrete = build_plan_entries(
         vec![entry_planned],
         &preview_command,
@@ -913,15 +917,12 @@ fn acquire_ticket(
     working_dir: &Path,
     config_override: Option<&Path>,
     loaded: &mut crate::project::LoadedProject,
-    scan_result: &libagent::ScanResult,
     ticket_ref: &libagent::TicketRef,
     identity: &libagent::ResolvedForgeIdentity,
     agent_command: &[String],
 ) -> Result<(String, libagent::ScanResult), RunError> {
     let acquisition = entry::acquisition_surface(loaded).map_err(RunError::from)?;
-    let scan_findings = libagent::collect_scan_findings(scan_result, &loaded.workspace_dir);
-    let entry_planned =
-        entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref, &scan_findings);
+    let entry_planned = entry::acquisition_planned_entry(loaded, &acquisition, ticket_ref);
     let config_path = crate::project::resolve_config(working_dir, config_override)
         .map_err(CommandError::from)
         .map_err(StepError::from)

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -957,16 +957,40 @@ fn acquire_ticket(
         "Executed: {} (entry from ticket {})",
         acquisition.name, ticket_ref.display
     );
-    let work_unit = entry::resolve_existing(loaded, identity, ticket_ref)
-        .map_err(RunError::from)?
-        .ok_or_else(|| {
-            RunError::from(StepError::TicketReference(
+    // The acquisition record is persisted; it only stands if the promise binds.
+    // When acquisition satisfied its contract but did not materialize a work-unit
+    // for this ticket, clear the record so no metadata claims the step completed.
+    match entry::resolve_existing(loaded, identity, ticket_ref) {
+        Ok(Some(work_unit)) => Ok((work_unit, post_scan)),
+        Ok(None) => {
+            clear_acquisition_record(loaded, &acquisition.name)?;
+            Err(RunError::from(StepError::TicketReference(
                 libagent::EntryError::Unresolved {
                     reference: ticket_ref.display.clone(),
                 },
-            ))
-        })?;
-    Ok((work_unit, post_scan))
+            )))
+        }
+        Err(error) => {
+            clear_acquisition_record(loaded, &acquisition.name)?;
+            Err(RunError::from(error))
+        }
+    }
+}
+
+fn clear_acquisition_record(
+    loaded: &mut crate::project::LoadedProject,
+    acquisition: &str,
+) -> Result<(), RunError> {
+    loaded
+        .store
+        .clear_execution_record(acquisition, None)
+        .map_err(|source| {
+            RunError::from(StepError::PostExecutionRecord {
+                protocol: acquisition.to_string(),
+                work_unit: None,
+                source,
+            })
+        })
 }
 
 #[cfg(test)]

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -58,6 +58,7 @@ pub enum StepError {
         work_unit: Option<String>,
         source: libagent::StoreError,
     },
+    TicketReference(libagent::EntryError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -171,6 +172,7 @@ impl fmt::Display for StepError {
                     "post-execution reconciliation failed for protocol '{protocol}': agent command succeeded but execution metadata could not be recorded: {source}"
                 ),
             },
+            StepError::TicketReference(err) => write!(f, "{err}"),
         }
     }
 }
@@ -189,6 +191,7 @@ impl std::error::Error for StepError {
             StepError::PostExecutionScan { source, .. } => Some(source),
             StepError::PostExecutionEnforcement { source, .. } => Some(source),
             StepError::PostExecutionRecord { source, .. } => Some(source),
+            StepError::TicketReference(source) => Some(source),
         }
     }
 }
@@ -207,6 +210,16 @@ impl StepError {
                 ExitCode::WorkFailed
             }
             StepError::SessionDidNotAdvance { .. } => ExitCode::WorkFailed,
+            StepError::TicketReference(err) => match err {
+                libagent::EntryError::InvalidReference { .. }
+                | libagent::EntryError::MissingDeploymentIdentity { .. }
+                | libagent::EntryError::DeploymentDisagreement { .. } => ExitCode::UsageError,
+                libagent::EntryError::Unresolved { .. } => ExitCode::WorkFailed,
+                libagent::EntryError::NoAcquisitionSurface { .. }
+                | libagent::EntryError::AmbiguousAcquisitionSurface { .. } => {
+                    ExitCode::InfrastructureFailure
+                }
+            },
             StepError::Command(_)
             | StepError::Json(_)
             | StepError::AgentCommandNotConfigured
@@ -1178,6 +1191,38 @@ pub(crate) fn build_session_mcp_config(
     }
 }
 
+pub(crate) fn build_session_ticket_mcp_config(
+    mcp_command: &str,
+    working_dir: &Path,
+    config_path: &Path,
+    ticket: &str,
+    runtime_env: &BTreeMap<String, String>,
+) -> McpServerConfig {
+    let working_dir = absolutize_path(working_dir, working_dir);
+    let config_path = absolutize_path(config_path, &working_dir);
+    let mut env = BTreeMap::new();
+    env.insert(
+        "RUNA_CONFIG".to_string(),
+        config_path.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "RUNA_WORKING_DIR".to_string(),
+        working_dir.to_string_lossy().into_owned(),
+    );
+    env.extend(libagent::transcript::transcript_env());
+    env.extend(runtime_env.clone());
+
+    McpServerConfig {
+        command: normalize_mcp_command(mcp_command, &working_dir),
+        args: vec![
+            "--session".to_string(),
+            "--ticket".to_string(),
+            ticket.to_string(),
+        ],
+        env,
+    }
+}
+
 fn normalize_mcp_command(command: &str, working_dir: &Path) -> String {
     let command_path = Path::new(command);
     if command_path.is_absolute() {
@@ -1325,6 +1370,7 @@ mod tests {
                 work_unit: work_unit.map(str::to_string),
                 instructions: "Tell the operator about SECRET_VALUE.".to_string(),
                 inputs: Vec::new(),
+                entry: None,
                 expected_outputs: libagent::context::ExpectedOutputs {
                     produces: vec!["claim".to_string()],
                     may_produce: Vec::new(),
@@ -1871,6 +1917,7 @@ cat >/dev/null
                 work_unit: None,
                 instructions: String::new(),
                 inputs: Vec::new(),
+                entry: None,
                 expected_outputs: libagent::context::ExpectedOutputs {
                     produces: vec!["implementation".to_string()],
                     may_produce: Vec::new(),

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -8,9 +8,7 @@ use std::process::{Command as ProcessCommand, ExitStatus, Stdio};
 use std::thread;
 
 use libagent::ExecutionRecord;
-use libagent::context::{
-    ArtifactRelationship, ContextInjection, ContextInjectionView, render_context_prompt,
-};
+use libagent::context::{ContextInjection, ContextInjectionView, render_context_prompt};
 use serde::{Serialize, Serializer};
 use tracing::{info, warn};
 
@@ -213,7 +211,8 @@ impl StepError {
             StepError::TicketReference(err) => match err {
                 libagent::EntryError::InvalidReference { .. }
                 | libagent::EntryError::MissingDeploymentIdentity { .. }
-                | libagent::EntryError::DeploymentDisagreement { .. } => ExitCode::UsageError,
+                | libagent::EntryError::DeploymentDisagreement { .. }
+                | libagent::EntryError::UnsupportedForge { .. } => ExitCode::UsageError,
                 libagent::EntryError::Unresolved { .. } => ExitCode::WorkFailed,
                 libagent::EntryError::NoAcquisitionSurface { .. }
                 | libagent::EntryError::AmbiguousAcquisitionSurface { .. } => {
@@ -379,17 +378,12 @@ pub(crate) fn build_execution_plan(
             let protocol = protocol_map
                 .get(entry.name.as_str())
                 .expect("planned protocol must exist in manifest");
-            let mut context = libagent::context::build_context(
+            let context = libagent::context::build_execution_context(
                 protocol,
                 &loaded.store,
                 entry.work_unit.as_deref(),
+                &scan_findings.affected_types,
             );
-            context.inputs.retain(|input| {
-                input.relationship == ArtifactRelationship::Requires
-                    || !scan_findings
-                        .affected_types
-                        .contains(input.artifact_type.as_str())
-            });
             PlannedEntry {
                 protocol: entry.name.clone(),
                 work_unit: entry.work_unit.clone(),

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -65,8 +65,12 @@ enum Commands {
     /// Advance a scoped interactive session by one operator tick
     Go {
         /// Delegated work unit to advance
+        #[arg(long, required_unless_present = "ticket", conflicts_with = "ticket")]
+        work_unit: Option<String>,
+
+        /// Open the session from a forge ticket reference (cold-start entry)
         #[arg(long)]
-        work_unit: String,
+        ticket: Option<String>,
     },
 }
 
@@ -83,6 +87,10 @@ struct RunArgs {
     /// Evaluate only the specified delegated work unit
     #[arg(long)]
     work_unit: Option<String>,
+
+    /// Open the cascade from a forge ticket reference (cold-start entry)
+    #[arg(long, conflicts_with = "work_unit")]
+    ticket: Option<String>,
 
     /// Override the live agent command; pass argv after `--`, for example `--agent-command -- <argv tokens>`
     #[arg(long = "agent-command")]
@@ -216,6 +224,7 @@ fn main() {
                 args.dry_run,
                 args.json,
                 args.work_unit.as_deref(),
+                args.ticket.as_deref(),
                 args.agent_command,
                 &args.agent_command_argv,
             ) {
@@ -228,8 +237,13 @@ fn main() {
                 Err(err) => fatal_command_error("run", &err, err.exit_code()),
             }
         }
-        Commands::Go { work_unit } => {
-            match commands::go::run(&working_dir, config_override_ref, &work_unit) {
+        Commands::Go { work_unit, ticket } => {
+            match commands::go::run(
+                &working_dir,
+                config_override_ref,
+                work_unit.as_deref(),
+                ticket.as_deref(),
+            ) {
                 Ok(outcome) => {
                     let exit_code = outcome.exit_code().code();
                     if exit_code != 0 {

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -538,6 +538,71 @@ fn go_ticket_blocks_when_acquisition_preconditions_unmet() {
     assert!(!log_path.exists(), "acquisition agent should not run");
 }
 
+/// Leave an unreadable `work-unit/*.json` so the type is only partially scanned.
+fn taint_work_unit_scan(project_dir: &Path) {
+    let wu_dir = project_dir.join(".runa/workspace/work-unit");
+    fs::create_dir_all(&wu_dir).unwrap();
+    let unreadable = wu_dir.join("hidden.json");
+    fs::write(
+        &unreadable,
+        r#"{"title":"hidden","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}"#,
+    )
+    .unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+}
+
+#[test]
+fn run_ticket_blocks_when_work_unit_scan_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+    taint_work_unit_scan(&project_dir);
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    // A no-match result is untrustworthy under a partial work-unit scan, so the
+    // ticket does not cold-start acquisition.
+    assert_eq!(output.status.code(), Some(6), "{output:?}");
+    assert!(
+        !log_path.exists(),
+        "must not cold-start under an incomplete work-unit scan"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("partially scanned"), "stderr: {stderr}");
+}
+
+#[test]
+fn go_ticket_blocks_when_work_unit_scan_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+    taint_work_unit_scan(&project_dir);
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("go")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6), "{output:?}");
+    assert!(
+        !log_path.exists(),
+        "must not cold-start under an incomplete work-unit scan"
+    );
+}
+
 #[test]
 fn run_ticket_rejects_foreign_deployment_reference() {
     let dir = tempfile::tempdir().unwrap();

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -529,6 +529,96 @@ fn run_ticket_reports_success_when_acquisition_is_the_only_work() {
     assert!(stdout.contains("Run outcome: success"), "stdout: {stdout}");
 }
 
+/// The acquisition triggers on `request` (which it does not require); the ticket
+/// substitutes that trigger.
+const TRIGGER_ONLY_ENTRY_MANIFEST: &str = r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "request"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[artifact_types]]
+name = "claim"
+
+[[protocols]]
+name = "decompose"
+produces = ["work-unit"]
+scoped = false
+trigger = { type = "on_artifact", name = "request" }
+
+[[protocols]]
+name = "take"
+requires = ["work-unit"]
+produces = ["claim"]
+scoped = true
+trigger = { type = "on_artifact", name = "work-unit" }
+"#;
+
+fn setup_trigger_only_entry_project(dir: &Path) -> PathBuf {
+    let manifest_path = common::write_methodology(
+        dir,
+        TRIGGER_ONLY_ENTRY_MANIFEST,
+        &[
+            (
+                "request",
+                r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+            ),
+            (
+                "work-unit",
+                r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+            ),
+            (
+                "claim",
+                r#"{"type":"object","required":["work_unit","scope"],"properties":{"work_unit":{"type":"string"},"scope":{"type":"string"}}}"#,
+            ),
+        ],
+        &["decompose", "take"],
+    );
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+    project_dir
+}
+
+#[test]
+fn run_ticket_admits_acquisition_when_only_trigger_type_partially_scanned() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_trigger_only_entry_project(dir.path());
+    // An unreadable `request` (the substituted trigger type, not a required
+    // input) leaves it only partially scanned.
+    let request_dir = project_dir.join(".runa/workspace/request");
+    fs::create_dir_all(&request_dir).unwrap();
+    let unreadable = request_dir.join("hidden.json");
+    fs::write(&unreadable, r#"{"title":"hidden"}"#).unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    // The ticket replaces the trigger, so a partial scan of the trigger-only
+    // `request` must not block: acquisition runs and the cascade completes.
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&log_path).unwrap(), "decompose\ntake\n");
+}
+
 #[test]
 fn run_ticket_blocks_when_acquisition_preconditions_unmet() {
     let dir = tempfile::tempdir().unwrap();

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -111,6 +111,32 @@ fn setup_blocked_entry_project(dir: &Path) -> PathBuf {
     project_dir
 }
 
+/// Reuses the `seed`-requiring manifest, but here a valid `seed` satisfies
+/// preconditions and a partial scan (not a missing input) blocks entry.
+fn setup_partial_scan_entry_project(dir: &Path) -> PathBuf {
+    let manifest_path = common::write_methodology(
+        dir,
+        BLOCKED_ENTRY_MANIFEST,
+        blocked_entry_schemas(),
+        &["decompose", "take"],
+    );
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+
+    // A valid `seed` satisfies preconditions, but an unreadable sibling under
+    // the same required type leaves it only partially scanned.
+    let seed_dir = project_dir.join(".runa/workspace/seed");
+    fs::create_dir_all(&seed_dir).unwrap();
+    fs::write(seed_dir.join("good.json"), r#"{"title":"good"}"#).unwrap();
+    let unreadable = seed_dir.join("unreadable.json");
+    fs::write(&unreadable, r#"{"title":"hidden"}"#).unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
+    project_dir
+}
+
 fn entry_schemas() -> &'static [(&'static str, &'static str)] {
     &[
         (
@@ -397,6 +423,48 @@ fn run_ticket_unresolved_leaves_no_acquisition_record() {
             "stale acquisition record: {records}"
         );
     }
+}
+
+#[test]
+fn run_ticket_blocks_when_acquisition_input_partially_scanned() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_partial_scan_entry_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    // Preconditions are met (a valid seed exists), but the partial scan makes
+    // the input untrusted: blocked (exit 3), agent never launched.
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    assert!(!log_path.exists(), "acquisition agent should not run");
+}
+
+#[test]
+fn go_ticket_blocks_when_acquisition_input_partially_scanned() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_partial_scan_entry_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("go")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    assert!(!log_path.exists(), "acquisition agent should not run");
 }
 
 #[test]

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -134,6 +134,45 @@ fn setup_entry_project(dir: &Path) -> PathBuf {
     project_dir
 }
 
+/// Like `ENTRY_MANIFEST`, but the acquisition declares `work-unit` via
+/// `may_produce` (the groundwork shape) instead of `produces`.
+const MAY_PRODUCE_ENTRY_MANIFEST: &str = r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[artifact_types]]
+name = "claim"
+
+[[protocols]]
+name = "decompose"
+may_produce = ["work-unit"]
+scoped = false
+trigger = { type = "on_artifact", name = "work-unit" }
+
+[[protocols]]
+name = "take"
+requires = ["work-unit"]
+produces = ["claim"]
+scoped = true
+trigger = { type = "on_artifact", name = "work-unit" }
+"#;
+
+fn setup_may_produce_entry_project(dir: &Path) -> PathBuf {
+    let manifest_path = common::write_methodology(
+        dir,
+        MAY_PRODUCE_ENTRY_MANIFEST,
+        entry_schemas(),
+        &["decompose", "take"],
+    );
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+    project_dir
+}
+
 /// Drop forge atoms from the inherited environment so the test resolves the
 /// deployment identity from `.runa/config.toml` deterministically.
 fn clear_forge_env(command: &mut Command) -> &mut Command {
@@ -167,6 +206,34 @@ case "$payload" in
     printf 'take\n' >> "$log_file"
     mkdir -p .runa/workspace/claim
     printf '%s\n' '{"work_unit":"work-unit-14-cold-start","scope":"acquired"}' > .runa/workspace/claim/claim-1.json
+    ;;
+  *)
+    printf '%s\n' "$payload" > "$log_file.unexpected"
+    exit 19
+    ;;
+esac
+"####,
+    )
+    .unwrap();
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+    script_path
+}
+
+/// An agent that satisfies `decompose`'s postconditions by producing a valid
+/// work-unit, but for a *different* ticket (number 99), so the promised #14
+/// never binds.
+fn write_mismatched_ticket_agent(dir: &Path) -> PathBuf {
+    let script_path = dir.join("mismatched-agent.sh");
+    fs::write(
+        &script_path,
+        r####"#!/bin/sh
+log_file="$1"
+payload=$(cat)
+case "$payload" in
+  *"# Protocol: decompose"*)
+    printf 'decompose\n' >> "$log_file"
+    mkdir -p .runa/workspace/work-unit
+    printf '%s\n' '{"title":"Other","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/99","number":99}}' > .runa/workspace/work-unit/work-unit-99-other.json
     ;;
   *)
     printf '%s\n' "$payload" > "$log_file.unexpected"
@@ -267,6 +334,69 @@ fn run_ticket_cold_acquires_then_cascades_to_take() {
             .is_file()
     );
     assert!(workspace.join("claim/claim-1.json").is_file());
+}
+
+#[test]
+fn run_ticket_dry_run_projects_take_for_may_produce_acquisition() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_may_produce_entry_project(dir.path());
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .arg("--dry-run")
+        .arg("--json")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let plan = value["execution_plan"].as_array().unwrap();
+    // The acquisition declares work-unit via may_produce, yet `take` must still
+    // project on the acquired work-unit.
+    assert_eq!(plan.len(), 2, "{value:#}");
+    assert_eq!(plan[0]["protocol"], "decompose");
+    assert_eq!(plan[1]["protocol"], "take");
+    assert_eq!(plan[1]["work_unit"], "work-unit-14");
+    assert_eq!(plan[1]["projection"], "projected");
+}
+
+#[test]
+fn run_ticket_unresolved_leaves_no_acquisition_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_mismatched_ticket_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    // The acquisition ran and satisfied postconditions, but produced a work-unit
+    // for a different ticket: the entry is unresolved (exit 5)...
+    assert_eq!(output.status.code(), Some(5), "{output:?}");
+    assert_eq!(fs::read_to_string(&log_path).unwrap(), "decompose\n");
+
+    // ...and no execution record claims the acquisition step completed.
+    let records_path = project_dir.join(".runa/store/execution-records.json");
+    if records_path.is_file() {
+        let records = fs::read_to_string(&records_path).unwrap();
+        assert!(
+            !records.contains("decompose"),
+            "stale acquisition record: {records}"
+        );
+    }
 }
 
 #[test]

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -1,0 +1,464 @@
+//! Cold-start ticket entry: `runa run --ticket` / `runa go --ticket`.
+
+mod common;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn runa_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_runa"))
+}
+
+fn init_project(project_dir: &Path, manifest_path: &Path) {
+    let output = runa_bin()
+        .arg("init")
+        .arg("--methodology")
+        .arg(manifest_path)
+        .current_dir(project_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A methodology with an unscoped acquisition surface (`decompose` produces
+/// `work-unit`) and a scoped `take`.
+const ENTRY_MANIFEST: &str = r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[artifact_types]]
+name = "claim"
+
+[[protocols]]
+name = "decompose"
+produces = ["work-unit"]
+scoped = false
+trigger = { type = "on_artifact", name = "work-unit" }
+
+[[protocols]]
+name = "take"
+requires = ["work-unit"]
+produces = ["claim"]
+scoped = true
+trigger = { type = "on_artifact", name = "work-unit" }
+"#;
+
+/// Like `ENTRY_MANIFEST`, but the acquisition surface requires an absent `seed`
+/// artifact, so its preconditions block cold-start entry.
+const BLOCKED_ENTRY_MANIFEST: &str = r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "seed"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[artifact_types]]
+name = "claim"
+
+[[protocols]]
+name = "decompose"
+requires = ["seed"]
+produces = ["work-unit"]
+scoped = false
+trigger = { type = "on_artifact", name = "seed" }
+
+[[protocols]]
+name = "take"
+requires = ["work-unit"]
+produces = ["claim"]
+scoped = true
+trigger = { type = "on_artifact", name = "work-unit" }
+"#;
+
+fn blocked_entry_schemas() -> &'static [(&'static str, &'static str)] {
+    &[
+        (
+            "seed",
+            r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+        ),
+        (
+            "work-unit",
+            r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+        ),
+        (
+            "claim",
+            r#"{"type":"object","required":["work_unit","scope"],"properties":{"work_unit":{"type":"string"},"scope":{"type":"string"}}}"#,
+        ),
+    ]
+}
+
+fn setup_blocked_entry_project(dir: &Path) -> PathBuf {
+    let manifest_path = common::write_methodology(
+        dir,
+        BLOCKED_ENTRY_MANIFEST,
+        blocked_entry_schemas(),
+        &["decompose", "take"],
+    );
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+    project_dir
+}
+
+fn entry_schemas() -> &'static [(&'static str, &'static str)] {
+    &[
+        (
+            "work-unit",
+            r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+        ),
+        (
+            "claim",
+            r#"{"type":"object","required":["work_unit","scope"],"properties":{"work_unit":{"type":"string"},"scope":{"type":"string"}}}"#,
+        ),
+    ]
+}
+
+fn setup_entry_project(dir: &Path) -> PathBuf {
+    let manifest_path =
+        common::write_methodology(dir, ENTRY_MANIFEST, entry_schemas(), &["decompose", "take"]);
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+    project_dir
+}
+
+/// Drop forge atoms from the inherited environment so the test resolves the
+/// deployment identity from `.runa/config.toml` deterministically.
+fn clear_forge_env(command: &mut Command) -> &mut Command {
+    command
+        .env_remove("RUNA_FORGE_TYPE")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
+        .env_remove("RUNA_FORGE_TRACKER_ID")
+}
+
+/// An agent that materializes the work-unit on the acquisition step and a claim
+/// on `take`. The acquisition prompt must carry the entry reference.
+fn write_entry_agent(dir: &Path) -> PathBuf {
+    let script_path = dir.join("entry-agent.sh");
+    fs::write(
+        &script_path,
+        r####"#!/bin/sh
+log_file="$1"
+payload=$(cat)
+case "$payload" in
+  *"# Protocol: decompose"*)
+    case "$payload" in
+      *"## Session entry"*"github:tesserine/runa#14"*) : ;;
+      *) printf '%s\n' "$payload" > "$log_file.no-entry"; exit 23 ;;
+    esac
+    printf 'decompose\n' >> "$log_file"
+    mkdir -p .runa/workspace/work-unit
+    printf '%s\n' '{"title":"Cold start","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}' > .runa/workspace/work-unit/work-unit-14-cold-start.json
+    ;;
+  *"# Protocol: take"*)
+    printf 'take\n' >> "$log_file"
+    mkdir -p .runa/workspace/claim
+    printf '%s\n' '{"work_unit":"work-unit-14-cold-start","scope":"acquired"}' > .runa/workspace/claim/claim-1.json
+    ;;
+  *)
+    printf '%s\n' "$payload" > "$log_file.unexpected"
+    exit 19
+    ;;
+esac
+"####,
+    )
+    .unwrap();
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+    script_path
+}
+
+fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
+    let config_path = project_dir.join(".runa/config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap();
+    let command_entries = command
+        .iter()
+        .map(|entry| format!("  {:?},", entry.display().to_string()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        config_path,
+        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn run_ticket_dry_run_projects_acquisition_then_take() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .arg("--dry-run")
+        .arg("--json")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["version"], 3, "{value:#}");
+    assert_eq!(value["entry"]["reference"], "github:tesserine/runa#14");
+    assert_eq!(value["entry"]["ticket_number"], 14);
+    assert_eq!(value["entry"]["acquisition_protocol"], "decompose");
+
+    let plan = value["execution_plan"].as_array().unwrap();
+    assert_eq!(plan.len(), 2, "{value:#}");
+    assert_eq!(plan[0]["protocol"], "decompose");
+    assert_eq!(plan[0]["projection"], "current");
+    // The acquisition step carries the entry reference in its context.
+    assert_eq!(
+        plan[0]["context"]["entry"]["reference"],
+        "github:tesserine/runa#14"
+    );
+    assert_eq!(plan[1]["protocol"], "take");
+    assert_eq!(plan[1]["projection"], "projected");
+    assert_eq!(plan[1]["work_unit"], "work-unit-14");
+}
+
+#[test]
+fn run_ticket_cold_acquires_then_cascades_to_take() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("tesserine/runa#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let executed = fs::read_to_string(&log_path).unwrap();
+    assert_eq!(executed, "decompose\ntake\n");
+    let workspace = project_dir.join(".runa/workspace");
+    assert!(
+        workspace
+            .join("work-unit/work-unit-14-cold-start.json")
+            .is_file()
+    );
+    assert!(workspace.join("claim/claim-1.json").is_file());
+}
+
+#[test]
+fn run_ticket_blocks_when_acquisition_preconditions_unmet() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_blocked_entry_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    // Exit 3 (blocked) and the agent is never launched.
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    assert!(!log_path.exists(), "acquisition agent should not run");
+    assert!(
+        !project_dir
+            .join(".runa/workspace/work-unit/work-unit-14-cold-start.json")
+            .exists()
+    );
+}
+
+#[test]
+fn run_ticket_dry_run_blocks_when_acquisition_preconditions_unmet() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_blocked_entry_project(dir.path());
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .arg("--dry-run")
+        .arg("--json")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["entry"]["acquisition_protocol"], "decompose");
+    assert_eq!(
+        value["execution_plan"].as_array().unwrap().len(),
+        0,
+        "{value:#}"
+    );
+}
+
+#[test]
+fn go_ticket_blocks_when_acquisition_preconditions_unmet() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_blocked_entry_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("go")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    assert!(!log_path.exists(), "acquisition agent should not run");
+}
+
+#[test]
+fn run_ticket_rejects_foreign_deployment_reference() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("tesserine/groundwork#14")
+        .arg("--dry-run")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("disagrees"), "stderr: {stderr}");
+}
+
+#[test]
+fn run_ticket_conflicts_with_work_unit() {
+    let output = runa_bin()
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .arg("--work-unit")
+        .arg("work-unit-14")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot be used with"), "stderr: {stderr}");
+}
+
+fn runa_mcp_bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_runa"))
+        .parent()
+        .unwrap()
+        .join(format!("runa-mcp{}", std::env::consts::EXE_SUFFIX))
+}
+
+#[test]
+fn mcp_session_ticket_entry_materializes_work_unit_and_binds_to_take() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+    let runa_mcp_path = runa_mcp_bin_path();
+    let log_path = dir.path().join("session.out");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(
+            r####"
+set -eu
+{
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"entry-test","version":"1.0.0"}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"next-protocol-context","arguments":{}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"work-unit","arguments":{"instance_id":"work-unit-14-cold-start","title":"Cold start","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"advance","arguments":{}}}'
+    sleep 1
+} | "$1" --session --ticket '#14' > "$2"
+if grep -q '"error"' "$2"; then
+    cat "$2" >&2
+    exit 23
+fi
+"####,
+        )
+        .arg("drive-entry")
+        .arg(&runa_mcp_path)
+        .arg(&log_path)
+        .env_remove("RUNA_FORGE_TYPE")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
+        .env_remove("RUNA_FORGE_TRACKER_ID")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "entry session failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let transcript = fs::read_to_string(&log_path).unwrap();
+    // The acquisition step is served, the work-unit is materialized, and the
+    // session binds — advance reports `take` as the next step.
+    assert!(transcript.contains("## Session entry"), "{transcript}");
+    assert!(
+        transcript.contains("github:tesserine/runa#14"),
+        "{transcript}"
+    );
+    // advance reports `take` as the bound next step.
+    assert!(transcript.contains("next_step"), "{transcript}");
+    assert!(transcript.contains("take"), "{transcript}");
+    assert!(
+        project_dir
+            .join(".runa/workspace/work-unit/work-unit-14-cold-start.json")
+            .is_file()
+    );
+}
+
+#[test]
+fn go_requires_work_unit_or_ticket() {
+    let output = runa_bin().arg("go").output().unwrap();
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+}
+
+#[test]
+fn go_ticket_conflicts_with_work_unit() {
+    let output = runa_bin()
+        .arg("go")
+        .arg("--ticket")
+        .arg("#14")
+        .arg("--work-unit")
+        .arg("work-unit-14")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+}

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -499,6 +499,87 @@ fn setup_acquisition_only_project(dir: &Path) -> PathBuf {
     project_dir
 }
 
+/// The acquisition optionally accepts `notes`; the ticket entry must withhold it
+/// when its type is untrusted.
+const ACCEPTS_NOTES_MANIFEST: &str = r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "notes"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[protocols]]
+name = "decompose"
+accepts = ["notes"]
+produces = ["work-unit"]
+scoped = false
+trigger = { type = "on_artifact", name = "work-unit" }
+"#;
+
+fn setup_accepts_notes_entry_project(dir: &Path) -> PathBuf {
+    let manifest_path = common::write_methodology(
+        dir,
+        ACCEPTS_NOTES_MANIFEST,
+        &[
+            (
+                "notes",
+                r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+            ),
+            (
+                "work-unit",
+                r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+            ),
+        ],
+        &["decompose"],
+    );
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+    project_dir
+}
+
+#[test]
+fn run_ticket_dry_run_withholds_accepts_from_partially_scanned_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_accepts_notes_entry_project(dir.path());
+    // A valid `notes` exists, but an unreadable sibling leaves the type only
+    // partially scanned (untrusted).
+    let notes_dir = project_dir.join(".runa/workspace/notes");
+    fs::create_dir_all(&notes_dir).unwrap();
+    fs::write(notes_dir.join("good.json"), r#"{"title":"good"}"#).unwrap();
+    let unreadable = notes_dir.join("hidden.json");
+    fs::write(&unreadable, r#"{"title":"hidden"}"#).unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .arg("--dry-run")
+        .arg("--json")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let acquisition = &value["execution_plan"][0];
+    assert_eq!(acquisition["protocol"], "decompose");
+    // The optional `notes` input is from an untrusted type and must be withheld.
+    let inputs = acquisition["context"]["inputs"].as_array().unwrap();
+    assert!(
+        inputs.iter().all(|input| input["artifact_type"] != "notes"),
+        "untrusted accepted input was exposed: {value:#}"
+    );
+}
+
 #[test]
 fn run_ticket_reports_success_when_acquisition_is_the_only_work() {
     let dir = tempfile::tempdir().unwrap();

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -467,6 +467,68 @@ fn go_ticket_blocks_when_acquisition_input_partially_scanned() {
     assert!(!log_path.exists(), "acquisition agent should not run");
 }
 
+/// A methodology whose only protocol is the acquisition itself — there is no
+/// further scoped work after the work-unit is materialized.
+const ACQUISITION_ONLY_MANIFEST: &str = r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[protocols]]
+name = "decompose"
+produces = ["work-unit"]
+scoped = false
+trigger = { type = "on_artifact", name = "work-unit" }
+"#;
+
+fn setup_acquisition_only_project(dir: &Path) -> PathBuf {
+    let manifest_path = common::write_methodology(
+        dir,
+        ACQUISITION_ONLY_MANIFEST,
+        &[(
+            "work-unit",
+            r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
+        )],
+        &["decompose"],
+    );
+    let project_dir = dir.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
+    project_dir
+}
+
+#[test]
+fn run_ticket_reports_success_when_acquisition_is_the_only_work() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_acquisition_only_project(dir.path());
+    let log_path = dir.path().join("executed.log");
+    let agent_path = write_entry_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("run")
+        .arg("--ticket")
+        .arg("#14")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    // Acquisition ran and there is no further scoped work: the command must
+    // report success, not nothing-ready (exit 4).
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&log_path).unwrap(), "decompose\n");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Run outcome: success"), "stdout: {stdout}");
+}
+
 #[test]
 fn run_ticket_blocks_when_acquisition_preconditions_unmet() {
     let dir = tempfile::tempdir().unwrap();

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -575,6 +575,29 @@ fi
 }
 
 #[test]
+fn go_ticket_invalid_reference_is_usage_error_without_agent() {
+    // No `[agent].command` is configured. An invalid reference must still report
+    // a usage error (2), not a missing-agent config failure (6).
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = setup_entry_project(dir.path());
+
+    let output = clear_forge_env(&mut runa_bin())
+        .arg("go")
+        .arg("--ticket")
+        .arg("not-a-ticket")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not a recognized forge ticket reference"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn go_requires_work_unit_or_ticket() {
     let output = runa_bin().arg("go").output().unwrap();
     assert_eq!(output.status.code(), Some(2), "{output:?}");

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -78,6 +78,31 @@ impl RunaHandler {
         })
     }
 
+    pub fn new_session_entry(
+        working_dir: PathBuf,
+        config_override: Option<&Path>,
+        ticket: libagent::TicketRef,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let session = SessionState::open_entry(
+            working_dir,
+            config_override,
+            ticket,
+            validate_session_step_output_types,
+        )?;
+
+        Ok(Self {
+            protocol: None,
+            work_unit: session
+                .current_step()
+                .and_then(|step| step.work_unit.clone()),
+            state: None,
+            workspace_dir: session.workspace_dir().to_path_buf(),
+            tools: Vec::new(),
+            tool_schemas: HashMap::new(),
+            session: Some(Mutex::new(session)),
+        })
+    }
+
     async fn call_session_tool(
         &self,
         session: &Mutex<SessionState>,

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -26,6 +26,10 @@ struct Cli {
     /// Optional work unit scope for tool serving
     #[arg(long)]
     work_unit: Option<String>,
+
+    /// Open a session from a forge ticket reference (cold-start entry)
+    #[arg(long, requires = "session", conflicts_with_all = ["work_unit", "protocol"])]
+    ticket: Option<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -68,7 +72,14 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     if cli.session {
-        let handler = RunaHandler::new_session(working_dir.clone(), config_ref, cli.work_unit)?;
+        let handler = match cli.ticket.as_deref() {
+            Some(ticket) => {
+                let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+                let ticket_ref = libagent::resolve_ticket_reference(ticket, &identity)?;
+                RunaHandler::new_session_entry(working_dir.clone(), config_ref, ticket_ref)?
+            }
+            None => RunaHandler::new_session(working_dir.clone(), config_ref, cli.work_unit)?,
+        };
         let (stdin, stdout) = io::stdio();
         let service = handler.serve((stdin, stdout)).await.inspect_err(|e| {
             error!(


### PR DESCRIPTION
Closes #188. This is the **runtime half** of cold-start ticket entry; the methodology half (the `acquire` skill) landed in tesserine/groundwork#394.

## What this adds

A session can be opened from nothing but a forge ticket reference, the natural developer entry — "start on runa#14":

- `runa run --ticket <REF>` — cold-start the cascade from a ticket.
- `runa go --ticket <REF>` — cold-start one interactive tick.
- `runa-mcp --session --ticket <ref>` — the same entry session surface.

Accepted reference forms: a bare number, `#N`, `owner/repo#N`, a GitHub issue URL, or `sourcehut:<tracker_id>#N`. The runtime resolves the reference to a tracker **identity** only and **never reads ticket content** — the methodology performs all forge reads through its own mechanics. The runtime delivers the reference (and `RUNA_ENTRY_TICKET`) into the session; once the methodology materializes the `work-unit`, the session binds and the cascade computes `take` next on it.

## Design — the promised scope

A session's scope is either **bound** (a recorded `work-unit`) or **promised** (a ticket reference standing for a work-unit not yet materialized). A promised scope admits exactly one step — the methodology's **acquisition surface**, derived methodology-neutrally as the sole unscoped producer of the `work-unit` artifact — and resolves to a bound scope when that step materializes the work-unit. Downstream of acquisition, a session opened from a reference and one opened from the materialized id are indistinguishable. A reference whose work-unit already exists degrades to a normal scoped session at open.

Entry substitutes **only the acquisition step's trigger**. Its `requires` preconditions still gate — an acquisition with unmet dependencies is **blocked** (exit 3), not executed, in every path (session, live run, and dry-run projection). The runtime core stays forge-neutral: it contains no ticket-content logic and `libagent` has no HTTP-client dependency.

## Acceptance criteria

- [x] A single invocation carrying a ticket reference starts a session in which the methodology's entry receives that reference.
- [x] The methodology's acquisition produces the validated `work-unit`, and the cascade computes `take` next on it — observable via the dry-run projection (`1. decompose [current, entry]` / `2. take (work_unit=work-unit-14) [projected]`).
- [x] All forge reads resolve through methodology-owned mechanics; the runtime core performs no forge content fetch.
- [x] Works in interactive and autonomous modes with identical semantics — mode changes only who issues the verb at what cadence.
- [x] The interface and session-surface contracts document the affordance, and the documented behavior matches a live run.

## Layers touched

- `libagent/src/entry.rs` (new) — reference parsing, acquisition-surface discovery, promise resolution.
- `libagent/src/context.rs` — entry reference delivered into the prompt.
- `libagent/src/session.rs` — `SessionScope::{Bound,Promised}`, `open_entry`, advance-time binding, precondition gate.
- `libagent/src/projection.rs` — `project_entry_cascade` (seeded, precondition-gated).
- `runa-mcp` — `--session --ticket`.
- `runa-cli` — `--ticket` on `go`/`run`, shared `commands/entry.rs`.
- Docs: interface-contract, session-surface-contract, cli-reference, README, ARCHITECTURE, CHANGELOG.

## Verification

663 tests pass (new entry unit tests + projection/session unit tests + CLI/MCP integration tests covering acquire→cascade, dry-run projection, mode parity, and precondition-blocked exits). `cargo clippy --workspace --all-targets` clean; `cargo fmt --all --check` clean. Live run confirms both the satisfiable path (projects `take`, exit 0) and the unmet-precondition path (blocked, exit 3) match the docs.