### PR TITLE
docs: repoint session-surface-contract's Design-Principle-21 citation off the commons mirror

### DIFF
--- a/docs/session-surface-contract.md
+++ b/docs/session-surface-contract.md
@@ -7,9 +7,10 @@ governs the runa-to-methodology boundary, while this contract governs the
 runa-to-driver boundary.
 
 The source invariant is commons
-[ADR-0015: Mode Is a Property of the Session](https://github.com/tesserine/commons/blob/main/adr/0015-mode-is-a-property-of-the-session.md)
-and
-[Design Principle 21](https://github.com/tesserine/commons/blob/main/DESIGN-PRINCIPLES.md#21-mode-is-a-property-of-the-session-not-the-operation).
+[ADR-0015: Mode Is a Property of the Session](https://github.com/tesserine/commons/blob/main/adr/0015-mode-is-a-property-of-the-session.md),
+grounded in the
+[Sovereignty](https://github.com/pentaxis93/principles/blob/main/principles/sovereignty.md)
+principle.
 The operation and contract layer is mode-agnostic by construction. Autonomous
 orchestrators and interactive drivers are clients of the same validated runa
 surface.


### PR DESCRIPTION
Closes #191. Part of the ecosystem source-repair coordinated by [groundwork#404](https://github.com/tesserine/groundwork/issues/404) (epic [groundwork#397](https://github.com/tesserine/groundwork/issues/397)).

## What changed

`docs/session-surface-contract.md` cited the superseded `tesserine/commons/DESIGN-PRINCIPLES.md` mirror (ascension banner; canonical home `pentaxis93/principles`), scheduled for retirement by the commons cleanup. This was the **only** inbound reference to the commons principle mirrors anywhere in runa — the last live one in the ecosystem — so it gated that deletion.

The principle ground now cites the living authority:

- **Governing decision** — [ADR-0015: Mode Is a Property of the Session](https://github.com/tesserine/commons/blob/main/adr/0015-mode-is-a-property-of-the-session.md) (unchanged; already canonical).
- **Principle ground** — [Sovereignty](https://github.com/pentaxis93/principles/blob/main/principles/sovereignty.md) at `pentaxis93/principles`, where Design Principle 21 ascended as a projection (per the corpus [SOURCES.md](https://github.com/pentaxis93/principles/blob/main/SOURCES.md) Register 2).

## Acceptance criteria

- ✅ `grep -rn "DESIGN-PRINCIPLES" docs/` returns zero hits (zero repo-wide).
- ✅ Both replacement links resolve (HTTP 200).