### PR TITLE
docs: fix step --json drift, document invariants at the code, enforce exit-code conformance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,13 @@
 
 Runa is a cognitive runtime for AI agents. This document describes the codebase as it exists today.
 
+Related but distinct: commons holds an **exploratory draft** concept document,
+[`concepts/_drafts/cognitive-state-machine.md`](https://github.com/tesserine/commons/blob/main/concepts/_drafts/cognitive-state-machine.md),
+describing a possible type-theoretic trajectory for the ecosystem. It is not
+committed project direction and this document does not implement it; runa
+deliberately does not import its vocabulary. This document is canonical for
+runa's actual architecture.
+
 ## Workspace Structure
 
 Three crates, Rust 2024 edition, resolver v3:
@@ -220,7 +227,7 @@ Exits 0 for successful state evaluation regardless of whether protocols are read
 
 Runs the same implicit scan and shared candidate classification used by `runa state`, then narrows the plan to the single next concrete `READY` `(protocol, work_unit)` pair in scope-filtered execution order. Without `--work-unit`, it considers only unscoped protocols. With `--work-unit <ID>`, it considers only scoped protocols for that delegated work unit.
 
-With `--dry-run`, text output prints the next execution plus the grouped READY/BLOCKED/WAITING view. JSON output adds an `execution_plan` array plus an optional scope-filtered `cycle` path while reusing the same `protocols` status entries and `scan_warnings` envelope fields as `runa state`; the `step --json` envelope version is now `4`, and `execution_plan` contains at most one entry. Dry-run still emits MCP launch config for preview, but it does not fail if `runa-mcp` is not currently discoverable. The dry-run context payload is display-oriented; live execution keeps using the exact internal path handles when it reopens artifact content.
+With `--dry-run`, text output prints the next execution plus the grouped READY/BLOCKED/WAITING view. JSON output adds an `execution_plan` array plus an optional scope-filtered `cycle` path while reusing the same `protocols` status entries and `scan_warnings` envelope fields as `runa state`; the `step --json` envelope version is `5`, and `execution_plan` contains at most one entry. Dry-run still emits MCP launch config for preview, but it does not fail if `runa-mcp` is not currently discoverable. The dry-run context payload is display-oriented; live execution keeps using the exact internal path handles when it reopens artifact content.
 
 Without `--dry-run`, `step` requires `[agent].command` in config and Linux as the execution platform. It rejects `--json` with exit `2`. If the initial execution plan is empty it performs a final workspace re-scan and re-evaluates readiness before concluding there is no work. If that refreshed state exposes a READY candidate, `step` executes that one protocol in the same invocation. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit: `3` when work remains blocked, waiting, or cyclic, `4` when no actionable work remains because outputs are current. Otherwise it resolves `runa-mcp`, builds the candidate's MCP launch config, exports it through `RUNA_MCP_CONFIG`, launches the configured agent argv unmodified, rescans the workspace, enforces postconditions for that candidate, and then prints the refreshed READY/BLOCKED/WAITING view. Attempted-work failures use exit `5`; bootstrap, scan, record, serialization, config, MCP lookup, and runtime failures use exit `6`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Semantic Versioning.
 
 ### Added
 
+- The quickstart methodology README now walks the full
+  scan → READY → produce loop without requiring an agent: entry artifact,
+  cascade advance on artifact appearance, quiescence, and freshness-driven
+  reopening — verified against the built binary.
 - The `commons_exit_codes_match_specification` test now verifies the
   `ExitCode` enum against a vendored copy of the commons exit-code table
   (`runa-cli/tests/fixtures/commons-exit-codes.json`, provenance-pinned to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- `RELEASING.md` Tooling Provenance section and a `scripts/release-check`
+  provenance header: the script is runa-owned, the ceremony convention is
+  canonical in commons, and no repo is the tooling upstream.
+
 ### Fixed
 
 - Invariant-bearing modules now document their invariants at the code:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Semantic Versioning.
 
 ### Added
 
+- The `commons_exit_codes_match_specification` test now verifies the
+  `ExitCode` enum against a vendored copy of the commons exit-code table
+  (`runa-cli/tests/fixtures/commons-exit-codes.json`, provenance-pinned to
+  commons `v0.3.0-rc.1`) instead of re-stated literals, making the
+  commons-conformance claim in its name mechanically true. The enum carries
+  a `canonical: commons/EXIT-CODES.md` back-reference.
 - `RELEASING.md` Tooling Provenance section and a `scripts/release-check`
   provenance header: the script is runa-owned, the ceremony convention is
   canonical in commons, and no repo is the tooling upstream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Semantic Versioning.
 
 ### Added
 
+- README ecosystem links corrected: commons described as the
+  convention/ADR authority with principles at their canonical home
+  `pentaxis93/principles` (#181), and the agentd/groundwork links moved to
+  the `tesserine` org.
 - `docs/security.md` — consolidated index of runa's security guarantees
   (previously scattered across four documents), each mapped to its
   enforcement site and authoritative specification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Semantic Versioning.
 
 ### Fixed
 
+- Invariant-bearing modules now document their invariants at the code:
+  `session.rs` opens with the session state-machine contract (state derives
+  from artifacts, single current step, transactional `advance`,
+  session-scoped exhaustion, promised-scope single step) referencing the
+  session surface contract; `scoped_identity.rs` opens with the scope
+  identity invariants referencing the interface contract; `selection.rs`
+  documents the freshness/currentness machinery — input-set equality on
+  the execution-record path, the timestamp fallback, and the
+  `AnyRecorded`-wins mode merge.
 - `ARCHITECTURE.md` documented the `step --json` envelope version as `4`;
   the code emits `5`. The doc now matches, and a workspace-contract test
   asserts code, `ARCHITECTURE.md`, and `docs/cli-reference.md` agree so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Semantic Versioning.
 
 ### Added
 
+- `docs/security.md` — consolidated index of runa's security guarantees
+  (previously scattered across four documents), each mapped to its
+  enforcement site and authoritative specification.
+- `CONTRIBUTING.md` test map: where unit, CLI-integration, MCP, and
+  docs-coherence gates live.
 - The quickstart methodology README now walks the full
   scan → READY → produce loop without requiring an agent: entry artifact,
   cascade advance on artifact appearance, quiescence, and freshness-driven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- `ARCHITECTURE.md` documented the `step --json` envelope version as `4`;
+  the code emits `5`. The doc now matches, and a workspace-contract test
+  asserts code, `ARCHITECTURE.md`, and `docs/cli-reference.md` agree so the
+  envelope version cannot silently drift again.
+
 ### Added
 
 - Cold-start ticket entry: `runa run --ticket <REF>` and `runa go --ticket <REF>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,23 @@ New domain logic goes in libagent. The CLI and MCP server must not contain
 domain logic — this keeps behavior testable and reasoned about in one place.
 See [ARCHITECTURE.md](ARCHITECTURE.md) for module detail.
 
+## Test map
+
+`cargo test --workspace` runs everything. Where behavior lives:
+
+- **Unit tests** — inline `#[cfg(test)] mod tests` in every libagent module
+  (the project convention; see ARCHITECTURE.md § Key Design Patterns).
+- **CLI integration tests** — `runa-cli/tests/`: end-to-end command behavior
+  (`e2e.rs`, `step.rs`, `run.rs`, `go.rs`, …), release tooling
+  (`release_check.rs`), and the docs/config coherence gates
+  (`workspace_contract.rs` — these fail when documentation drifts from
+  code, e.g. the `step --json` envelope version or the vendored commons
+  exit-code table).
+- **MCP integration tests** — `runa-mcp/tests/`.
+
+A behavior change without a failing-then-passing test is incomplete; the
+workspace-contract gates mean documentation drift is also a test failure.
+
 ## Conventions
 
 - Conventional commits (e.g., `feat(trigger):`, `fix(store):`, `docs:`)

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ READY:
 
 Runa is the enforcement layer in a larger agent toolchain:
 
-- [**agentd**](https://github.com/pentaxis93/agentd) — a process runtime that orchestrates autonomous agents through runa-managed workflows.
-- [**groundwork**](https://github.com/pentaxis93/groundwork) — a methodology plugin that provides protocols and artifact types for runa.
+- [**agentd**](https://github.com/tesserine/agentd) — a process runtime that orchestrates autonomous agents through runa-managed workflows.
+- [**groundwork**](https://github.com/tesserine/groundwork) — a methodology plugin that provides protocols and artifact types for runa.
 
 Both projects are in early development.
 
@@ -159,7 +159,7 @@ Both projects are in early development.
 - [Contributing](CONTRIBUTING.md) — Conventions for landing PRs
 - [Releasing](RELEASING.md) — Repository release operation and verification
 - [Quickstart Example](examples/quickstart-methodology/) — A two-protocol review pipeline you can browse and run
-- [Commons](https://github.com/tesserine/commons) — Shared governance for the ecosystem: bedrock principles, design principles, and architectural decision records. All development on runa follows commons as active guidelines, not optional reading
+- [Commons](https://github.com/tesserine/commons) — The ecosystem's convention and ADR authority: cross-component contracts, release conventions, and the [source-of-truth map](https://github.com/tesserine/commons/blob/main/SOURCE-OF-TRUTH.md). The principles themselves live at their canonical home, [pentaxis93/principles](https://github.com/pentaxis93/principles). All development on runa follows both as active guidelines, not optional reading
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Both projects are in early development.
 - [Methodology Authoring Guide](docs/methodology-authoring-guide.md) — Building a first methodology from scratch
 - [Interface Contract](docs/interface-contract.md) — The three primitives defining the methodology-runtime boundary
 - [Session Surface Contract](docs/session-surface-contract.md) — The mode-agnostic driver/agent boundary for session invocation and lifecycle movement
+- [Security and Safety Surface](docs/security.md) — Index of guarantees: path safety, validate-before-write, ticket-content blindness, redaction, and where each is enforced
 - [Architecture](ARCHITECTURE.md) — Workspace structure, data flow, module descriptions, disk layout
 - [Contributing](CONTRIBUTING.md) — Conventions for landing PRs
 - [Releasing](RELEASING.md) — Repository release operation and verification

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,20 @@ runa's own release check does not validate base images. The
 `org.tesserine.runa.ref` label on base images is owned by base and by the
 ecosystem-level release manifest verification in commons.
 
+## Tooling Provenance
+
+`scripts/release-check` (with its `scripts/verify-release-adoption.sh`
+self-test) is the runa-owned implementation of the shared release
+ceremony's verification checks; the release cut itself uses `cargo release`
+per ADR-0006. The ceremony convention is canonical in
+[commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md)
+and ADR-0006/0011/0012. The script shares ancestry with the sibling
+implementations in the other release-component repos
+([commons#21](https://github.com/tesserine/commons/issues/21)) but is
+independently owned: no repo is the tooling upstream, and fixes do not
+propagate automatically. Ownership details:
+[base RELEASING.md § Release Tooling Ownership](https://github.com/tesserine/base/blob/main/RELEASING.md#release-tooling-ownership).
+
 ## Pre-Release Gate
 
 A releasable commit is on `main`, up to date with `origin/main`, and has a

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,20 @@
+# Security and Safety Surface
+
+Index of runa's security-relevant guarantees: what each guarantees, where
+it is enforced, and where it is specified. This document adds no new
+rules — each linked location is authoritative for its own guarantee.
+
+| Guarantee | Enforced in | Specified in |
+| --- | --- | --- |
+| **Path safety by construction.** Artifact-type and protocol names must be single path components (no `/`, `\`, `..`); runa derives every schema/instruction/workspace path from validated names, so a methodology cannot point runa outside the project tree. | `libagent/src/manifest.rs` (name validation at parse time) | [interface-contract.md](interface-contract.md) (artifact-type and protocol naming rules) |
+| **Validate before write.** Artifacts delivered through `runa-mcp` output tools are validated against the full schema before being written; invalid artifacts are rejected with details and never reach disk. | `runa-mcp` output tools → libagent validation path | [AGENTS.md](../AGENTS.md) § Artifact production contract |
+| **Atomic, canonical persistence.** Store state is persisted with atomic writes; content hashing uses canonical JSON (sorted keys), so hashes are deterministic and partial writes are never observed. | `libagent/src/store.rs` (module docs) | [ARCHITECTURE.md](../ARCHITECTURE.md) § Key Design Patterns |
+| **Ticket-content blindness.** A `--ticket` reference is resolved to a tracker *identity* only; runa performs no forge read, and a reference asserting a foreign deployment is rejected. Forge reads belong to the methodology's mechanics under its own credentials. | `libagent/src/entry.rs` | [interface-contract.md](interface-contract.md) § Entry References |
+| **Scoped identity checks.** Tracker-backed work-unit roots get the runtime checks schema validation cannot express: id/handle agreement, duplicate-identity rejection, active-deployment agreement. | `libagent/src/scoped_identity.rs` (module docs) | [interface-contract.md](interface-contract.md) § scoped identity |
+| **Transcript redaction.** Environment variables named by `[transcript].redact_env` (or `RUNA_TRANSCRIPT_REDACT_ENV`) have their current values redacted from emitted transcript events. | transcript emission in `runa-cli`/`runa-mcp` | [cli-reference.md](cli-reference.md) § configuration |
+| **Driver verbs cannot bypass state.** Every session driver verb rescans and revalidates before reporting or advancing; transition authority stays in the session state machine, not the driver. | `libagent/src/session.rs` (module docs) | [session-surface-contract.md](session-surface-contract.md) |
+
+Out of runa's scope by design: process isolation, credential injection, and
+audit sealing belong to the runtime host —
+[agentd](https://github.com/tesserine/agentd) (see its `ARCHITECTURE.md`
+and `docs/audit-record.md`).

--- a/examples/quickstart-methodology/README.md
+++ b/examples/quickstart-methodology/README.md
@@ -19,6 +19,57 @@ runa init --methodology manifest.toml
 runa state
 ```
 
+Both protocols are WAITING — no `requirements` artifact exists yet.
+
+## The scan → READY → produce loop
+
+The full loop can be walked without an agent by producing the artifacts by
+hand; runa derives every transition from the workspace state.
+
+1. **Deliver the entry artifact and scan.** `draft` becomes READY:
+
+   ```bash
+   mkdir -p .runa/workspace/requirements
+   echo '{"title": "Widget API"}' > .runa/workspace/requirements/widget.json
+   runa scan && runa state
+   ```
+
+   ```
+   READY:
+     draft
+       - requirements/widget (requires)
+   ```
+
+2. **Produce `draft`'s output.** In a live session the agent delivers this
+   through the `design` MCP tool; producing it by hand shows the same
+   state movement:
+
+   ```bash
+   mkdir -p .runa/workspace/design
+   echo '{"summary": "Three endpoints, one store"}' > .runa/workspace/design/widget.json
+   runa scan && runa state
+   ```
+
+   `draft` is now WAITING — its output is current — and `review` is READY
+   with both inputs listed. The cascade advanced one stage because an
+   artifact appeared, not because anything was commanded.
+
+3. **Produce `review`'s output** the same way
+   (`echo '{"approved": true}' > .runa/workspace/review-report/widget.json`,
+   then `runa scan && runa state`): every protocol reports WAITING with
+   outputs current. The topology is quiescent — `runa run` would exit `4`
+   (nothing ready).
+
+4. **Reopen the loop.** Touch the requirements artifact with changed
+   content and scan: downstream outputs are no longer current, and the
+   affected protocols come back READY. Freshness is derived from the
+   artifact store, not from any run history you must manage.
+
+For live execution the same loop is driven by an agent:
+`runa step` executes the single next READY protocol through your
+configured agent command, and `runa run` repeats that to quiescence — see
+the [CLI reference](../../docs/cli-reference.md).
+
 ## Further Reading
 
 - [Methodology Authoring Guide](../../docs/methodology-authoring-guide.md) — full walkthrough of this example with explanations

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -1,3 +1,28 @@
+//! Canonical scoped work-unit identity validation, shared by the CLI
+//! commands and `runa-mcp`.
+//!
+//! Governing contract: [`docs/interface-contract.md`] — runa owns scope
+//! *identity*; the methodology owns the `work-unit` schema and the
+//! semantics of its content. This module holds the runtime checks that
+//! JSON Schema cannot express.
+//!
+//! Invariants:
+//!
+//! - **The canonical scope set is the recorded `work-unit` instance ids —
+//!   including invalid and malformed records.** A broken record still
+//!   occupies its identity; excluding it would let a session silently open
+//!   against a scope that exists but failed validation.
+//! - For valid tracker-backed roots: the canonical instance id's tracker
+//!   number must agree with the handle number; duplicate tracker
+//!   identities across roots are rejected; and the handle's deployment
+//!   identity must agree with the active deployment resolved from the
+//!   config-backed `RUNA_FORGE_*` atoms (`github:<owner>/<name>` or
+//!   `sourcehut:<tracker_id>`).
+//! - Endpoint and host resolution are deliberately outside scoped identity
+//!   validation; identity is textual agreement, not network reachability.
+//!
+//! [`docs/interface-contract.md`]: https://github.com/tesserine/runa/blob/main/docs/interface-contract.md
+
 use std::collections::HashMap;
 use std::fmt;
 

--- a/libagent/src/selection.rs
+++ b/libagent/src/selection.rs
@@ -317,6 +317,29 @@ fn trigger_artifact_types<'a>(condition: &'a TriggerCondition, out: &mut HashSet
     }
 }
 
+/// Decide whether a protocol's outputs are *current* — the suppression
+/// that turns an already-satisfied protocol into output-current WAITING
+/// instead of reopening it.
+///
+/// Invariants, in evaluation order:
+///
+/// - A protocol that produces nothing is never current: it stays
+///   re-runnable by design.
+/// - A scan gap touching any produced (or present may-produce, or
+///   required-choice) type defeats currentness: if the store cannot vouch
+///   for the outputs, suppression would hide work behind unverifiable
+///   state.
+/// - With a persisted execution record, currentness is **input-set
+///   equality**: the snapshot of (instance id, content hash) pairs taken
+///   at execution time, recomputed under the record's own per-type input
+///   modes, must match exactly. Timestamps are irrelevant on this path —
+///   outputs stay current even when input mtimes churn without content
+///   change, and go stale the moment the input *set* differs.
+/// - Without a record (state predating execution records), currentness
+///   falls back to timestamps: every freshness input's latest modification
+///   must not postdate the derived completion timestamp. This path uses
+///   the conservative `AnyRecorded`-leaning modes from
+///   [`protocol_freshness_inputs`].
 fn protocol_is_current(
     protocol: &ProtocolDeclaration,
     store: &ArtifactStore,
@@ -385,6 +408,10 @@ fn protocol_is_current(
         .is_none_or(|latest_input| latest_input <= output_timestamp)
 }
 
+/// Merge a freshness mode for an artifact type that may appear under
+/// several edges. `AnyRecorded` always wins: if any edge is sensitive to
+/// invalid or malformed instances, narrowing to `ValidOnly` would let an
+/// invalid-input arrival go unnoticed by freshness.
 fn record_freshness_input(
     freshness_inputs: &mut HashMap<String, FreshnessInputMode>,
     artifact_type: &str,
@@ -400,6 +427,11 @@ fn record_freshness_input(
         .or_insert(mode);
 }
 
+/// Snapshot the current input set — ordered (instance id, content hash)
+/// pairs per artifact type, filtered by each type's input mode. Equality
+/// of two snapshots is the definition of output currentness on the
+/// execution-record path of [`protocol_is_current`]; determinism of the
+/// ordering is what makes that equality meaningful.
 pub(crate) fn execution_input_snapshot_for_freshness_inputs<'a, I>(
     store: &ArtifactStore,
     freshness_inputs: I,
@@ -465,6 +497,10 @@ fn trigger_freshness_inputs(
     }
 }
 
+/// Freshness inputs for the *timestamp fallback* path: every trigger and
+/// requires type at `AnyRecorded`. Without an execution record there is no
+/// per-execution mode evidence, so the fallback errs toward reopening —
+/// any recorded activity, valid or not, can defeat currentness.
 pub(crate) fn protocol_freshness_inputs(
     protocol: &ProtocolDeclaration,
 ) -> HashMap<String, FreshnessInputMode> {
@@ -480,6 +516,12 @@ pub(crate) fn protocol_freshness_inputs(
     freshness_inputs
 }
 
+/// Collect the input modes persisted into an execution record, from the
+/// *satisfied* trigger branches only. Mode assignment is the subtle part:
+/// `on_artifact` is satisfied by valid instances, so it snapshots
+/// `ValidOnly`; `on_change` and `on_invalid` are sensitive to any recorded
+/// state, so they snapshot `AnyRecorded`. Unsatisfied branches contributed
+/// nothing to this execution and are excluded from its freshness identity.
 pub(crate) fn collect_satisfied_execution_record_inputs<F>(
     condition: &TriggerCondition,
     out: &mut HashMap<String, FreshnessInputMode>,
@@ -506,6 +548,10 @@ pub(crate) fn collect_satisfied_execution_record_inputs<F>(
     }
 }
 
+/// Input modes recorded at execution time: satisfied trigger branches per
+/// [`collect_satisfied_execution_record_inputs`], plus every `requires`
+/// type at `ValidOnly` (requires inputs are guaranteed valid when
+/// delivered, so only the valid set defines this execution's identity).
 pub(crate) fn protocol_execution_record_inputs(
     protocol: &ProtocolDeclaration,
     store: &ArtifactStore,

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -1,3 +1,37 @@
+//! Scoped session state machine: one work unit, one current step, and
+//! `advance` as a single transactional operation.
+//!
+//! Governing contract: [`docs/session-surface-contract.md`] — this module
+//! is the inner cascade behind the one operator verb, *advance the session
+//! by one step* (commons ADR-0015: mode is a property of the session).
+//! Drivers — `runa go`, the `runa-mcp` session mode — are clients of this
+//! state machine; no driver reimplements readiness, context delivery, or
+//! transition authority.
+//!
+//! Invariants:
+//!
+//! - **State derives from artifacts, never from driver assertion.** Every
+//!   lifecycle operation (`open*`, `readiness`, `next_context`, `advance`)
+//!   reconciles against a real workspace scan before acting; a driver
+//!   cannot move the session by claiming a state.
+//! - **One current step.** The session holds at most one
+//!   `(protocol, work_unit)` pair; an empty session lets readiness select
+//!   the first ready step.
+//! - **`advance` is one operation:** rescan, enforce the current step's
+//!   postconditions, stage its execution record (the freshness snapshot
+//!   `selection.rs` uses for input-set currentness), validate the next
+//!   selected step, then persist and move. A postcondition failure leaves
+//!   the session on the current step with no transition.
+//! - **Exhaustion is session-scoped.** Failed candidates are skipped for
+//!   the lifetime of this `SessionState` only; nothing about failure is
+//!   persisted as artifact state.
+//! - **Promised scope admits exactly one step.** A session opened from a
+//!   ticket reference (`SessionScope::Promised`) can only run the
+//!   methodology's acquisition surface until the work-unit materializes
+//!   and the scope binds.
+//!
+//! [`docs/session-surface-contract.md`]: https://github.com/tesserine/runa/blob/main/docs/session-surface-contract.md
+
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/runa-cli/src/exit_codes.rs
+++ b/runa-cli/src/exit_codes.rs
@@ -1,3 +1,9 @@
+/// Session-outcome exit codes — canonical: commons/EXIT-CODES.md.
+///
+/// runa implements the shared vocabulary; it does not define it. The
+/// conformance test below verifies this enum against the vendored copy of
+/// the commons table at `tests/fixtures/commons-exit-codes.json`, which
+/// carries immutable provenance to its canonical version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExitCode {
     Success,
@@ -27,14 +33,45 @@ impl ExitCode {
 mod tests {
     use super::ExitCode;
 
+    /// The vendored commons exit-code table; provenance inside the fixture.
+    const VENDORED_COMMONS_TABLE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/commons-exit-codes.json"
+    ));
+
     #[test]
     fn commons_exit_codes_match_specification() {
-        assert_eq!(ExitCode::Success.code(), 0);
-        assert_eq!(ExitCode::GenericFailure.code(), 1);
-        assert_eq!(ExitCode::UsageError.code(), 2);
-        assert_eq!(ExitCode::Blocked.code(), 3);
-        assert_eq!(ExitCode::NothingReady.code(), 4);
-        assert_eq!(ExitCode::WorkFailed.code(), 5);
-        assert_eq!(ExitCode::InfrastructureFailure.code(), 6);
+        let table: serde_json::Value = serde_json::from_str(VENDORED_COMMONS_TABLE)
+            .expect("vendored commons exit-code table should be valid JSON");
+        let application_defined = table["application_defined"]
+            .as_object()
+            .expect("vendored table should carry an application_defined object");
+
+        let implemented = [
+            ("success", ExitCode::Success),
+            ("generic_failure", ExitCode::GenericFailure),
+            ("usage_error", ExitCode::UsageError),
+            ("blocked", ExitCode::Blocked),
+            ("nothing_ready", ExitCode::NothingReady),
+            ("work_failed", ExitCode::WorkFailed),
+            ("infrastructure_failure", ExitCode::InfrastructureFailure),
+        ];
+
+        assert_eq!(
+            application_defined.len(),
+            implemented.len(),
+            "the vendored commons table and the ExitCode enum should cover the same labels"
+        );
+        for (label, exit_code) in implemented {
+            let expected = application_defined
+                .get(label)
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or_else(|| panic!("vendored commons table should define `{label}`"));
+            assert_eq!(
+                i64::from(exit_code.code()),
+                expected,
+                "ExitCode::{exit_code:?} disagrees with the vendored commons table for `{label}`"
+            );
+        }
     }
 }

--- a/runa-cli/tests/fixtures/commons-exit-codes.json
+++ b/runa-cli/tests/fixtures/commons-exit-codes.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Vendored copy of the application-defined exit-code table from commons/EXIT-CODES.md. runa vendors it so the exit_codes.rs conformance test verifies against the commons contract rather than against re-stated literals. When commons changes the table, re-vendor with updated provenance; drift between this copy and its declared canonical is a review-time governance failure (commons ADR-0005 pattern).",
+  "x-tesserine-canonical": {
+    "doc_url": "https://raw.githubusercontent.com/tesserine/commons/v0.3.0-rc.1/EXIT-CODES.md",
+    "commons_ref": "v0.3.0-rc.1"
+  },
+  "application_defined": {
+    "success": 0,
+    "generic_failure": 1,
+    "usage_error": 2,
+    "blocked": 3,
+    "nothing_ready": 4,
+    "work_failed": 5,
+    "infrastructure_failure": 6
+  },
+  "reserved_external": {
+    "command_not_executable": 126,
+    "command_not_found": 127,
+    "terminated_by_signal": "128+N"
+  }
+}

--- a/runa-cli/tests/workspace_contract.rs
+++ b/runa-cli/tests/workspace_contract.rs
@@ -413,3 +413,51 @@ fn release_documentation_describes_runa_release_identity() {
         "RELEASING.md should describe the event-identity trust check"
     );
 }
+
+#[test]
+fn step_json_envelope_version_is_consistent_across_code_and_docs() {
+    fn extract(source: &str, pattern: &str, what: &str) -> u32 {
+        let versions: Vec<u32> = source
+            .match_indices(pattern)
+            .filter_map(|(start, _)| {
+                let digits: String = source[start + pattern.len()..]
+                    .chars()
+                    .take_while(char::is_ascii_digit)
+                    .collect();
+                digits.parse().ok()
+            })
+            .collect();
+        assert_eq!(
+            versions.len(),
+            1,
+            "{what} should contain exactly one integer-valued `{pattern}` occurrence, found {}",
+            versions.len()
+        );
+        versions[0]
+    }
+
+    let code_version = extract(
+        &read_workspace_file("runa-cli/src/commands/step.rs"),
+        "version: ",
+        "step.rs StepJson construction",
+    );
+    let architecture_version = extract(
+        &read_workspace_file("ARCHITECTURE.md"),
+        "the `step --json` envelope version is `",
+        "ARCHITECTURE.md step section",
+    );
+    let cli_reference_version = extract(
+        &read_workspace_file("docs/cli-reference.md"),
+        "Dry-run only. Emits a versioned JSON envelope: `{ \"version\": ",
+        "cli-reference.md step section",
+    );
+
+    assert_eq!(
+        architecture_version, code_version,
+        "ARCHITECTURE.md documents step --json envelope version {architecture_version}, but step.rs emits {code_version}"
+    );
+    assert_eq!(
+        cli_reference_version, code_version,
+        "cli-reference.md documents step --json envelope version {cli_reference_version}, but step.rs emits {code_version}"
+    );
+}

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# runa-owned implementation of the Tesserine release ceremony.
+# Convention canonical: commons RELEASE.md + ADR-0006/0011/0012
+# (https://github.com/tesserine/commons). This script verifies runa's own
+# release surface. Sibling implementations in agentd, base, commons, runa,
+# and groundwork share ancestry (commons#21) but are independently owned:
+# no repo is the tooling upstream and fixes do not propagate automatically.
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 


### PR DESCRIPTION
Part of the ecosystem-wide documentation coherence pass (refs tesserine/commons#5).

## What this does

- **Fix the one real drift**: ARCHITECTURE.md said the `step --json` envelope version is `4`; code emits `5`. A new workspace-contract test extracts the version from step.rs, ARCHITECTURE.md, and cli-reference.md and asserts agreement, so it cannot drift silently again.
- **Invariants at the code**: module headers for `session.rs` (state derives from artifacts, transactional `advance`, session-scoped exhaustion, promised scope) and `scoped_identity.rs` (canonical scope set includes invalid records; the runtime checks schema cannot express); invariant docs on `selection.rs`'s freshness machinery (input-set equality vs timestamp fallback, ValidOnly/AnyRecorded mode merge).
- **Exit-code conformance made real**: `commons_exit_codes_match_specification` now verifies the enum against a vendored commons table (`tests/fixtures/commons-exit-codes.json`, provenance-pinned to commons v0.3.0-rc.1) instead of re-stated literals.
- **docs/security.md** — consolidated index of guarantees previously scattered across four docs, each mapped to enforcement site and spec.
- **Quickstart walks the full scan → READY → produce loop** (verified against the built binary), CONTRIBUTING gains a test map.
- ARCHITECTURE cross-references the commons cognitive-state-machine draft as exploratory; README ecosystem links corrected (closes #181); RELEASING tooling-provenance section.

## Verification

- `cargo test`: 691 passed, 0 failed (including the new drift gate and the rewritten conformance test).
- Quickstart loop executed step-by-step against `target/debug/runa`; documented output matches actual output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
