### PR TITLE
[codex] Redesign project identity surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Semantic Versioning.
 
 ### Changed
 
+- Project identity and launch configuration moved to the portable
+  `.runa/project.toml` surface: `[target_project]` now emits
+  `RUNA_TARGET_PROJECT` for launched agents/MCP servers, `[launch].command`
+  replaces `[agent].command` and `--launch-command` replaces
+  `--agent-command`, retired `RUNA_FORGE_*` atoms are rejected, and `runa init`
+  writes `.runa/.gitignore` so local config, state, store, and workspace files
+  stay out of version control.
 - Transcript capture now treats `[transcript].dir` and `RUNA_TRANSCRIPT_DIR`
   as roots and writes events beneath deployment/work-unit/run paths. Events
   carry `deployment` and `run_id` fields, while existing redaction behavior is

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Both projects are in early development.
 | `runa state` | Evaluate and classify protocol readiness |
 | `runa doctor` | Check project health |
 | `runa step` | Execute the next ready protocol |
-| `runa run` | Walk the ready frontier to quiescence; live runs may override the agent command with `--agent-command -- <argv...>` |
+| `runa run` | Walk the ready frontier to quiescence; live runs may override the launch command with `--launch-command -- <argv...>` |
 | `runa go` | Advance one scoped interactive session tick through the session MCP surface |
 | `runa-mcp` | MCP server for artifact production and session driver verbs |
 
@@ -206,14 +206,15 @@ See [CLI Reference](docs/cli-reference.md) for flags, exit codes, configuration,
 
 ## Configuration
 
-`runa init` creates `.runa/config.toml` with the methodology path. Operators
-may also set durable project defaults there for live agent command,
-transcript capture, and scoped forge identity. Environment variables such as
-`RUNA_TRANSCRIPT_DIR` and `RUNA_FORGE_*` remain per-invocation overrides;
-config is the project-local default.
+`runa init` creates machine-local `.runa/config.toml`, portable
+`.runa/project.toml`, and `.runa/.gitignore`. Commit `project.toml`; keep
+`config.toml`, `state.toml`, `store/`, and `workspace/` local. Operators set
+portable launch command, transcript redaction, and typed target-project
+identity in `project.toml`; `RUNA_TRANSCRIPT_DIR` remains a per-invocation
+machine-local override.
 
 Runa ships supported agent adapters for Codex and Claude Code in `adapters/`.
-Set `[agent].command` to `./adapters/agent-codex.sh` or
+Set `[launch].command` to `./adapters/agent-codex.sh` or
 `./adapters/agent-claude-code.sh`; the adapter translates `RUNA_MCP_CONFIG` for
 the selected runtime.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,19 +15,30 @@ For `runa init`, `--config` controls where the config file is written. For all o
 
 ### Durable Project Settings
 
-Durable project settings live in `.runa/config.toml`. Environment variables
-with matching runtime meaning remain per-invocation overrides.
+Machine-local settings live in `.runa/config.toml`; portable project settings
+live in `.runa/project.toml`. `runa init` writes both files and a
+`.runa/.gitignore` that keeps `config.toml`, `state.toml`, `store/`, and
+`workspace/` local while leaving `project.toml` commit-ready.
 
 ```toml
+# .runa/config.toml
 [transcript]
 dir = "transcripts"
+
+# .runa/project.toml
+[launch]
+command = ["./adapters/agent-codex.sh", "--model", "gpt-5-codex"]
+
+[transcript]
 redact_env = ["SECRET_TOKEN", "API_KEY"]
 
-[forge]
-type = "github"
+[target_project]
+forge_type = "github"
+
+[[target_project.repositories]]
+selector = "runa"
 owner = "tesserine"
 name = "runa"
-tracker_id = "4"
 ```
 
 `[transcript].dir` enables transcript capture and is resolved relative to the
@@ -37,13 +48,12 @@ current values should be redacted from transcript events.
 `RUNA_TRANSCRIPT_REDACT_ENV`, when set to a comma-separated list, overrides the
 configured list.
 
-`[forge]` supplies the active scoped work-unit deployment identity. Runa uses
-it when validating tracker-backed `work-unit` roots and injects the resolved
-`RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
-`RUNA_FORGE_TRACKER_ID` values into launched agent and MCP environments.
-Any non-empty matching `RUNA_FORGE_*` environment variable overrides the
-configured field for that invocation. The forge type still defaults to `github`
-when neither config nor env specifies one.
+`[target_project]` supplies the typed project forge identity. Runa uses it when
+validating tracker-backed `work-unit` roots and injects the structured
+`RUNA_TARGET_PROJECT` JSON payload into launched agent and MCP environments.
+Mechanics select configured repositories or trackers by selector; they must not
+accept repository coordinates from the agent. A one-repository project works as
+the one-element case without an explicit selector.
 
 ### Logging
 
@@ -61,22 +71,22 @@ filter = "info"   # any tracing env-filter directive
 
 ### Agent Execution
 
-Live `runa step` and `runa go` require an `[agent].command` entry in the
-config. Live `runa run` uses the same config entry by default, but a single
-invocation may override it with `--agent-command -- <argv tokens>`:
+Live `runa step` and `runa go` require a `[launch].command` entry in
+`.runa/project.toml`. Live `runa run` uses the same config entry by default,
+but a single invocation may override it with `--launch-command -- <argv tokens>`:
 
 ```toml
-[agent]
+[launch]
 command = ["./adapters/agent-codex.sh", "--model", "gpt-5-codex"]
 ```
 
 ```toml
-[agent]
+[launch]
 command = ["./adapters/agent-claude-code.sh", "-p", "--dangerously-skip-permissions"]
 ```
 
 ```bash
-runa run --agent-command -- ./adapters/agent-codex.sh --model gpt-5-codex
+runa run --launch-command -- ./adapters/agent-codex.sh --model gpt-5-codex
 ```
 
 Runa executes the configured argv unmodified in the project root with stdout
@@ -89,7 +99,7 @@ child process. Runtime-specific translation, such as wrapping that payload in a
 client-specific config file, belongs to the runtime or adapter, not to runa.
 
 The supported runtime adapters live in `adapters/`: `agent-codex.sh` for Codex
-and `agent-claude-code.sh` for Claude Code. Point `[agent].command` at one of
+and `agent-claude-code.sh` for Claude Code. Point `[launch].command` at one of
 those scripts and pass runtime-specific options after the script path. The
 Codex adapter requires `jq` because Codex accepts external MCP servers through
 `-c mcp_servers.<name>.*` TOML overrides rather than a JSON config file. It
@@ -97,7 +107,7 @@ registers each invocation under a process-scoped server name so an existing
 operator-defined `mcp_servers.runa` entry is left untouched.
 Migration note: older documentation used
 `./examples/agent-claude-code.sh` for Claude Code. That path no longer exists;
-repoint existing `[agent].command` values to
+repoint existing `[launch].command` values to
 `./adapters/agent-claude-code.sh`.
 
 When transcript capture is enabled through `[transcript].dir` or
@@ -232,7 +242,7 @@ When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 
 With `--dry-run`, text output prints the next execution plus the grouped READY/BLOCKED/WAITING status view. The execution entry includes the protocol name, optional work unit, the trigger that activated it, an MCP server config, and the serialized agent-facing context payload (protocol name, optional work unit, instruction content, valid required and available accepted inputs with display paths and content hashes, and expected outputs split into `produces`, `may_produce`, and `required_output_choices`). Dry-run does not require a discoverable `runa-mcp` binary. If the in-scope graph contains a hard dependency cycle, `step` reports it as a warning, exposes the scope-filtered cycle in JSON, and keeps those participants out of `READY`.
 
-Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux host. If the initial scan finds no READY work, `step` performs one final re-scan and re-evaluates readiness before returning a no-work outcome. If that refreshed state exposes a READY candidate, the same invocation executes that one protocol. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit without requiring `runa-mcp`: exit `3` when work remains blocked, waiting, or trapped in a cycle, and exit `4` when no actionable work remains because outputs are already current. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), exports the candidate MCP launch config through `RUNA_MCP_CONFIG`, launches the configured agent argv unmodified, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
+Without `--dry-run`, `step` requires `[launch].command` in `.runa/project.toml` and a Linux host. If the initial scan finds no READY work, `step` performs one final re-scan and re-evaluates readiness before returning a no-work outcome. If that refreshed state exposes a READY candidate, the same invocation executes that one protocol. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit without requiring `runa-mcp`: exit `3` when work remains blocked, waiting, or trapped in a cycle, and exit `4` when no actionable work remains because outputs are already current. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), exports the candidate MCP launch config through `RUNA_MCP_CONFIG`, launches the configured argv unmodified, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
 
 **Flags:**
 
@@ -254,7 +264,7 @@ Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux
 ### `runa run`
 
 ```bash
-runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--agent-command -- <argv tokens>] [--config <PATH>]
+runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--launch-command -- <argv tokens>] [--config <PATH>]
 ```
 
 The cascade command. Walks the READY frontier repeatedly until quiescence instead of stopping after one execution.
@@ -263,10 +273,12 @@ Without `--work-unit`, `run` considers only unscoped protocols. With `--work-uni
 
 With `--ticket <REF>` (mutually exclusive with `--work-unit`), `run` opens a
 cold-start session from a forge ticket reference. Accepted forms are a bare
-number, `#<N>`, `owner/repo#<N>`, a GitHub issue URL, or
-`sourcehut:<tracker_id>#<N>`; the asserted deployment must match the active
-`[forge]` deployment, and a bare reference inherits it. When the referenced
-work-unit already exists, `run` behaves as `--work-unit <id>` on it. Otherwise
+number, `#<N>`, `owner/repo#<N>`, a GitHub issue URL,
+`github:<tracker-selector>#<N>`, or `sourcehut:<tracker-selector-or-id>#<N>`;
+the asserted deployment must resolve in the configured target project, and a
+bare reference inherits the sole configured tracker identity when exactly one
+exists. When the referenced work-unit already exists, `run` behaves as
+`--work-unit <id>` on it. Otherwise
 the methodology's acquisition surface (the sole unscoped producer of the
 `work-unit` artifact) runs first — under `--dry-run` it is projected as the
 `current, entry` step with the acquired work-unit's `take` projected after it;
@@ -282,7 +294,7 @@ When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 
 With `--dry-run`, projects the full optimistic cascade from the same scope-filtered execution order used by evaluation and planning, plus declared `produces` outputs, dependency edges, and the caller-supplied evaluation scope. `may_produce` outputs do not advance the projection unless they already exist on disk. Required output choice members are branch-dependent, so projection uses an already-present single member when one exists and otherwise does not synthesize a choice branch. Initially ready entries include MCP config and full context on first emission; downstream projected entries carry only protocol name, optional work unit, trigger, and projection kind. The projection never synthesizes artifact values, forks the store, bypasses schema validation, or discovers sibling work units from artifact state.
 
-Without `--dry-run`, requires a Linux host plus an effective agent command. `run` resolves that command in this order: `--agent-command -- <argv tokens>` when supplied, otherwise `[agent].command` from config, otherwise the existing `AgentCommandNotConfigured` error. If `--agent-command` is present but no usable argv tokens follow the `--`, `run` fails with `AgentCommandNotConfigured` and does not fall back to config. If no READY protocol is ever dispatched, `run` exits `4` (`nothing_ready`) instead of treating that invocation as `success`. Failed candidates are skipped for the rest of the invocation; any artifacts emitted before failure are still reconciled into workspace state for downstream readiness. Previously exhausted work reopens when a later reconciliation changes relevant inputs.
+Without `--dry-run`, requires a Linux host plus an effective launch command. `run` resolves that command in this order: `--launch-command -- <argv tokens>` when supplied, otherwise `[launch].command` from `.runa/project.toml`, otherwise an infrastructure error naming the missing launch command. If `--launch-command` is present but no usable argv tokens follow the `--`, `run` fails and does not fall back to config. If no READY protocol is ever dispatched, `run` exits `4` (`nothing_ready`) instead of treating that invocation as `success`. Failed candidates are skipped for the rest of the invocation; any artifacts emitted before failure are still reconciled into workspace state for downstream readiness. Previously exhausted work reopens when a later reconciliation changes relevant inputs.
 
 **Interrupt behavior.** The first `Ctrl-C` is boundary-scoped: the current protocol run completes its scan and postcondition reconciliation. After that reconciliation, `run` exits `130` only if the interrupt prevented the next READY candidate from starting. If no further READY work remains, the quiescent topology outcome takes precedence. A second `Ctrl-C` forces immediate exit with status `130`; the isolated child process may continue running after `runa` terminates.
 
@@ -292,7 +304,7 @@ Without `--dry-run`, requires a Linux host plus an effective agent command. `run
 - `--json` — Dry-run only. Emits version `2` and otherwise uses the same envelope structure as `runa step --json`, but `execution_plan` may contain multiple entries including projected downstream work.
 - `--work-unit <ID>` — Plan or execute only scoped protocols for the delegated work unit `<ID>`.
 - `--ticket <REF>` — Open a cold-start session from a forge ticket reference. Mutually exclusive with `--work-unit`. An unparseable reference or one that disagrees with the active deployment exits `2`; a manifest with no single unscoped `work-unit` producer exits `6`; acquisition that produces no matching work-unit exits `5`.
-- `--agent-command -- <argv tokens>` — Override `[agent].command` for this live `run` invocation. Pass the agent argv after `--` so hyphen-prefixed tokens are forwarded unchanged.
+- `--launch-command -- <argv tokens>` — Override `[launch].command` for this live `run` invocation. Pass the launch argv after `--` so hyphen-prefixed tokens are forwarded unchanged.
 
 **Exit codes** (`4` is live-only; dry-run still reflects current topology state, not the projection):
 
@@ -378,9 +390,10 @@ resolves them from the local filesystem, so adapters do not depend on child
 process cwd to launch `runa-mcp`. Transcript environment variables are forwarded
 into the MCP config when transcript capture is enabled, which lets the MCP
 server append tool events under the same deployment/work-unit/run transcript
-path as the CLI execution events. Configured forge identity is forwarded the same way through
-`RUNA_FORGE_*` entries so tooling inside the agent session can
-use the project-local identity without user-global shell state.
+path as the CLI execution events. The configured target project is forwarded as
+`RUNA_TARGET_PROJECT`, so tooling inside the agent session can select
+configured repositories or trackers by selector without user-global shell
+state.
 
 **Environment variables:**
 
@@ -391,7 +404,7 @@ use the project-local identity without user-global shell state.
   override for one invocation.
 - `RUNA_TRANSCRIPT_DEPLOYMENT`, `RUNA_TRANSCRIPT_RUN_ID` — Internal transcript
   attribution values propagated by runa into child MCP servers.
-- `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`,
-  `RUNA_FORGE_TRACKER_ID` — Forge identity field overrides for one
-  invocation.
+- `RUNA_TARGET_PROJECT` — Structured project payload propagated into launched
+  environments. It contains typed forge identity, configured repositories, and
+  configured trackers.
 - `RUST_LOG` — Tracing filter override for stderr diagnostics.

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -89,27 +89,47 @@ Scoped evaluation is a runtime capability. When the caller supplies
 `work-unit` artifact instance when any such instances exist. Tracker-looking
 aliases such as bare issue numbers are not accepted as scope identifiers.
 
-For tracker-backed delegated work, runa also owns the active deployment
-identity used by scoped work-unit validation. The durable operator surface is
-the project-local `[forge]` config section:
+For tracker-backed delegated work, runa also owns the configured target
+project used by scoped work-unit validation and launched forge mechanics. The
+portable operator surface is `.runa/project.toml`:
 
 ```toml
-[forge]
-type = "github"
+[target_project]
+forge_type = "github"
+
+[[target_project.repositories]]
+selector = "runa"
 owner = "tesserine"
 name = "runa"
+
+[[target_project.repositories]]
+selector = "groundwork"
+owner = "tesserine"
+name = "groundwork"
+
+[[target_project.trackers]]
+selector = "groundwork"
+repository = "groundwork"
 tracker_id = "4"
 ```
 
-The matching per-invocation override and launched-runtime environment surface
-is runa-owned: `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
-`RUNA_FORGE_TRACKER_ID`. Non-empty environment values override matching config
-fields, and `RUNA_FORGE_TYPE` defaults to `github` when omitted.
+The single-repository project is the one-element case: if exactly one
+repository or tracker is configured, consumers may resolve that one without a
+selector. Multi-repository projects require the agent or methodology mechanic
+to provide a configured selector such as `repository_selector = "groundwork"`;
+the agent never supplies repository coordinates.
 
-Runa computes the active deployment identity from those atoms. For GitHub, the
-identity is `github:<owner>/<name>`. For SourceHut, the identity is
-`sourcehut:<tracker_id>`. Endpoint or host resolution is not part of scoped
-identity validation.
+The launched-runtime environment surface is the runa-owned
+`RUNA_TARGET_PROJECT` variable. Its value is a JSON payload containing
+`version`, typed `forge_type`, `repositories`, and `trackers` arrays. The
+payload is the same project identity surface rendered for children; the retired
+single-repository `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
+`RUNA_FORGE_TRACKER_ID` atoms are rejected when non-empty.
+
+Runa computes configured deployment identities from the typed project payload.
+For GitHub repositories, the identity is `github:<owner>/<name>`. For SourceHut
+trackers, the identity is `sourcehut:<tracker_id>`. Endpoint or host resolution
+is not part of scoped identity validation.
 
 When a valid recorded `work-unit` root contains a forge-tagged tracker handle,
 runa enforces the runtime checks that JSON Schema cannot express: the canonical
@@ -124,15 +144,17 @@ checks described here.
 A session may be opened from a forge ticket reference instead of a recorded
 `work-unit` instance id, via `runa run --ticket <REF>` or
 `runa go --ticket <REF>`. The accepted reference forms are a bare ticket number,
-`#<N>`, `owner/repo#<N>`, a GitHub issue URL, or `sourcehut:<tracker_id>#<N>`.
+`#<N>`, `owner/repo#<N>`, a GitHub issue URL, `github:<tracker-selector>#<N>`,
+or `sourcehut:<tracker-selector-or-id>#<N>`.
 runa parses the reference and normalizes it to a tracker identity
 (`github:<owner>/<name>:<N>` or `sourcehut:<tracker_id>:<N>`); a reference that
-asserts a deployment other than the active one is rejected, and a bare reference
-inherits the active deployment identity. **runa never reads ticket content** —
+asserts a deployment not present in the configured target project is rejected,
+and a bare reference inherits the sole configured tracker identity when exactly
+one exists. **runa never reads ticket content** —
 the reference carries identity only, and the methodology performs all forge
 reads through its own mechanics. During entry, runa exports `RUNA_ENTRY_TICKET`
-(the ticket number) alongside the `RUNA_FORGE_*` atoms so those mechanics can
-resolve the ticket.
+(the ticket number) alongside `RUNA_TARGET_PROJECT` so those mechanics can
+resolve the ticket by selector.
 
 The acquisition surface runa serves is the single unscoped protocol whose
 declared outputs (`produces`, `may_produce`, or required output choice members)

--- a/libagent/src/context.rs
+++ b/libagent/src/context.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::project::TargetProjectPayload;
 use crate::{ArtifactStore, ProtocolDeclaration, ValidationStatus};
 
 /// Whether an artifact is a hard dependency (`Requires`) or optional input (`Accepts`)
@@ -84,6 +85,7 @@ pub struct ExpectedOutputs {
 pub struct ContextInjection {
     pub protocol: String,
     pub work_unit: Option<String>,
+    pub target_project: Option<TargetProjectPayload>,
     pub instructions: String,
     pub inputs: Vec<ArtifactRef>,
     pub expected_outputs: ExpectedOutputs,
@@ -97,6 +99,8 @@ pub struct ContextInjection {
 pub struct ContextInjectionView {
     pub protocol: String,
     pub work_unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_project: Option<TargetProjectPayload>,
     pub instructions: String,
     pub inputs: Vec<ArtifactRefView>,
     pub expected_outputs: ExpectedOutputs,
@@ -134,6 +138,7 @@ pub fn build_context(
     ContextInjection {
         protocol: protocol.name.clone(),
         work_unit: work_unit.map(str::to_owned),
+        target_project: None,
         instructions: protocol.instructions.clone().unwrap_or_default(),
         inputs,
         expected_outputs: ExpectedOutputs {
@@ -190,6 +195,22 @@ pub fn render_context_prompt(context: &ContextInjection) -> String {
              listed output tools.",
             entry.reference, entry.ticket_number
         ));
+    }
+
+    if let Some(target_project) = &context.target_project {
+        sections.push("\n## Target project".to_string());
+        match serde_json::to_string_pretty(target_project) {
+            Ok(payload) => {
+                sections.push(
+                    "The configured target project is delivered as structured JSON. \
+                     Select repositories or trackers by their configured selector; \
+                     do not supply repository coordinates to forge mechanics."
+                        .to_string(),
+                );
+                sections.push(format!("```json\n{payload}\n```"));
+            }
+            Err(error) => sections.push(format!("(Could not render target project: {error})")),
+        }
     }
 
     if !context.instructions.is_empty() {
@@ -365,6 +386,7 @@ impl From<&ContextInjection> for ContextInjectionView {
         Self {
             protocol: context.protocol.clone(),
             work_unit: context.work_unit.clone(),
+            target_project: context.target_project.clone(),
             instructions: context.instructions.clone(),
             inputs: context.inputs.iter().map(ArtifactRefView::from).collect(),
             expected_outputs: context.expected_outputs.clone(),
@@ -595,6 +617,7 @@ mod tests {
         let context = ContextInjection {
             protocol: "implement".into(),
             work_unit: None,
+            target_project: None,
             instructions: String::new(),
             inputs: vec![ArtifactRef {
                 artifact_type: "constraints".into(),
@@ -709,6 +732,7 @@ mod tests {
         let prompt = render_context_prompt(&ContextInjection {
             protocol: "implement".into(),
             work_unit: None,
+            target_project: None,
             instructions: "# Follow the protocol\n".into(),
             inputs: Vec::new(),
             entry: None,
@@ -734,6 +758,7 @@ mod tests {
         let prompt = render_context_prompt(&ContextInjection {
             protocol: "decompose".into(),
             work_unit: None,
+            target_project: None,
             instructions: "# decompose\n".into(),
             inputs: Vec::new(),
             entry: Some(EntryDelivery {
@@ -764,6 +789,7 @@ mod tests {
         let prompt = render_context_prompt(&ContextInjection {
             protocol: "implement".into(),
             work_unit: Some("wu-a".into()),
+            target_project: None,
             instructions: String::new(),
             inputs: Vec::new(),
             entry: None,
@@ -782,6 +808,7 @@ mod tests {
         let prompt = render_context_prompt(&ContextInjection {
             protocol: "implement".into(),
             work_unit: None,
+            target_project: None,
             instructions: String::new(),
             inputs: vec![ArtifactRef {
                 artifact_type: "constraints".into(),

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -482,7 +482,7 @@ mod tests {
             forge_type: crate::project::ForgeType::Github,
             repositories: vec![crate::project::RepositoryConfig {
                 selector: "default".to_string(),
-                host: "github.com".to_string(),
+                host: None,
                 owner: owner.to_string(),
                 name: name.to_string(),
             }],

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -48,8 +48,10 @@ enum AssertedForge {
     None,
     /// `owner/repo#N` or a GitHub issue URL.
     Github { owner: String, name: String },
-    /// `sourcehut:<tracker_id>#N`.
-    Sourcehut { tracker_id: String },
+    /// `github:<tracker_selector>#N`.
+    GithubTracker { selector: String },
+    /// `sourcehut:<tracker_selector>#N` or legacy `sourcehut:<tracker_id>#N`.
+    Sourcehut { tracker: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,9 +76,8 @@ pub enum EntryError {
     NoAcquisitionSurface { scoped_producers: Vec<String> },
     /// More than one unscoped protocol declares the `work-unit` artifact.
     AmbiguousAcquisitionSurface { candidates: Vec<String> },
-    /// A bare reference cannot inherit an active forge type that is neither
-    /// `github` nor `sourcehut`.
-    UnsupportedForge { forge_type: String },
+    /// A qualified reference names a tracker that is not configured.
+    UnknownTracker { selector: String },
     /// Acquisition completed its contract but materialized no matching work-unit.
     Unresolved { reference: String },
 }
@@ -118,9 +119,9 @@ impl fmt::Display for EntryError {
                 "more than one unscoped protocol produces '{WORK_UNIT_ARTIFACT_TYPE}' ({}); cold-start ticket entry requires a single acquisition surface",
                 candidates.join(", ")
             ),
-            EntryError::UnsupportedForge { forge_type } => write!(
+            EntryError::UnknownTracker { selector } => write!(
                 f,
-                "active forge type '{forge_type}' is not supported for a bare ticket reference; use an explicit 'owner/repo#N' (github) or 'sourcehut:<tracker_id>#N' form, or set a supported RUNA_FORGE_TYPE"
+                "ticket reference names tracker '{selector}', which is not declared by the configured target project"
             ),
             EntryError::Unresolved { reference } => write!(
                 f,
@@ -168,16 +169,30 @@ fn parse_ticket_reference(raw: &str) -> Result<ParsedReference, EntryError> {
         });
     }
 
-    if let Some(rest) = trimmed.strip_prefix("sourcehut:") {
-        let (tracker_id, tail) = rest.split_once('#').ok_or_else(invalid)?;
+    if let Some(rest) = trimmed.strip_prefix("github:") {
+        let (selector, tail) = rest.split_once('#').ok_or_else(invalid)?;
         let number = parse_number(tail).ok_or_else(invalid)?;
-        if tracker_id.is_empty() {
+        if selector.is_empty() {
+            return Err(invalid());
+        }
+        return Ok(ParsedReference {
+            number,
+            asserted: AssertedForge::GithubTracker {
+                selector: selector.to_string(),
+            },
+        });
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("sourcehut:") {
+        let (tracker, tail) = rest.split_once('#').ok_or_else(invalid)?;
+        let number = parse_number(tail).ok_or_else(invalid)?;
+        if tracker.is_empty() {
             return Err(invalid());
         }
         return Ok(ParsedReference {
             number,
             asserted: AssertedForge::Sourcehut {
-                tracker_id: tracker_id.to_string(),
+                tracker: tracker.to_string(),
             },
         });
     }
@@ -221,60 +236,111 @@ fn bind_reference_identity(
     let number = parsed.number;
     match &parsed.asserted {
         AssertedForge::Github { owner, name } => {
-            require_forge(identity, "github")?;
-            let active = require_atom(identity.owner.as_deref(), "RUNA_FORGE_OWNER")?;
-            let active_name = require_atom(identity.name.as_deref(), "RUNA_FORGE_NAME")?;
-            if owner != active || name != active_name {
+            require_forge(identity, crate::project::ForgeType::Github)?;
+            let reference_identity = format!("github:{owner}/{name}");
+            if !identity
+                .configured_tracker_identities()
+                .iter()
+                .any(|configured| configured == &reference_identity)
+            {
                 return Err(EntryError::DeploymentDisagreement {
-                    reference_identity: format!("github:{owner}/{name}"),
-                    active_identity: format!("github:{active}/{active_name}"),
+                    reference_identity,
+                    active_identity: display_configured_identity(identity),
                 });
             }
             Ok(github_ticket(owner, name, number))
         }
-        AssertedForge::Sourcehut { tracker_id } => {
-            require_forge(identity, "sourcehut")?;
-            let active = require_atom(identity.tracker_id.as_deref(), "RUNA_FORGE_TRACKER_ID")?;
-            if tracker_id != active {
-                return Err(EntryError::DeploymentDisagreement {
-                    reference_identity: format!("sourcehut:{tracker_id}"),
-                    active_identity: format!("sourcehut:{active}"),
-                });
-            }
+        AssertedForge::GithubTracker { selector } => {
+            require_forge(identity, crate::project::ForgeType::Github)?;
+            let tracker = identity.tracker_by_selector(selector).ok_or_else(|| {
+                EntryError::UnknownTracker {
+                    selector: selector.clone(),
+                }
+            })?;
+            let repository = tracker
+                .repository
+                .as_deref()
+                .and_then(|selector| identity.repository_by_selector(selector))
+                .ok_or_else(|| EntryError::UnknownTracker {
+                    selector: selector.clone(),
+                })?;
+            Ok(github_ticket(&repository.owner, &repository.name, number))
+        }
+        AssertedForge::Sourcehut { tracker } => {
+            require_forge(identity, crate::project::ForgeType::Sourcehut)?;
+            let configured = identity
+                .tracker_by_selector(tracker)
+                .or_else(|| {
+                    identity
+                        .trackers
+                        .iter()
+                        .find(|candidate| candidate.tracker_id.as_deref() == Some(tracker.as_str()))
+                })
+                .ok_or_else(|| EntryError::UnknownTracker {
+                    selector: tracker.clone(),
+                })?;
+            let tracker_id =
+                configured
+                    .tracker_id
+                    .as_deref()
+                    .ok_or_else(|| EntryError::UnknownTracker {
+                        selector: tracker.clone(),
+                    })?;
             Ok(sourcehut_ticket(tracker_id, number))
         }
-        AssertedForge::None => match identity.forge_type.as_str() {
-            "github" => {
-                let owner = require_atom(identity.owner.as_deref(), "RUNA_FORGE_OWNER")?;
-                let name = require_atom(identity.name.as_deref(), "RUNA_FORGE_NAME")?;
-                Ok(github_ticket(owner, name, number))
-            }
-            "sourcehut" => {
-                let tracker_id =
-                    require_atom(identity.tracker_id.as_deref(), "RUNA_FORGE_TRACKER_ID")?;
-                Ok(sourcehut_ticket(tracker_id, number))
-            }
-            other => Err(EntryError::UnsupportedForge {
-                forge_type: other.to_string(),
-            }),
-        },
+        AssertedForge::None => bind_bare_reference(identity, number),
     }
 }
 
-fn require_forge(identity: &ResolvedForgeIdentity, expected: &str) -> Result<(), EntryError> {
+fn bind_bare_reference(
+    identity: &ResolvedForgeIdentity,
+    number: u64,
+) -> Result<TicketRef, EntryError> {
+    match identity.configured_tracker_identities().as_slice() {
+        [only] if only.starts_with("github:") => {
+            let repository = only.trim_start_matches("github:");
+            let (owner, name) =
+                repository
+                    .split_once('/')
+                    .ok_or_else(|| EntryError::InvalidReference {
+                        supplied: only.clone(),
+                    })?;
+            Ok(github_ticket(owner, name, number))
+        }
+        [only] if only.starts_with("sourcehut:") => Ok(sourcehut_ticket(
+            only.trim_start_matches("sourcehut:"),
+            number,
+        )),
+        [] => Err(EntryError::MissingDeploymentIdentity {
+            variable: "RUNA_TARGET_PROJECT",
+        }),
+        _ => Err(EntryError::DeploymentDisagreement {
+            reference_identity: format!("#{number}"),
+            active_identity: display_configured_identity(identity),
+        }),
+    }
+}
+
+fn display_configured_identity(identity: &ResolvedForgeIdentity) -> String {
+    let identities = identity.configured_tracker_identities();
+    if identities.is_empty() {
+        identity.forge_type.to_string()
+    } else {
+        identities.join(", ")
+    }
+}
+
+fn require_forge(
+    identity: &ResolvedForgeIdentity,
+    expected: crate::project::ForgeType,
+) -> Result<(), EntryError> {
     if identity.forge_type == expected {
         return Ok(());
     }
     Err(EntryError::DeploymentDisagreement {
         reference_identity: expected.to_string(),
-        active_identity: identity.forge_type.clone(),
+        active_identity: identity.forge_type.to_string(),
     })
-}
-
-fn require_atom<'a>(value: Option<&'a str>, variable: &'static str) -> Result<&'a str, EntryError> {
-    value
-        .filter(|value| !value.is_empty())
-        .ok_or(EntryError::MissingDeploymentIdentity { variable })
 }
 
 fn github_ticket(owner: &str, name: &str, number: u64) -> TicketRef {
@@ -413,19 +479,36 @@ mod tests {
 
     fn github_identity(owner: &str, name: &str) -> ResolvedForgeIdentity {
         ResolvedForgeIdentity {
-            forge_type: "github".to_string(),
-            owner: Some(owner.to_string()),
-            name: Some(name.to_string()),
-            tracker_id: None,
+            forge_type: crate::project::ForgeType::Github,
+            repositories: vec![crate::project::RepositoryConfig {
+                selector: "default".to_string(),
+                host: "github.com".to_string(),
+                owner: owner.to_string(),
+                name: name.to_string(),
+            }],
+            trackers: vec![crate::project::TrackerConfig {
+                selector: "default".to_string(),
+                repository: Some("default".to_string()),
+                host: None,
+                owner: None,
+                name: None,
+                tracker_id: None,
+            }],
         }
     }
 
     fn sourcehut_identity(tracker_id: &str) -> ResolvedForgeIdentity {
         ResolvedForgeIdentity {
-            forge_type: "sourcehut".to_string(),
-            owner: None,
-            name: None,
-            tracker_id: Some(tracker_id.to_string()),
+            forge_type: crate::project::ForgeType::Sourcehut,
+            repositories: Vec::new(),
+            trackers: vec![crate::project::TrackerConfig {
+                selector: "default".to_string(),
+                repository: None,
+                host: Some("weforge.build".to_string()),
+                owner: Some("operator".to_string()),
+                name: Some("weforge".to_string()),
+                tracker_id: Some(tracker_id.to_string()),
+            }],
         }
     }
 
@@ -512,35 +595,49 @@ mod tests {
     }
 
     #[test]
-    fn missing_owner_atom_is_rejected() {
+    fn bare_reference_without_configured_tracker_is_rejected() {
         let identity = ResolvedForgeIdentity {
-            forge_type: "github".to_string(),
-            owner: None,
-            name: Some("runa".to_string()),
-            tracker_id: None,
+            forge_type: crate::project::ForgeType::Github,
+            repositories: Vec::new(),
+            trackers: Vec::new(),
         };
         let error = resolve_ticket_reference("14", &identity).unwrap_err();
         assert!(matches!(
             error,
             EntryError::MissingDeploymentIdentity {
-                variable: "RUNA_FORGE_OWNER"
+                variable: "RUNA_TARGET_PROJECT"
             }
         ));
     }
 
     #[test]
-    fn bare_reference_on_unsupported_forge_is_rejected() {
-        // A typo or future custom forge type must not silently bind as GitHub.
+    fn bare_reference_with_multiple_trackers_is_rejected_as_ambiguous() {
         let identity = ResolvedForgeIdentity {
-            forge_type: "gitlab".to_string(),
-            owner: Some("tesserine".to_string()),
-            name: Some("runa".to_string()),
-            tracker_id: None,
+            forge_type: crate::project::ForgeType::Sourcehut,
+            repositories: Vec::new(),
+            trackers: vec![
+                crate::project::TrackerConfig {
+                    selector: "one".to_string(),
+                    repository: None,
+                    host: Some("weforge.build".to_string()),
+                    owner: Some("operator".to_string()),
+                    name: Some("one".to_string()),
+                    tracker_id: Some("1".to_string()),
+                },
+                crate::project::TrackerConfig {
+                    selector: "two".to_string(),
+                    repository: None,
+                    host: Some("weforge.build".to_string()),
+                    owner: Some("operator".to_string()),
+                    name: Some("two".to_string()),
+                    tracker_id: Some("2".to_string()),
+                },
+            ],
         };
 
         assert!(matches!(
             resolve_ticket_reference("14", &identity),
-            Err(EntryError::UnsupportedForge { forge_type }) if forge_type == "gitlab"
+            Err(EntryError::DeploymentDisagreement { .. })
         ));
     }
 

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -55,8 +55,10 @@ pub use model::{
     UnscopedOutputRequiresWorkUnitError, validate_output_scope,
 };
 pub use project::{
-    Config, ForgeConfig, LoadedProject, LogFormat, LoggingConfig, ProjectError, State,
-    TranscriptConfig,
+    Config, ForgeType, LaunchConfig, LoadedProject, LogFormat, LoggingConfig, MachineConfig,
+    PROJECT_FILENAME, ProjectConfig, ProjectError, RUNA_TARGET_PROJECT, RepositoryConfig, State,
+    TargetProjectConfig, TargetProjectPayload, TrackerConfig, TranscriptConfig,
+    UnsupportedForgeError, target_project_env,
 };
 pub use projection::{
     ProjectionCandidate, ProjectionClass, project_cascade, project_entry_cascade,

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -13,9 +13,11 @@ use crate::{ArtifactStore, DependencyGraph, GraphError, Manifest, ManifestError,
 
 pub const RUNA_DIR: &str = ".runa";
 pub const CONFIG_FILENAME: &str = "config.toml";
+pub const PROJECT_FILENAME: &str = "project.toml";
 pub const STATE_FILENAME: &str = "state.toml";
 pub const DEFAULT_WORKSPACE_DIR: &str = "workspace";
 pub const STORE_DIRNAME: &str = "store";
+pub const RUNA_TARGET_PROJECT: &str = "RUNA_TARGET_PROJECT";
 
 /// Output format for tracing events written to stderr.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -41,14 +43,14 @@ impl LoggingConfig {
     }
 }
 
-/// The `[agent]` section of `.runa/config.toml`.
+/// The `[launch]` section of `.runa/project.toml`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct AgentConfig {
+pub struct LaunchConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<Vec<String>>,
 }
 
-impl AgentConfig {
+impl LaunchConfig {
     fn is_default(&self) -> bool {
         self == &Self::default()
     }
@@ -69,11 +71,67 @@ impl TranscriptConfig {
     }
 }
 
-/// The `[forge]` section of `.runa/config.toml`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct ForgeConfig {
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub forge_type: Option<String>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ForgeType {
+    #[default]
+    Github,
+    Sourcehut,
+}
+
+impl ForgeType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Github => "github",
+            Self::Sourcehut => "sourcehut",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, UnsupportedForgeError> {
+        match value {
+            "github" => Ok(Self::Github),
+            "sourcehut" => Ok(Self::Sourcehut),
+            other => Err(UnsupportedForgeError {
+                forge_type: other.to_string(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for ForgeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedForgeError {
+    pub forge_type: String,
+}
+
+impl fmt::Display for UnsupportedForgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unsupported forge type `{}`", self.forge_type)
+    }
+}
+
+impl std::error::Error for UnsupportedForgeError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryConfig {
+    pub selector: String,
+    pub host: String,
+    pub owner: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerConfig {
+    pub selector: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,24 +140,76 @@ pub struct ForgeConfig {
     pub tracker_id: Option<String>,
 }
 
-impl ForgeConfig {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TargetProjectConfig {
+    #[serde(default)]
+    pub forge_type: ForgeType,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<RepositoryConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trackers: Vec<TrackerConfig>,
+}
+
+impl TargetProjectConfig {
     fn is_default(&self) -> bool {
         self == &Self::default()
     }
 }
 
-/// On-disk format for `.runa/config.toml` — operator configuration.
+/// Structured child-process payload delivered through `RUNA_TARGET_PROJECT`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TargetProjectPayload {
+    pub version: u32,
+    pub forge_type: ForgeType,
+    pub repositories: Vec<RepositoryConfig>,
+    pub trackers: Vec<TrackerConfig>,
+}
+
+impl From<&TargetProjectConfig> for TargetProjectPayload {
+    fn from(value: &TargetProjectConfig) -> Self {
+        Self {
+            version: 1,
+            forge_type: value.forge_type,
+            repositories: value.repositories.clone(),
+            trackers: value.trackers.clone(),
+        }
+    }
+}
+
+/// Effective runtime configuration after combining machine-local config and
+/// portable project config.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     pub methodology_path: String,
     #[serde(default, skip_serializing_if = "LoggingConfig::is_default")]
     pub logging: LoggingConfig,
-    #[serde(default, skip_serializing_if = "AgentConfig::is_default")]
-    pub agent: AgentConfig,
+    #[serde(default, skip_serializing_if = "LaunchConfig::is_default")]
+    pub launch: LaunchConfig,
     #[serde(default, skip_serializing_if = "TranscriptConfig::is_default")]
     pub transcript: TranscriptConfig,
-    #[serde(default, skip_serializing_if = "ForgeConfig::is_default")]
-    pub forge: ForgeConfig,
+    #[serde(default, skip_serializing_if = "TargetProjectConfig::is_default")]
+    pub target_project: TargetProjectConfig,
+}
+
+/// On-disk format for machine-local `.runa/config.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MachineConfig {
+    pub methodology_path: String,
+    #[serde(default, skip_serializing_if = "LoggingConfig::is_default")]
+    pub logging: LoggingConfig,
+    #[serde(default, skip_serializing_if = "TranscriptConfig::is_default")]
+    pub transcript: TranscriptConfig,
+}
+
+/// On-disk format for portable `.runa/project.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ProjectConfig {
+    #[serde(default, skip_serializing_if = "LaunchConfig::is_default")]
+    pub launch: LaunchConfig,
+    #[serde(default, skip_serializing_if = "TranscriptConfig::is_default")]
+    pub transcript: TranscriptConfig,
+    #[serde(default, skip_serializing_if = "TargetProjectConfig::is_default")]
+    pub target_project: TargetProjectConfig,
 }
 
 /// On-disk format for `.runa/state.toml` — initialization metadata managed by runa.
@@ -127,6 +237,8 @@ pub enum ProjectError {
     ConfigPathNotFound(PathBuf),
     /// Config file exists but cannot be parsed.
     ConfigParseFailed(String),
+    /// Project config exists but cannot be parsed.
+    ProjectConfigParseFailed(String),
     /// `.runa/state.toml` is missing — project not initialized.
     NotInitialized,
     /// Filesystem I/O failure.
@@ -152,6 +264,9 @@ impl fmt::Display for ProjectError {
             }
             ProjectError::ConfigParseFailed(detail) => {
                 write!(f, "failed to parse config: {detail}")
+            }
+            ProjectError::ProjectConfigParseFailed(detail) => {
+                write!(f, "failed to parse project config: {detail}")
             }
             ProjectError::NotInitialized => {
                 write!(f, "not a runa project (run 'runa init' first)")
@@ -235,6 +350,7 @@ pub fn read_config(
     working_dir: &Path,
     config_override: Option<&Path>,
 ) -> Result<Config, ProjectError> {
+    reject_retired_forge_env()?;
     let config_path = resolve_config(working_dir, config_override)?;
     let config_content = std::fs::read_to_string(&config_path).map_err(ProjectError::Io)?;
     let config_value: toml::Value = toml::from_str(&config_content)
@@ -245,9 +361,87 @@ pub fn read_config(
                 .to_string(),
         ));
     }
-    config_value
+    reject_legacy_surface(&config_value).map_err(ProjectError::ConfigParseFailed)?;
+    let machine_config: MachineConfig = config_value
         .try_into()
-        .map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))
+        .map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))?;
+    let project_config = read_project_config(working_dir)?;
+    Ok(merge_config(machine_config, project_config))
+}
+
+fn reject_retired_forge_env() -> Result<(), ProjectError> {
+    for name in [
+        "RUNA_FORGE_TYPE",
+        "RUNA_FORGE_OWNER",
+        "RUNA_FORGE_NAME",
+        "RUNA_FORGE_TRACKER_ID",
+    ] {
+        if std::env::var(name)
+            .ok()
+            .is_some_and(|value| !value.is_empty())
+        {
+            return Err(ProjectError::ConfigParseFailed(format!(
+                "`{name}` has been retired; configure `.runa/project.toml` and use `RUNA_TARGET_PROJECT` in launched environments"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub fn read_project_config(working_dir: &Path) -> Result<ProjectConfig, ProjectError> {
+    let path = working_dir.join(RUNA_DIR).join(PROJECT_FILENAME);
+    if !path.exists() {
+        return Ok(ProjectConfig::default());
+    }
+    let content = std::fs::read_to_string(&path).map_err(ProjectError::Io)?;
+    let value: toml::Value = toml::from_str(&content)
+        .map_err(|e| ProjectError::ProjectConfigParseFailed(e.to_string()))?;
+    reject_legacy_surface(&value).map_err(ProjectError::ProjectConfigParseFailed)?;
+    value
+        .try_into()
+        .map_err(|e| ProjectError::ProjectConfigParseFailed(e.to_string()))
+}
+
+fn merge_config(machine: MachineConfig, project: ProjectConfig) -> Config {
+    let mut transcript = project.transcript;
+    if machine.transcript.dir.is_some() {
+        transcript.dir = machine.transcript.dir;
+    }
+    Config {
+        methodology_path: machine.methodology_path,
+        logging: machine.logging,
+        launch: project.launch,
+        transcript,
+        target_project: project.target_project,
+    }
+}
+
+fn reject_legacy_surface(value: &toml::Value) -> Result<(), String> {
+    let Some(table) = value.as_table() else {
+        return Ok(());
+    };
+    if table.contains_key("agent") {
+        return Err(
+            "`[agent]` has been retired; use portable `[launch]` in `.runa/project.toml`"
+                .to_string(),
+        );
+    }
+    if table.contains_key("forge") {
+        return Err(
+            "`[forge]` has been retired; use portable `[target_project]` in `.runa/project.toml`"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub fn target_project_env(
+    config: &TargetProjectConfig,
+) -> Result<Vec<(String, String)>, ProjectError> {
+    let payload = TargetProjectPayload::from(config);
+    let encoded = serde_json::to_string(&payload)
+        .map_err(|error| ProjectError::ConfigParseFailed(error.to_string()))?;
+    Ok(vec![(RUNA_TARGET_PROJECT.to_string(), encoded)])
 }
 
 /// Load a runa project from `working_dir`.
@@ -337,12 +531,10 @@ trigger = { type = "on_change", name = "constraints" }
         fs::create_dir_all(&runa_dir).unwrap();
 
         let canonical = fs::canonicalize(manifest_path).unwrap();
-        let config = Config {
+        let config = MachineConfig {
             methodology_path: canonical.display().to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
-            forge: ForgeConfig::default(),
         };
         fs::write(
             runa_dir.join("config.toml"),
@@ -400,12 +592,10 @@ trigger = { type = "on_change", name = "constraints" }
 
         let canonical = fs::canonicalize(&manifest_path).unwrap();
         let external_config_path = dir.path().join("external-config.toml");
-        let config = Config {
+        let config = MachineConfig {
             methodology_path: canonical.display().to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
-            forge: ForgeConfig::default(),
         };
         fs::write(&external_config_path, toml::to_string(&config).unwrap()).unwrap();
 
@@ -483,12 +673,10 @@ artifacts_dir = "custom-artifacts"
         let runa_dir = working.join(".runa");
         fs::create_dir_all(&runa_dir).unwrap();
         let canonical = fs::canonicalize(&manifest_path).unwrap();
-        let config = Config {
+        let config = MachineConfig {
             methodology_path: canonical.display().to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
-            forge: ForgeConfig::default(),
         };
         fs::write(
             runa_dir.join("config.toml"),
@@ -597,7 +785,7 @@ methodology_path = "/tmp/methodology.toml"
 
         assert_eq!(config.logging.format, LogFormat::Text);
         assert_eq!(config.logging.filter, None);
-        assert_eq!(config.agent.command, None);
+        assert_eq!(config.launch.command, None);
     }
 
     #[test]
@@ -615,39 +803,60 @@ filter = "info"
 
         assert_eq!(config.logging.format, LogFormat::Json);
         assert_eq!(config.logging.filter.as_deref(), Some("info"));
-        assert_eq!(config.agent.command, None);
+        assert_eq!(config.launch.command, None);
     }
 
     #[test]
-    fn config_with_agent_table_parses_command() {
-        let config: Config = toml::from_str(
+    fn project_config_with_launch_table_parses_command() {
+        let config: ProjectConfig = toml::from_str(
             r#"
-methodology_path = "/tmp/methodology.toml"
-
-[agent]
+[launch]
 command = ["agent-runtime", "exec"]
 "#,
         )
         .unwrap();
 
         assert_eq!(
-            config.agent.command,
+            config.launch.command,
             Some(vec!["agent-runtime".to_string(), "exec".to_string()])
         );
     }
 
     #[test]
-    fn config_with_transcript_and_forge_tables_parses_durable_runtime_settings() {
-        let config: Config = toml::from_str(
+    fn split_config_combines_machine_and_portable_runtime_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
             r#"
 methodology_path = "/tmp/methodology.toml"
 
 [transcript]
 dir = "var/transcripts"
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            runa_dir.join("project.toml"),
+            r#"
+[transcript]
 redact_env = ["SECRET_TOKEN", "API_KEY"]
 
-[forge]
-type = "sourcehut"
+[target_project]
+forge_type = "sourcehut"
+
+[[target_project.repositories]]
+selector = "groundwork"
+host = "weforge.build"
+owner = "operator"
+name = "weforge"
+
+[[target_project.trackers]]
+selector = "todo"
+host = "weforge.build"
 owner = "operator"
 name = "weforge"
 tracker_id = "4"
@@ -655,12 +864,16 @@ tracker_id = "4"
         )
         .unwrap();
 
+        let config = read_config(&working, None).unwrap();
+
         assert_eq!(config.transcript.dir.as_deref(), Some("var/transcripts"));
         assert_eq!(config.transcript.redact_env, ["SECRET_TOKEN", "API_KEY"]);
-        assert_eq!(config.forge.forge_type.as_deref(), Some("sourcehut"));
-        assert_eq!(config.forge.owner.as_deref(), Some("operator"));
-        assert_eq!(config.forge.name.as_deref(), Some("weforge"));
-        assert_eq!(config.forge.tracker_id.as_deref(), Some("4"));
+        assert_eq!(config.target_project.forge_type, ForgeType::Sourcehut);
+        assert_eq!(config.target_project.repositories[0].selector, "groundwork");
+        assert_eq!(
+            config.target_project.trackers[0].tracker_id.as_deref(),
+            Some("4")
+        );
     }
 
     #[test]
@@ -668,16 +881,29 @@ tracker_id = "4"
         let config = Config {
             methodology_path: "/tmp/methodology.toml".to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
+            launch: LaunchConfig {
+                command: Some(vec!["agent-runtime".to_string(), "exec".to_string()]),
+            },
             transcript: TranscriptConfig {
                 dir: Some("transcripts".to_string()),
                 redact_env: vec!["SECRET_TOKEN".to_string()],
             },
-            forge: ForgeConfig {
-                forge_type: Some("github".to_string()),
-                owner: Some("tesserine".to_string()),
-                name: Some("runa".to_string()),
-                tracker_id: Some("4".to_string()),
+            target_project: TargetProjectConfig {
+                forge_type: ForgeType::Github,
+                repositories: vec![RepositoryConfig {
+                    selector: "runa".to_string(),
+                    host: "github.com".to_string(),
+                    owner: "tesserine".to_string(),
+                    name: "runa".to_string(),
+                }],
+                trackers: vec![TrackerConfig {
+                    selector: "issues".to_string(),
+                    repository: Some("runa".to_string()),
+                    host: None,
+                    owner: None,
+                    name: None,
+                    tracker_id: None,
+                }],
             },
         };
 
@@ -685,5 +911,27 @@ tracker_id = "4"
         let round_tripped: Config = toml::from_str(&serialized).unwrap();
 
         assert_eq!(round_tripped, config);
+    }
+
+    #[test]
+    fn read_config_rejects_legacy_agent_and_forge_tables() {
+        for legacy in [
+            "[agent]\ncommand = [\"agent\"]\n",
+            "[forge]\ntype = \"github\"\n",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let working = dir.path().join("project");
+            fs::create_dir(&working).unwrap();
+            let runa_dir = working.join(".runa");
+            fs::create_dir_all(&runa_dir).unwrap();
+            fs::write(
+                runa_dir.join("config.toml"),
+                format!("methodology_path = \"/tmp/methodology.toml\"\n{legacy}"),
+            )
+            .unwrap();
+
+            let err = read_config(&working, None).unwrap_err();
+            assert!(err.to_string().contains("retired"), "{err}");
+        }
     }
 }

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{ArtifactStore, DependencyGraph, GraphError, Manifest, ManifestError, StoreError};
 
@@ -140,19 +140,52 @@ pub struct TrackerConfig {
     pub tracker_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
 pub struct TargetProjectConfig {
-    #[serde(default)]
     pub forge_type: ForgeType,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub repositories: Vec<RepositoryConfig>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub trackers: Vec<TrackerConfig>,
 }
 
 impl TargetProjectConfig {
     fn is_default(&self) -> bool {
         self == &Self::default()
+    }
+}
+
+impl<'de> Deserialize<'de> for TargetProjectConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawTargetProjectConfig {
+            forge_type: Option<ForgeType>,
+            #[serde(default)]
+            repositories: Vec<RepositoryConfig>,
+            #[serde(default)]
+            trackers: Vec<TrackerConfig>,
+        }
+
+        let raw = RawTargetProjectConfig::deserialize(deserializer)?;
+        let populated = !raw.repositories.is_empty() || !raw.trackers.is_empty();
+        let forge_type = match raw.forge_type {
+            Some(forge_type) => forge_type,
+            None if populated => {
+                return Err(serde::de::Error::custom(
+                    "target_project.forge_type is required when target_project declares repositories or trackers",
+                ));
+            }
+            None => ForgeType::default(),
+        };
+
+        Ok(Self {
+            forge_type,
+            repositories: raw.repositories,
+            trackers: raw.trackers,
+        })
     }
 }
 
@@ -819,6 +852,28 @@ command = ["agent-runtime", "exec"]
         assert_eq!(
             config.launch.command,
             Some(vec!["agent-runtime".to_string(), "exec".to_string()])
+        );
+    }
+
+    #[test]
+    fn project_config_rejects_populated_target_project_without_forge_type() {
+        let err = toml::from_str::<ProjectConfig>(
+            r#"
+[target_project]
+
+[[target_project.repositories]]
+selector = "groundwork"
+host = "git.sr.ht"
+owner = "tesserine"
+name = "groundwork"
+"#,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(
+            message.contains("target_project.forge_type"),
+            "error should name required forge_type: {message}"
         );
     }
 

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -120,7 +120,8 @@ impl std::error::Error for UnsupportedForgeError {}
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryConfig {
     pub selector: String,
-    pub host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
     pub owner: String,
     pub name: String,
 }
@@ -394,6 +395,7 @@ pub fn read_config(
                 .to_string(),
         ));
     }
+    reject_machine_config_surface(&config_value).map_err(ProjectError::ConfigParseFailed)?;
     reject_legacy_surface(&config_value).map_err(ProjectError::ConfigParseFailed)?;
     let machine_config: MachineConfig = config_value
         .try_into()
@@ -462,6 +464,19 @@ fn reject_legacy_surface(value: &toml::Value) -> Result<(), String> {
     if table.contains_key("forge") {
         return Err(
             "`[forge]` has been retired; use portable `[target_project]` in `.runa/project.toml`"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn reject_machine_config_surface(value: &toml::Value) -> Result<(), String> {
+    let Some(transcript) = value.get("transcript").and_then(toml::Value::as_table) else {
+        return Ok(());
+    };
+    if transcript.contains_key("redact_env") {
+        return Err(
+            "`[transcript].redact_env` has moved; configure it in portable `.runa/project.toml`"
                 .to_string(),
         );
     }
@@ -808,6 +823,36 @@ artifacts_dir = "custom-artifacts"
     }
 
     #[test]
+    fn read_config_rejects_machine_transcript_redact_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
+            r#"
+methodology_path = "/tmp/methodology.toml"
+
+[transcript]
+redact_env = ["SECRET_TOKEN"]
+"#,
+        )
+        .unwrap();
+
+        let err = read_config(&working, None).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("redact_env"),
+            "error should name migrated field: {message}"
+        );
+        assert!(
+            message.contains(".runa/project.toml"),
+            "error should name migration target: {message}"
+        );
+    }
+
+    #[test]
     fn config_without_logging_uses_default_logging_settings() {
         let config: Config = toml::from_str(
             r#"
@@ -878,6 +923,26 @@ name = "groundwork"
     }
 
     #[test]
+    fn project_config_accepts_hostless_github_repository() {
+        let config: ProjectConfig = toml::from_str(
+            r#"
+[target_project]
+forge_type = "github"
+
+[[target_project.repositories]]
+selector = "runa"
+owner = "tesserine"
+name = "runa"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.target_project.forge_type, ForgeType::Github);
+        assert_eq!(config.target_project.repositories[0].selector, "runa");
+        assert_eq!(config.target_project.repositories[0].host, None);
+    }
+
+    #[test]
     fn split_config_combines_machine_and_portable_runtime_settings() {
         let dir = tempfile::tempdir().unwrap();
         let working = dir.path().join("project");
@@ -926,6 +991,10 @@ tracker_id = "4"
         assert_eq!(config.target_project.forge_type, ForgeType::Sourcehut);
         assert_eq!(config.target_project.repositories[0].selector, "groundwork");
         assert_eq!(
+            config.target_project.repositories[0].host.as_deref(),
+            Some("weforge.build")
+        );
+        assert_eq!(
             config.target_project.trackers[0].tracker_id.as_deref(),
             Some("4")
         );
@@ -947,7 +1016,7 @@ tracker_id = "4"
                 forge_type: ForgeType::Github,
                 repositories: vec![RepositoryConfig {
                     selector: "runa".to_string(),
-                    host: "github.com".to_string(),
+                    host: None,
                     owner: "tesserine".to_string(),
                     name: "runa".to_string(),
                 }],

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -483,7 +483,7 @@ mod tests {
             forge_type: ForgeType::Github,
             repositories: vec![RepositoryConfig {
                 selector: "default".to_string(),
-                host: "github.com".to_string(),
+                host: None,
                 owner: owner.to_string(),
                 name: name.to_string(),
             }],
@@ -519,7 +519,7 @@ mod tests {
             forge_type: ForgeType::Sourcehut,
             repositories: vec![RepositoryConfig {
                 selector: "groundwork".to_string(),
-                host: "weforge.build".to_string(),
+                host: Some("weforge.build".to_string()),
                 owner: "operator".to_string(),
                 name: "weforge".to_string(),
             }],
@@ -552,7 +552,7 @@ mod tests {
             forge_type: ForgeType::Github,
             repositories: vec![RepositoryConfig {
                 selector: "runa".to_string(),
-                host: "github.com".to_string(),
+                host: None,
                 owner: "tesserine".to_string(),
                 name: "runa".to_string(),
             }],

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -16,7 +16,7 @@
 //!   number must agree with the handle number; duplicate tracker
 //!   identities across roots are rejected; and the handle's deployment
 //!   identity must agree with the active deployment resolved from the
-//!   config-backed `RUNA_FORGE_*` atoms (`github:<owner>/<name>` or
+//!   configured target project (`github:<owner>/<name>` or
 //!   `sourcehut:<tracker_id>`).
 //! - Endpoint and host resolution are deliberately outside scoped identity
 //!   validation; identity is textual agreement, not network reachability.
@@ -28,60 +28,91 @@ use std::fmt;
 
 use serde_json::Value;
 
-use crate::project::ForgeConfig;
+use crate::project::{ForgeType, RepositoryConfig, TargetProjectConfig, TrackerConfig};
 use crate::store::{ArtifactStore, ValidationStatus};
 
-pub const RUNA_FORGE_TYPE: &str = "RUNA_FORGE_TYPE";
-pub const RUNA_FORGE_OWNER: &str = "RUNA_FORGE_OWNER";
-pub const RUNA_FORGE_NAME: &str = "RUNA_FORGE_NAME";
-pub const RUNA_FORGE_TRACKER_ID: &str = "RUNA_FORGE_TRACKER_ID";
+pub const RETIRED_FORGE_ENV: [&str; 4] = [
+    "RUNA_FORGE_TYPE",
+    "RUNA_FORGE_OWNER",
+    "RUNA_FORGE_NAME",
+    "RUNA_FORGE_TRACKER_ID",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedForgeIdentity {
-    pub forge_type: String,
-    pub owner: Option<String>,
-    pub name: Option<String>,
-    pub tracker_id: Option<String>,
+    pub forge_type: ForgeType,
+    pub repositories: Vec<RepositoryConfig>,
+    pub trackers: Vec<TrackerConfig>,
 }
 
 impl ResolvedForgeIdentity {
     fn environment(&self) -> HashMap<String, String> {
-        let mut environment =
-            HashMap::from([(RUNA_FORGE_TYPE.to_string(), self.forge_type.clone())]);
-        insert_if_present(&mut environment, RUNA_FORGE_OWNER, self.owner.as_deref());
-        insert_if_present(&mut environment, RUNA_FORGE_NAME, self.name.as_deref());
-        insert_if_present(
-            &mut environment,
-            RUNA_FORGE_TRACKER_ID,
-            self.tracker_id.as_deref(),
-        );
-        environment
+        crate::project::target_project_env(&TargetProjectConfig {
+            forge_type: self.forge_type,
+            repositories: self.repositories.clone(),
+            trackers: self.trackers.clone(),
+        })
+        .unwrap_or_default()
+        .into_iter()
+        .collect()
     }
 
-    fn active_deployment_identity(&self) -> Result<String, ScopedWorkUnitError> {
-        match self.forge_type.as_str() {
-            "github" => {
-                let owner = self.required_atom(RUNA_FORGE_OWNER, self.owner.as_deref())?;
-                let name = self.required_atom(RUNA_FORGE_NAME, self.name.as_deref())?;
-                Ok(format!("github:{owner}/{name}"))
-            }
-            "sourcehut" => {
-                let tracker_id =
-                    self.required_atom(RUNA_FORGE_TRACKER_ID, self.tracker_id.as_deref())?;
-                Ok(format!("sourcehut:{tracker_id}"))
-            }
-            other => Ok(other.to_string()),
+    pub fn active_deployment_identity(&self) -> Result<String, ScopedWorkUnitError> {
+        let identities = self.configured_tracker_identities();
+        match identities.as_slice() {
+            [identity] => Ok(identity.clone()),
+            [] => Err(ScopedWorkUnitError::MissingDeploymentIdentity {
+                detail: "target project declares no tracker identity".to_string(),
+            }),
+            _ => Err(ScopedWorkUnitError::AmbiguousTrackerIdentity),
         }
     }
 
-    fn required_atom<'a>(
-        &self,
-        variable: &'static str,
-        value: Option<&'a str>,
-    ) -> Result<&'a str, ScopedWorkUnitError> {
-        value
-            .filter(|value| !value.is_empty())
-            .ok_or(ScopedWorkUnitError::MissingDeploymentIdentity { variable })
+    pub fn configured_tracker_identities(&self) -> Vec<String> {
+        match self.forge_type {
+            ForgeType::Github => {
+                if self.trackers.is_empty() {
+                    self.repositories
+                        .iter()
+                        .map(|repo| format!("github:{}/{}", repo.owner, repo.name))
+                        .collect()
+                } else {
+                    self.trackers
+                        .iter()
+                        .filter_map(|tracker| {
+                            let selector = tracker.repository.as_deref()?;
+                            let repo = self
+                                .repositories
+                                .iter()
+                                .find(|repo| repo.selector == selector)?;
+                            Some(format!("github:{}/{}", repo.owner, repo.name))
+                        })
+                        .collect()
+                }
+            }
+            ForgeType::Sourcehut => self
+                .trackers
+                .iter()
+                .filter_map(|tracker| {
+                    tracker
+                        .tracker_id
+                        .as_deref()
+                        .map(|tracker_id| format!("sourcehut:{tracker_id}"))
+                })
+                .collect(),
+        }
+    }
+
+    pub fn repository_by_selector(&self, selector: &str) -> Option<&RepositoryConfig> {
+        self.repositories
+            .iter()
+            .find(|repository| repository.selector == selector)
+    }
+
+    pub fn tracker_by_selector(&self, selector: &str) -> Option<&TrackerConfig> {
+        self.trackers
+            .iter()
+            .find(|tracker| tracker.selector == selector)
     }
 }
 
@@ -104,12 +135,13 @@ pub enum ScopedWorkUnitError {
         tracker_identity: String,
     },
     MissingDeploymentIdentity {
-        variable: &'static str,
+        detail: String,
     },
+    AmbiguousTrackerIdentity,
     DeploymentDisagreement {
         instance_id: String,
         handle_identity: String,
-        active_identity: String,
+        configured_identities: Vec<String>,
     },
     WorkUnitScanIncomplete,
 }
@@ -144,17 +176,22 @@ impl fmt::Display for ScopedWorkUnitError {
                 f,
                 "work-unit instances '{first_instance_id}' and '{duplicate_instance_id}' share tracker identity {tracker_identity}"
             ),
-            ScopedWorkUnitError::MissingDeploymentIdentity { variable } => write!(
+            ScopedWorkUnitError::MissingDeploymentIdentity { detail } => write!(
                 f,
-                "missing required deployment identity atom '{variable}' for scoped work-unit validation"
+                "missing configured target-project identity for scoped work-unit validation: {detail}"
+            ),
+            ScopedWorkUnitError::AmbiguousTrackerIdentity => write!(
+                f,
+                "bare tracker reference is ambiguous because the target project declares multiple trackers"
             ),
             ScopedWorkUnitError::DeploymentDisagreement {
                 instance_id,
                 handle_identity,
-                active_identity,
+                configured_identities,
             } => write!(
                 f,
-                "work-unit instance '{instance_id}' belongs to {handle_identity}, which disagrees with active deployment {active_identity}"
+                "work-unit instance '{instance_id}' belongs to {handle_identity}, which is not declared by the configured target project ({})",
+                configured_identities.join(", ")
             ),
             ScopedWorkUnitError::WorkUnitScanIncomplete => write!(
                 f,
@@ -170,7 +207,7 @@ pub fn validate_scoped_work_unit(
     store: &ArtifactStore,
     supplied: &str,
 ) -> Result<(), ScopedWorkUnitError> {
-    let identity = resolve_forge_identity(&ForgeConfig::default());
+    let identity = resolve_forge_identity(&TargetProjectConfig::default());
     validate_scoped_work_unit_with_identity(store, supplied, &identity)
 }
 
@@ -216,42 +253,16 @@ pub fn find_work_unit_by_tracker_identity(store: &ArtifactStore, target: &str) -
     None
 }
 
-pub fn resolve_forge_identity(config: &ForgeConfig) -> ResolvedForgeIdentity {
+pub fn resolve_forge_identity(config: &TargetProjectConfig) -> ResolvedForgeIdentity {
     ResolvedForgeIdentity {
-        forge_type: resolve_atom(RUNA_FORGE_TYPE, config.forge_type.as_deref())
-            .unwrap_or_else(|| "github".to_string()),
-        owner: resolve_atom(RUNA_FORGE_OWNER, config.owner.as_deref()),
-        name: resolve_atom(RUNA_FORGE_NAME, config.name.as_deref()),
-        tracker_id: resolve_atom(RUNA_FORGE_TRACKER_ID, config.tracker_id.as_deref()),
+        forge_type: config.forge_type,
+        repositories: config.repositories.clone(),
+        trackers: config.trackers.clone(),
     }
 }
 
-pub fn resolve_forge_environment(config: &ForgeConfig) -> HashMap<String, String> {
+pub fn resolve_forge_environment(config: &TargetProjectConfig) -> HashMap<String, String> {
     resolve_forge_identity(config).environment()
-}
-
-fn resolve_atom(variable: &'static str, config_value: Option<&str>) -> Option<String> {
-    std::env::var(variable)
-        .ok()
-        .and_then(|value| normalize_atom(Some(value.as_str())))
-        .or_else(|| normalize_atom(config_value))
-}
-
-fn normalize_atom(value: Option<&str>) -> Option<String> {
-    value
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn insert_if_present(
-    environment: &mut HashMap<String, String>,
-    variable: &'static str,
-    value: Option<&str>,
-) {
-    if let Some(value) = normalize_atom(value) {
-        environment.insert(variable.to_string(), value);
-    }
 }
 
 pub fn validate_scoped_work_unit_with_identity(
@@ -336,14 +347,15 @@ fn validate_deployment_identity(
         .get("forge_tag")
         .and_then(Value::as_str)
         .unwrap_or("");
-
     let handle_identity = deployment_identity_for_handle(handle)?;
-    let active_identity = identity.active_deployment_identity()?;
-    if handle_forge != identity.forge_type || handle_identity != active_identity {
+    let configured = identity.configured_tracker_identities();
+    if handle_forge != identity.forge_type.as_str()
+        || !configured.iter().any(|item| item == &handle_identity)
+    {
         return Err(ScopedWorkUnitError::DeploymentDisagreement {
             instance_id: instance_id.to_string(),
             handle_identity,
-            active_identity,
+            configured_identities: configured,
         });
     }
 
@@ -353,12 +365,13 @@ fn validate_deployment_identity(
 fn deployment_identity_for_handle(
     handle: &serde_json::Map<String, Value>,
 ) -> Result<String, ScopedWorkUnitError> {
-    match handle
-        .get("forge_tag")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-    {
-        "github" => {
+    match ForgeType::parse(
+        handle
+            .get("forge_tag")
+            .and_then(Value::as_str)
+            .unwrap_or(""),
+    ) {
+        Ok(ForgeType::Github) => {
             let repository = github_repository(
                 handle
                     .get("url")
@@ -368,30 +381,29 @@ fn deployment_identity_for_handle(
             .unwrap_or_default();
             Ok(format!("github:{repository}"))
         }
-        "sourcehut" => {
+        Ok(ForgeType::Sourcehut) => {
             let tracker_id = handle
                 .get("tracker_id")
                 .and_then(Value::as_u64)
                 .unwrap_or_default();
             Ok(format!("sourcehut:{tracker_id}"))
         }
-        forge => Ok(forge.to_string()),
+        Err(error) => Ok(error.forge_type),
     }
 }
 
 fn tracker_identity(handle: &serde_json::Map<String, Value>) -> Option<String> {
-    match handle.get("forge_tag").and_then(Value::as_str)? {
-        "github" => {
+    match ForgeType::parse(handle.get("forge_tag").and_then(Value::as_str)?).ok()? {
+        ForgeType::Github => {
             let repository = github_repository(handle.get("url")?.as_str()?)?;
             let number = handle.get("number")?.as_u64()?;
             Some(format!("github:{repository}:{number}"))
         }
-        "sourcehut" => {
+        ForgeType::Sourcehut => {
             let tracker_id = handle.get("tracker_id")?.as_u64()?;
             let number = handle.get("number")?.as_u64()?;
             Some(format!("sourcehut:{tracker_id}:{number}"))
         }
-        _ => None,
     }
 }
 
@@ -409,12 +421,11 @@ fn instance_work_unit_number(instance_id: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::EnvGuard;
     use serde_json::json;
     use tempfile::TempDir;
 
     use super::*;
-    use crate::project::ForgeConfig;
+    use crate::project::{ForgeType, RepositoryConfig, TargetProjectConfig, TrackerConfig};
     use crate::{ArtifactStore, ArtifactType};
 
     fn work_unit_store(dir: &TempDir) -> ArtifactStore {
@@ -469,121 +480,93 @@ mod tests {
     fn github_identity(repository: &str) -> ResolvedForgeIdentity {
         let (owner, name) = repository.split_once('/').unwrap();
         ResolvedForgeIdentity {
-            forge_type: "github".to_string(),
-            owner: Some(owner.to_string()),
-            name: Some(name.to_string()),
-            tracker_id: None,
+            forge_type: ForgeType::Github,
+            repositories: vec![RepositoryConfig {
+                selector: "default".to_string(),
+                host: "github.com".to_string(),
+                owner: owner.to_string(),
+                name: name.to_string(),
+            }],
+            trackers: vec![TrackerConfig {
+                selector: "default".to_string(),
+                repository: Some("default".to_string()),
+                host: None,
+                owner: None,
+                name: None,
+                tracker_id: None,
+            }],
         }
     }
 
     fn sourcehut_identity(tracker_id: u64) -> ResolvedForgeIdentity {
         ResolvedForgeIdentity {
-            forge_type: "sourcehut".to_string(),
-            owner: None,
-            name: None,
-            tracker_id: Some(tracker_id.to_string()),
+            forge_type: ForgeType::Sourcehut,
+            repositories: Vec::new(),
+            trackers: vec![TrackerConfig {
+                selector: "default".to_string(),
+                repository: None,
+                host: Some("weforge.build".to_string()),
+                owner: Some("operator".to_string()),
+                name: Some("weforge".to_string()),
+                tracker_id: Some(tracker_id.to_string()),
+            }],
         }
     }
 
     #[test]
-    fn forge_environment_resolves_config_values_when_environment_is_unset() {
-        let _env = EnvGuard::unset(&[
-            "RUNA_FORGE_TYPE",
-            "RUNA_FORGE_OWNER",
-            "RUNA_FORGE_NAME",
-            "RUNA_FORGE_TRACKER_ID",
-        ]);
-        let config = ForgeConfig {
-            forge_type: Some("sourcehut".to_string()),
-            owner: Some("operator".to_string()),
-            name: Some("weforge".to_string()),
-            tracker_id: Some("4".to_string()),
+    fn forge_environment_exports_structured_target_project_payload() {
+        let config = TargetProjectConfig {
+            forge_type: ForgeType::Sourcehut,
+            repositories: vec![RepositoryConfig {
+                selector: "groundwork".to_string(),
+                host: "weforge.build".to_string(),
+                owner: "operator".to_string(),
+                name: "weforge".to_string(),
+            }],
+            trackers: vec![TrackerConfig {
+                selector: "todo".to_string(),
+                repository: None,
+                host: Some("weforge.build".to_string()),
+                owner: Some("operator".to_string()),
+                name: Some("weforge".to_string()),
+                tracker_id: Some("4".to_string()),
+            }],
         };
 
         let environment = resolve_forge_environment(&config);
+        let payload: serde_json::Value = serde_json::from_str(
+            environment
+                .get(crate::project::RUNA_TARGET_PROJECT)
+                .unwrap(),
+        )
+        .unwrap();
 
-        assert_eq!(
-            environment.get("RUNA_FORGE_TYPE").map(String::as_str),
-            Some("sourcehut")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_OWNER").map(String::as_str),
-            Some("operator")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_NAME").map(String::as_str),
-            Some("weforge")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_TRACKER_ID").map(String::as_str),
-            Some("4")
-        );
+        assert_eq!(payload["forge_type"], "sourcehut");
+        assert_eq!(payload["repositories"][0]["selector"], "groundwork");
+        assert_eq!(payload["trackers"][0]["tracker_id"], "4");
     }
 
     #[test]
-    fn forge_environment_resolves_environment_values_over_config_values() {
-        let _env = EnvGuard::set(&[
-            ("RUNA_FORGE_TYPE", "github"),
-            ("RUNA_FORGE_OWNER", "env-owner"),
-            ("RUNA_FORGE_NAME", "env-name"),
-            ("RUNA_FORGE_TRACKER_ID", "9"),
-        ]);
-        let config = ForgeConfig {
-            forge_type: Some("sourcehut".to_string()),
-            owner: Some("config-owner".to_string()),
-            name: Some("config-name".to_string()),
-            tracker_id: Some("4".to_string()),
+    fn forge_environment_does_not_emit_retired_forge_atoms() {
+        let config = TargetProjectConfig {
+            forge_type: ForgeType::Github,
+            repositories: vec![RepositoryConfig {
+                selector: "runa".to_string(),
+                host: "github.com".to_string(),
+                owner: "tesserine".to_string(),
+                name: "runa".to_string(),
+            }],
+            trackers: Vec::new(),
         };
 
         let environment = resolve_forge_environment(&config);
 
-        assert_eq!(
-            environment.get("RUNA_FORGE_TYPE").map(String::as_str),
-            Some("github")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_OWNER").map(String::as_str),
-            Some("env-owner")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_NAME").map(String::as_str),
-            Some("env-name")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_TRACKER_ID").map(String::as_str),
-            Some("9")
-        );
-    }
-
-    #[test]
-    fn forge_environment_materializes_default_github_type_when_config_and_environment_omit_type() {
-        let _env = EnvGuard::unset(&[
-            "RUNA_FORGE_TYPE",
-            "RUNA_FORGE_OWNER",
-            "RUNA_FORGE_NAME",
-            "RUNA_FORGE_TRACKER_ID",
-        ]);
-        let config = ForgeConfig {
-            forge_type: None,
-            owner: Some("tesserine".to_string()),
-            name: Some("runa".to_string()),
-            tracker_id: None,
-        };
-
-        let environment = resolve_forge_environment(&config);
-
-        assert_eq!(
-            environment.get("RUNA_FORGE_TYPE").map(String::as_str),
-            Some("github")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_OWNER").map(String::as_str),
-            Some("tesserine")
-        );
-        assert_eq!(
-            environment.get("RUNA_FORGE_NAME").map(String::as_str),
-            Some("runa")
-        );
+        for retired in RETIRED_FORGE_ENV {
+            assert!(
+                !environment.contains_key(retired),
+                "{retired} should be retired"
+            );
+        }
     }
 
     #[test]
@@ -772,12 +755,6 @@ mod tests {
 
     #[test]
     fn exact_work_unit_id_accepts_matching_sourcehut_deployment_from_config() {
-        let _env = EnvGuard::unset(&[
-            "RUNA_FORGE_TYPE",
-            "RUNA_FORGE_OWNER",
-            "RUNA_FORGE_NAME",
-            "RUNA_FORGE_TRACKER_ID",
-        ]);
         let tmp = TempDir::new().unwrap();
         let mut store = work_unit_store(&tmp);
         let artifact = sourcehut_work_unit(4, 163);
@@ -792,11 +769,17 @@ mod tests {
                 1,
             )
             .unwrap();
-        let identity = resolve_forge_identity(&ForgeConfig {
-            forge_type: Some("sourcehut".to_string()),
-            owner: Some("operator".to_string()),
-            name: Some("weforge".to_string()),
-            tracker_id: Some("4".to_string()),
+        let identity = resolve_forge_identity(&TargetProjectConfig {
+            forge_type: ForgeType::Sourcehut,
+            repositories: Vec::new(),
+            trackers: vec![TrackerConfig {
+                selector: "todo".to_string(),
+                repository: None,
+                host: Some("weforge.build".to_string()),
+                owner: Some("operator".to_string()),
+                name: Some("weforge".to_string()),
+                tracker_id: Some("4".to_string()),
+            }],
         });
 
         let result =

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -315,7 +315,7 @@ impl SessionState {
         let mut loaded = crate::project::load(&working_dir, config_override)?;
         let scan_result = crate::scan(&loaded.workspace_dir, &mut loaded.store)?;
         let scan_findings = crate::collect_scan_findings(&scan_result, &loaded.workspace_dir);
-        let identity = crate::resolve_forge_identity(&loaded.config.forge);
+        let identity = crate::resolve_forge_identity(&loaded.config.target_project);
 
         // Resolve the promise first. Re-entry (the work-unit already exists)
         // degrades to an ordinary bound session and needs no acquisition surface;
@@ -436,6 +436,7 @@ impl SessionState {
             self.context_work_unit(),
             &reconciled.scan_findings.affected_types,
         );
+        context.target_project = Some((&self.loaded.config.target_project).into());
         if let SessionScope::Promised { ticket, .. } = &self.scope {
             context.entry = Some(crate::context::EntryDelivery {
                 reference: ticket.display.clone(),
@@ -604,7 +605,7 @@ impl SessionState {
         require_current_ready: bool,
     ) -> Result<ReconciledScan, SessionError> {
         let scan_result = self.scan_workspace()?;
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let identity = crate::resolve_forge_identity(&self.loaded.config.target_project);
         match &self.scope {
             SessionScope::Bound(work_unit) => {
                 crate::validate_scoped_work_unit_with_identity(
@@ -688,7 +689,7 @@ impl SessionState {
     /// work-unit ([`EntryError::Unresolved`]) or the recorded work-unit fails
     /// scoped-identity validation.
     fn bind_promise(&mut self) -> Result<(), SessionError> {
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let identity = crate::resolve_forge_identity(&self.loaded.config.target_project);
         let ticket = match &self.scope {
             SessionScope::Promised { ticket, .. } => ticket.clone(),
             SessionScope::Bound(_) => return Ok(()),
@@ -1035,9 +1036,14 @@ trigger = { type = "on_artifact", name = "work-unit" }
         fs::write(
             runa_dir.join("config.toml"),
             format!(
-                "methodology_path = {:?}\n\n[forge]\ntype = \"github\"\nowner = \"tesserine\"\nname = \"runa\"\n",
+                "methodology_path = {:?}\n",
                 manifest_path.display().to_string()
             ),
+        )
+        .unwrap();
+        fs::write(
+            runa_dir.join("project.toml"),
+            "[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"runa\"\nowner = \"tesserine\"\nname = \"runa\"\nhost = \"github.com\"\n",
         )
         .unwrap();
         fs::write(

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -1043,7 +1043,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
         .unwrap();
         fs::write(
             runa_dir.join("project.toml"),
-            "[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"runa\"\nowner = \"tesserine\"\nname = \"runa\"\nhost = \"github.com\"\n",
+            "[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"runa\"\nowner = \"tesserine\"\nname = \"runa\"\n",
         )
         .unwrap();
         fs::write(

--- a/libagent/src/transcript.rs
+++ b/libagent/src/transcript.rs
@@ -679,7 +679,7 @@ mod tests {
                 forge_type: ForgeType::Github,
                 repositories: vec![RepositoryConfig {
                     selector: "runa".to_string(),
-                    host: "github.com".to_string(),
+                    host: None,
                     owner: "tesserine".to_string(),
                     name: "runa".to_string(),
                 }],

--- a/libagent/src/transcript.rs
+++ b/libagent/src/transcript.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sha2::{Digest, Sha256};
 
-use crate::project::{ForgeConfig, TranscriptConfig};
+use crate::project::{TargetProjectConfig, TranscriptConfig};
 
 pub const TRANSCRIPT_DIR_ENV: &str = "RUNA_TRANSCRIPT_DIR";
 pub const REDACT_ENV_ENV: &str = "RUNA_TRANSCRIPT_REDACT_ENV";
@@ -200,13 +200,13 @@ pub fn resolve_transcript_settings(
     working_dir: &Path,
     config: &TranscriptConfig,
 ) -> TranscriptSettings {
-    resolve_transcript_settings_with_forge(working_dir, config, &ForgeConfig::default())
+    resolve_transcript_settings_with_forge(working_dir, config, &TargetProjectConfig::default())
 }
 
 pub fn resolve_transcript_settings_with_forge(
     working_dir: &Path,
     config: &TranscriptConfig,
-    forge: &ForgeConfig,
+    forge: &TargetProjectConfig,
 ) -> TranscriptSettings {
     let dir = std::env::var_os(TRANSCRIPT_DIR_ENV)
         .filter(|value| !value.is_empty())
@@ -329,18 +329,10 @@ fn redact_text(text: &str, redactions: &[(String, String)]) -> String {
     redacted
 }
 
-fn deployment_identity(working_dir: &Path, forge: &ForgeConfig) -> Option<String> {
+fn deployment_identity(working_dir: &Path, forge: &TargetProjectConfig) -> Option<String> {
     let identity = crate::resolve_forge_identity(forge);
-    match identity.forge_type.as_str() {
-        "github" => match (identity.owner.as_deref(), identity.name.as_deref()) {
-            (Some(owner), Some(name)) => Some(format!("github:{owner}/{name}")),
-            _ => Some(project_deployment_identity(working_dir)),
-        },
-        "sourcehut" => match identity.tracker_id.as_deref() {
-            Some(tracker_id) => Some(format!("sourcehut:{tracker_id}")),
-            None => Some(project_deployment_identity(working_dir)),
-        },
-        other if !other.is_empty() && other != "github" => Some(other.to_string()),
+    match identity.configured_tracker_identities().as_slice() {
+        [only] => Some(only.clone()),
         _ => Some(project_deployment_identity(working_dir)),
     }
 }
@@ -411,7 +403,9 @@ mod tests {
         redact_value, resolve_transcript_settings, resolve_transcript_settings_with_forge,
         transcript_env_from_settings,
     };
-    use crate::project::{ForgeConfig, TranscriptConfig};
+    use crate::project::{
+        ForgeType, RepositoryConfig, TargetProjectConfig, TrackerConfig, TranscriptConfig,
+    };
     use crate::test_helpers::EnvGuard;
     use serde_json::json;
     use std::path::PathBuf;
@@ -681,11 +675,22 @@ mod tests {
         let settings = resolve_transcript_settings_with_forge(
             temp.path(),
             &TranscriptConfig::default(),
-            &ForgeConfig {
-                forge_type: Some("github".to_string()),
-                owner: Some("tesserine".to_string()),
-                name: Some("runa".to_string()),
-                tracker_id: None,
+            &TargetProjectConfig {
+                forge_type: ForgeType::Github,
+                repositories: vec![RepositoryConfig {
+                    selector: "runa".to_string(),
+                    host: "github.com".to_string(),
+                    owner: "tesserine".to_string(),
+                    name: "runa".to_string(),
+                }],
+                trackers: vec![TrackerConfig {
+                    selector: "issues".to_string(),
+                    repository: Some("runa".to_string()),
+                    host: None,
+                    owner: None,
+                    name: None,
+                    tracker_id: None,
+                }],
             },
         );
 

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -41,7 +41,7 @@ pub(crate) fn resolve_reference(
     loaded: &LoadedProject,
     raw: &str,
 ) -> Result<(TicketRef, ResolvedForgeIdentity), StepError> {
-    let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+    let identity = libagent::resolve_forge_identity(&loaded.config.target_project);
     let ticket =
         libagent::resolve_ticket_reference(raw, &identity).map_err(StepError::TicketReference)?;
     Ok((ticket, identity))
@@ -92,6 +92,7 @@ pub(crate) fn acquisition_planned_entry(
         None,
         &scan_findings.affected_types,
     );
+    context.target_project = Some((&loaded.config.target_project).into());
     context.entry = Some(libagent::context::EntryDelivery {
         reference: ticket.display.clone(),
         ticket_number: ticket.number,

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -17,7 +17,7 @@ fn configured_agent_command(
         .map_err(CommandError::from)
         .map_err(StepError::from)?;
     config
-        .agent
+        .launch
         .command
         .filter(|command| {
             !command.is_empty() && !command.first().is_some_and(|part| part.is_empty())
@@ -113,7 +113,7 @@ fn run_ticket(
     let transcript_settings = libagent::transcript::resolve_transcript_settings_with_forge(
         working_dir,
         &loaded.config.transcript,
-        &loaded.config.forge,
+        &loaded.config.target_project,
     );
     let mcp_binary = locate_runa_mcp()?;
     let receipt_dir = tempfile::Builder::new()
@@ -141,6 +141,7 @@ fn run_ticket(
         context: libagent::context::ContextInjection {
             protocol: "go".to_string(),
             work_unit: None,
+            target_project: Some((&loaded.config.target_project).into()),
             instructions: tick_prompt().to_string(),
             inputs: Vec::new(),
             entry: None,
@@ -253,7 +254,7 @@ fn run_bound(
     let transcript_settings = libagent::transcript::resolve_transcript_settings_with_forge(
         working_dir,
         &loaded.config.transcript,
-        &loaded.config.forge,
+        &loaded.config.target_project,
     );
     let mcp_binary = locate_runa_mcp()?;
     let receipt_dir = tempfile::Builder::new()
@@ -281,6 +282,7 @@ fn run_bound(
         context: libagent::context::ContextInjection {
             protocol: "go".to_string(),
             work_unit: Some(work_unit.to_string()),
+            target_project: Some((&loaded.config.target_project).into()),
             instructions: tick_prompt().to_string(),
             inputs: Vec::new(),
             entry: None,

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -4,7 +4,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::project::{
-    CONFIG_FILENAME, Config, DEFAULT_WORKSPACE_DIR, RUNA_DIR, STATE_FILENAME, STORE_DIRNAME, State,
+    CONFIG_FILENAME, DEFAULT_WORKSPACE_DIR, MachineConfig, PROJECT_FILENAME, ProjectConfig,
+    RUNA_DIR, STATE_FILENAME, STORE_DIRNAME, State,
 };
 
 #[derive(Debug)]
@@ -113,20 +114,30 @@ pub fn run(
     let workspace_dir = runa_dir.join(DEFAULT_WORKSPACE_DIR);
     fs::create_dir_all(&workspace_dir).map_err(InitError::Io)?;
 
-    // Write config.
-    let config = Config {
+    let machine_config = MachineConfig {
         methodology_path: canonical_path.display().to_string(),
         logging: crate::project::LoggingConfig::default(),
-        agent: crate::project::AgentConfig::default(),
         transcript: crate::project::TranscriptConfig::default(),
-        forge: crate::project::ForgeConfig::default(),
     };
-    let config_toml = toml::to_string(&config).expect("Config serialization should not fail");
+    let config_toml =
+        toml::to_string(&machine_config).expect("Config serialization should not fail");
 
     if let Some(parent) = config_dest.parent() {
         fs::create_dir_all(parent).map_err(InitError::Io)?;
     }
     fs::write(&config_dest, config_toml).map_err(InitError::Io)?;
+
+    let project_config = ProjectConfig::default();
+    fs::write(
+        runa_dir.join(PROJECT_FILENAME),
+        toml::to_string(&project_config).expect("Project config serialization should not fail"),
+    )
+    .map_err(InitError::Io)?;
+    fs::write(
+        runa_dir.join(".gitignore"),
+        "config.toml\nstate.toml\nstore/\nworkspace/\n",
+    )
+    .map_err(InitError::Io)?;
 
     // Write state.
     let state = State {

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -127,12 +127,15 @@ pub fn run(
     }
     fs::write(&config_dest, config_toml).map_err(InitError::Io)?;
 
-    let project_config = ProjectConfig::default();
-    fs::write(
-        runa_dir.join(PROJECT_FILENAME),
-        toml::to_string(&project_config).expect("Project config serialization should not fail"),
-    )
-    .map_err(InitError::Io)?;
+    let project_path = runa_dir.join(PROJECT_FILENAME);
+    if !project_path.exists() {
+        let project_config = ProjectConfig::default();
+        fs::write(
+            project_path,
+            toml::to_string(&project_config).expect("Project config serialization should not fail"),
+        )
+        .map_err(InitError::Io)?;
+    }
     fs::write(
         runa_dir.join(".gitignore"),
         "config.toml\nstate.toml\nstore/\nworkspace/\n",
@@ -645,5 +648,34 @@ trigger = { type = "on_artifact", name = "design-doc" }
         assert_eq!(summary1.methodology_name, summary2.methodology_name);
         assert_eq!(summary1.artifact_type_count, summary2.artifact_type_count);
         assert_eq!(summary1.protocol_count, summary2.protocol_count);
+    }
+
+    #[test]
+    fn run_preserves_existing_project_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_methodology_layout(dir.path());
+
+        let working = dir.path().join("project");
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        let project_path = runa_dir.join("project.toml");
+        let existing = r#"
+[launch]
+command = ["agent-runtime", "exec"]
+
+[target_project]
+forge_type = "sourcehut"
+
+[[target_project.repositories]]
+selector = "groundwork"
+host = "git.sr.ht"
+owner = "tesserine"
+name = "groundwork"
+"#;
+        fs::write(&project_path, existing).unwrap();
+
+        run(&working, &manifest_path, None).unwrap();
+
+        assert_eq!(fs::read_to_string(project_path).unwrap(), existing);
     }
 }

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -136,11 +136,14 @@ pub fn run(
         )
         .map_err(InitError::Io)?;
     }
-    fs::write(
-        runa_dir.join(".gitignore"),
-        "config.toml\nstate.toml\nstore/\nworkspace/\n",
-    )
-    .map_err(InitError::Io)?;
+    let gitignore_path = runa_dir.join(".gitignore");
+    if !gitignore_path.exists() {
+        fs::write(
+            gitignore_path,
+            "config.toml\nstate.toml\nstore/\nworkspace/\n",
+        )
+        .map_err(InitError::Io)?;
+    }
 
     // Write state.
     let state = State {
@@ -677,5 +680,22 @@ name = "groundwork"
         run(&working, &manifest_path, None).unwrap();
 
         assert_eq!(fs::read_to_string(project_path).unwrap(), existing);
+    }
+
+    #[test]
+    fn run_preserves_existing_gitignore() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = write_methodology_layout(dir.path());
+
+        let working = dir.path().join("project");
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        let gitignore_path = runa_dir.join(".gitignore");
+        let existing = "custom-cache/\n";
+        fs::write(&gitignore_path, existing).unwrap();
+
+        run(&working, &manifest_path, None).unwrap();
+
+        assert_eq!(fs::read_to_string(gitignore_path).unwrap(), existing);
     }
 }

--- a/runa-cli/src/commands/mod.rs
+++ b/runa-cli/src/commands/mod.rs
@@ -75,7 +75,7 @@ pub fn validate_scoped_work_unit(
     work_unit: Option<&str>,
 ) -> Result<(), CommandError> {
     if let Some(work_unit) = work_unit {
-        let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+        let identity = libagent::resolve_forge_identity(&loaded.config.target_project);
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     Ok(())

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -212,7 +212,7 @@ fn resolve_agent_command(
         .map_err(StepError::from)
         .map_err(RunError::from)?;
     config
-        .agent
+        .launch
         .command
         .filter(|command| is_usable_agent_command(command))
         .ok_or(RunError::from(StepError::AgentCommandNotConfigured))
@@ -367,7 +367,7 @@ fn execute_and_reconcile(
     let transcript_settings = libagent::transcript::resolve_transcript_settings_with_forge(
         working_dir,
         &loaded.config.transcript,
-        &loaded.config.forge,
+        &loaded.config.target_project,
     );
     let execution_entry = build_plan_entries(
         vec![next_entry],

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -1726,7 +1726,7 @@ cat >/dev/null
                 forge_type: libagent::ForgeType::Github,
                 repositories: vec![libagent::RepositoryConfig {
                     selector: "runa".to_string(),
-                    host: "github.com".to_string(),
+                    host: None,
                     owner: "tesserine".to_string(),
                     name: "runa".to_string(),
                 }],

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -73,7 +73,7 @@ impl fmt::Display for StepError {
             StepError::Json(err) => write!(f, "{err}"),
             StepError::AgentCommandNotConfigured => write!(
                 f,
-                "no agent command configured in config.toml; add [agent] command = [\"binary\", ...]"
+                "no launch command configured in project.toml; add [launch] command = [\"binary\", ...]"
             ),
             StepError::JsonRequiresDryRun => {
                 write!(f, "--json is only supported with --dry-run")
@@ -212,7 +212,7 @@ impl StepError {
                 libagent::EntryError::InvalidReference { .. }
                 | libagent::EntryError::MissingDeploymentIdentity { .. }
                 | libagent::EntryError::DeploymentDisagreement { .. }
-                | libagent::EntryError::UnsupportedForge { .. } => ExitCode::UsageError,
+                | libagent::EntryError::UnknownTracker { .. } => ExitCode::UsageError,
                 libagent::EntryError::Unresolved { .. } => ExitCode::WorkFailed,
                 libagent::EntryError::NoAcquisitionSurface { .. }
                 | libagent::EntryError::AmbiguousAcquisitionSurface { .. } => {
@@ -378,12 +378,13 @@ pub(crate) fn build_execution_plan(
             let protocol = protocol_map
                 .get(entry.name.as_str())
                 .expect("planned protocol must exist in manifest");
-            let context = libagent::context::build_execution_context(
+            let mut context = libagent::context::build_execution_context(
                 protocol,
                 &loaded.store,
                 entry.work_unit.as_deref(),
                 &scan_findings.affected_types,
             );
+            context.target_project = Some((&loaded.config.target_project).into());
             PlannedEntry {
                 protocol: entry.name.clone(),
                 work_unit: entry.work_unit.clone(),
@@ -418,26 +419,15 @@ pub(crate) fn resolved_runtime_env(
     let transcript_settings = libagent::transcript::resolve_transcript_settings_with_forge(
         working_dir,
         &config.transcript,
-        &config.forge,
+        &config.target_project,
     );
     let mut env: BTreeMap<String, String> =
         libagent::transcript::transcript_env_from_settings(&transcript_settings)
             .into_iter()
             .collect();
 
-    let forge_environment = libagent::resolve_forge_environment(&config.forge);
-    for name in [
-        "RUNA_FORGE_TYPE",
-        "RUNA_FORGE_OWNER",
-        "RUNA_FORGE_NAME",
-        "RUNA_FORGE_TRACKER_ID",
-    ] {
-        if let Some(value) = forge_environment
-            .get(name)
-            .filter(|value| !value.is_empty())
-        {
-            env.insert(name.to_string(), value.clone());
-        }
+    if let Ok(project_env) = libagent::target_project_env(&config.target_project) {
+        env.extend(project_env);
     }
 
     env
@@ -885,7 +875,7 @@ fn run_internal(
     let transcript_settings = libagent::transcript::resolve_transcript_settings_with_forge(
         working_dir,
         &loaded.config.transcript,
-        &loaded.config.forge,
+        &loaded.config.target_project,
     );
 
     let agent_command = if dry_run {
@@ -894,7 +884,7 @@ fn run_internal(
         let config = crate::project::read_config(working_dir, config_override)
             .map_err(CommandError::from)
             .map_err(StepError::from)?;
-        let command = config.agent.command.filter(|command| {
+        let command = config.launch.command.filter(|command| {
             !command.is_empty() && !command.first().is_some_and(|part| part.is_empty())
         });
         if command.is_none() {
@@ -1382,6 +1372,7 @@ mod tests {
             context: libagent::context::ContextInjection {
                 protocol: protocol.to_string(),
                 work_unit: work_unit.map(str::to_string),
+                target_project: None,
                 instructions: "Tell the operator about SECRET_VALUE.".to_string(),
                 inputs: Vec::new(),
                 entry: None,
@@ -1720,45 +1711,44 @@ cat >/dev/null
     }
 
     #[test]
-    fn resolved_runtime_env_materializes_default_github_forge_type_from_config_identity() {
+    fn resolved_runtime_env_exports_target_project_payload_from_config_identity() {
         let _lock = transcript_env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let _env = EnvGuard::unset(&[
-            "RUNA_FORGE_TYPE",
-            "RUNA_FORGE_OWNER",
-            "RUNA_FORGE_NAME",
-            "RUNA_FORGE_TRACKER_ID",
-            "RUNA_TRANSCRIPT_DIR",
-            "RUNA_TRANSCRIPT_REDACT_ENV",
-        ]);
+        let _env = EnvGuard::unset(&["RUNA_TRANSCRIPT_DIR", "RUNA_TRANSCRIPT_REDACT_ENV"]);
         let temp = tempfile::tempdir().unwrap();
         let config = libagent::Config {
             methodology_path: "methodology.toml".to_string(),
             logging: libagent::LoggingConfig::default(),
-            agent: libagent::project::AgentConfig::default(),
+            launch: libagent::project::LaunchConfig::default(),
             transcript: libagent::TranscriptConfig::default(),
-            forge: libagent::ForgeConfig {
-                forge_type: None,
-                owner: Some("tesserine".to_string()),
-                name: Some("runa".to_string()),
-                tracker_id: None,
+            target_project: libagent::TargetProjectConfig {
+                forge_type: libagent::ForgeType::Github,
+                repositories: vec![libagent::RepositoryConfig {
+                    selector: "runa".to_string(),
+                    host: "github.com".to_string(),
+                    owner: "tesserine".to_string(),
+                    name: "runa".to_string(),
+                }],
+                trackers: Vec::new(),
             },
         };
 
         let env = resolved_runtime_env(temp.path(), &config);
+        let payload: serde_json::Value =
+            serde_json::from_str(env.get("RUNA_TARGET_PROJECT").unwrap()).unwrap();
 
-        assert_eq!(env.get("RUNA_FORGE_TYPE"), Some(&"github".to_string()));
-        assert_eq!(env.get("RUNA_FORGE_OWNER"), Some(&"tesserine".to_string()));
-        assert_eq!(env.get("RUNA_FORGE_NAME"), Some(&"runa".to_string()));
+        assert_eq!(payload["forge_type"], "github");
+        assert_eq!(payload["repositories"][0]["owner"], "tesserine");
+        assert_eq!(payload["repositories"][0]["name"], "runa");
     }
 
     #[test]
     fn build_mcp_config_includes_supplied_runtime_environment() {
-        let runtime_env = BTreeMap::from([
-            ("RUNA_FORGE_OWNER".to_string(), "tesserine".to_string()),
-            ("RUNA_FORGE_NAME".to_string(), "runa".to_string()),
-        ]);
+        let runtime_env = BTreeMap::from([(
+            "RUNA_TARGET_PROJECT".to_string(),
+            r#"{"version":1,"forge_type":"github","repositories":[],"trackers":[]}"#.to_string(),
+        )]);
 
         let config = build_mcp_config(
             "/tmp/bin/runa-mcp",
@@ -1770,10 +1760,12 @@ cat >/dev/null
         );
 
         assert_eq!(
-            config.env.get("RUNA_FORGE_OWNER"),
-            Some(&"tesserine".to_string())
+            config.env.get("RUNA_TARGET_PROJECT"),
+            Some(
+                &r#"{"version":1,"forge_type":"github","repositories":[],"trackers":[]}"#
+                    .to_string()
+            )
         );
-        assert_eq!(config.env.get("RUNA_FORGE_NAME"), Some(&"runa".to_string()));
     }
 
     #[test]
@@ -1949,6 +1941,7 @@ cat >/dev/null
             context: libagent::context::ContextInjection {
                 protocol: "implement".to_string(),
                 work_unit: None,
+                target_project: None,
                 instructions: String::new(),
                 inputs: Vec::new(),
                 entry: None,

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -92,19 +92,19 @@ struct RunArgs {
     #[arg(long, conflicts_with = "work_unit")]
     ticket: Option<String>,
 
-    /// Override the live agent command; pass argv after `--`, for example `--agent-command -- <argv tokens>`
-    #[arg(long = "agent-command")]
-    agent_command: bool,
+    /// Override the live launch command; pass argv after `--`, for example `--launch-command -- <argv tokens>`
+    #[arg(long = "launch-command")]
+    launch_command: bool,
 
-    /// Agent argv passed through after `--` when `--agent-command` is set
+    /// Launch argv passed through after `--` when `--launch-command` is set
     #[arg(
         num_args = 0..,
         last = true,
         allow_hyphen_values = true,
-        requires = "agent_command",
+        requires = "launch_command",
         value_name = "ARGV"
     )]
-    agent_command_argv: Vec<String>,
+    launch_command_argv: Vec<String>,
 }
 
 fn main() {
@@ -225,8 +225,8 @@ fn main() {
                 args.json,
                 args.work_unit.as_deref(),
                 args.ticket.as_deref(),
-                args.agent_command,
-                &args.agent_command_argv,
+                args.launch_command,
+                &args.launch_command_argv,
             ) {
                 Ok(outcome) => {
                     let exit_code = outcome.exit_code();

--- a/runa-cli/tests/common/mod.rs
+++ b/runa-cli/tests/common/mod.rs
@@ -80,7 +80,7 @@ pub fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     fs::write(
         project_dir.join(".runa/project.toml"),
         format!(
-            "{}\n[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\nhost = \"github.com\"\n",
+            "{}\n[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\n",
             fs::read_to_string(project_dir.join(".runa/project.toml")).unwrap()
         ),
     )

--- a/runa-cli/tests/common/mod.rs
+++ b/runa-cli/tests/common/mod.rs
@@ -78,10 +78,10 @@ pub fn github_work_unit_json(number: u64) -> String {
 #[allow(dead_code)]
 pub fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     fs::write(
-        project_dir.join(".runa/config.toml"),
+        project_dir.join(".runa/project.toml"),
         format!(
-            "{}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\n",
-            fs::read_to_string(project_dir.join(".runa/config.toml")).unwrap()
+            "{}\n[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\nhost = \"github.com\"\n",
+            fs::read_to_string(project_dir.join(".runa/project.toml")).unwrap()
         ),
     )
     .unwrap();

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -274,7 +274,7 @@ esac
 }
 
 fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
-    let config_path = project_dir.join(".runa/config.toml");
+    let config_path = project_dir.join(".runa/project.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
     let command_entries = command
         .iter()
@@ -283,7 +283,7 @@ fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
         .join("\n");
     fs::write(
         config_path,
-        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+        format!("{existing}\n[launch]\ncommand = [\n{command_entries}\n]\n"),
     )
     .unwrap();
 }

--- a/runa-cli/tests/go.rs
+++ b/runa-cli/tests/go.rs
@@ -31,9 +31,9 @@ fn init_project(project_dir: &Path, manifest_path: &Path) {
 }
 
 fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
-    let config_path = project_dir.join(".runa/config.toml");
+    let config_path = project_dir.join(".runa/project.toml");
     let mut config = fs::read_to_string(&config_path).unwrap();
-    config.push_str("\n[agent]\ncommand = [");
+    config.push_str("\n[launch]\ncommand = [");
     for (index, part) in command.iter().enumerate() {
         if index > 0 {
             config.push_str(", ");
@@ -78,8 +78,8 @@ fi
         .arg(log_path)
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(project_dir)
         .output()
         .unwrap();
@@ -124,6 +124,7 @@ fn setup_ready_scoped_project(dir: &Path) -> PathBuf {
     let project_dir = dir.join("project");
     fs::create_dir(&project_dir).unwrap();
     init_project(&project_dir, &manifest_path);
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
 
     let workspace = project_dir.join(".runa/workspace");
     fs::create_dir_all(workspace.join("work-unit")).unwrap();
@@ -144,8 +145,8 @@ fn scoped_state_json(project_dir: &Path) -> serde_json::Value {
         .arg("work-unit-168")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(project_dir)
         .output()
         .unwrap();
@@ -218,8 +219,8 @@ fi
         .arg("work-unit-168")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(&project_dir)
         .output()
         .unwrap();
@@ -287,8 +288,8 @@ fn go_fails_when_agent_exits_without_advancing_the_session_step() {
         .arg("work-unit-168")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(&project_dir)
         .output()
         .unwrap();
@@ -344,8 +345,8 @@ fn go_matches_direct_session_surface_when_regenerating_deleted_output_with_uncha
         .arg("work-unit-168")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(&go_project_dir)
         .output()
         .unwrap();

--- a/runa-cli/tests/init.rs
+++ b/runa-cli/tests/init.rs
@@ -70,7 +70,13 @@ fn init_creates_runa_directory() {
     assert!(stdout.contains("3 protocols"), "stdout: {stdout}");
 
     assert!(project_dir.join(".runa").is_dir());
+    assert!(project_dir.join(".runa/project.toml").is_file());
+    assert!(project_dir.join(".runa/config.toml").is_file());
     assert!(project_dir.join(".runa/state.toml").is_file());
+    assert_eq!(
+        std::fs::read_to_string(project_dir.join(".runa/.gitignore")).unwrap(),
+        "config.toml\nstate.toml\nstore/\nworkspace/\n"
+    );
 
     assert!(project_dir.join(".runa/store").is_dir());
     assert!(project_dir.join(".runa/workspace").is_dir());

--- a/runa-cli/tests/run.rs
+++ b/runa-cli/tests/run.rs
@@ -204,6 +204,7 @@ fn run_dry_run_accepts_exact_tracker_backed_work_unit_without_slug() {
         common::github_work_unit_json(163),
     )
     .unwrap();
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
 
     let output = runa_bin()
         .arg("run")
@@ -212,8 +213,8 @@ fn run_dry_run_accepts_exact_tracker_backed_work_unit_without_slug() {
         .arg("work-unit-163")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(&project_dir)
         .output()
         .unwrap();
@@ -451,7 +452,7 @@ trigger = { type = "on_artifact", name = "implementation" }
 }
 
 fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
-    let config_path = project_dir.join(".runa/config.toml");
+    let config_path = project_dir.join(".runa/project.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
     let command_entries = command
         .iter()
@@ -460,7 +461,7 @@ fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
         .join("\n");
     fs::write(
         config_path,
-        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+        format!("{existing}\n[launch]\ncommand = [\n{command_entries}\n]\n"),
     )
     .unwrap();
 }
@@ -717,7 +718,7 @@ trigger = { type = "on_artifact", name = "constraints" }
 
     let output = runa_bin()
         .arg("run")
-        .arg("--agent-command")
+        .arg("--launch-command")
         .arg("--")
         .arg(&cli_agent)
         .arg(&cli_log_path)
@@ -786,7 +787,7 @@ trigger = { type = "on_artifact", name = "constraints" }
 
     let output = runa_bin()
         .arg("run")
-        .arg("--agent-command")
+        .arg("--launch-command")
         .arg("--")
         .arg(&agent_path)
         .arg(&log_path)
@@ -862,7 +863,7 @@ trigger = { type = "on_artifact", name = "constraints" }
 
     let output = runa_bin()
         .arg("run")
-        .arg("--agent-command")
+        .arg("--launch-command")
         .arg("--")
         .current_dir(&project_dir)
         .output()
@@ -871,7 +872,7 @@ trigger = { type = "on_artifact", name = "constraints" }
     assert_eq!(output.status.code(), Some(6), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("no agent command configured"),
+        stderr.contains("no launch command configured"),
         "stderr: {stderr}"
     );
     assert!(!config_log_path.exists(), "configured agent should not run");
@@ -931,7 +932,7 @@ trigger = { type = "on_artifact", name = "constraints" }
     assert_eq!(output.status.code(), Some(6), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("no agent command configured"),
+        stderr.contains("no launch command configured"),
         "stderr: {stderr}"
     );
     assert!(!workspace.join("implementation/impl-1.json").exists());
@@ -947,7 +948,7 @@ fn run_help_describes_agent_command_passthrough() {
         stdout.contains("Usage: runa run [OPTIONS] [-- [ARGV]...]"),
         "stdout: {stdout}"
     );
-    assert!(stdout.contains("--agent-command"), "stdout: {stdout}");
+    assert!(stdout.contains("--launch-command"), "stdout: {stdout}");
     assert!(stdout.contains("-- <argv"), "stdout: {stdout}");
     assert!(
         !stdout.contains("Usage: runa run [OPTIONS] [ARGV]..."),
@@ -1004,7 +1005,7 @@ trigger = { type = "on_artifact", name = "constraints" }
 
     let output = runa_bin()
         .arg("run")
-        .arg("--agent-command")
+        .arg("--launch-command")
         .arg(&agent_path)
         .arg("--dry-run")
         .current_dir(&project_dir)
@@ -1071,7 +1072,7 @@ trigger = { type = "on_artifact", name = "constraints" }
 
     let output = runa_bin()
         .arg("run")
-        .arg("--agent-command")
+        .arg("--launch-command")
         .arg(&agent_path)
         .arg("--work-unit")
         .arg("wu-xyz")
@@ -1605,7 +1606,7 @@ fn run_without_dry_run_with_no_ready_protocols_still_requires_agent_command() {
     assert_eq!(output.status.code(), Some(6), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("no agent command configured"),
+        stderr.contains("no launch command configured"),
         "stderr: {stderr}"
     );
 }
@@ -1621,7 +1622,7 @@ fn run_without_dry_run_rejects_empty_cli_agent_command_when_no_protocols_are_rea
 
     let output = runa_bin()
         .arg("run")
-        .arg("--agent-command")
+        .arg("--launch-command")
         .arg("--")
         .current_dir(&project_dir)
         .output()
@@ -1630,7 +1631,7 @@ fn run_without_dry_run_rejects_empty_cli_agent_command_when_no_protocols_are_rea
     assert_eq!(output.status.code(), Some(6), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("no agent command configured"),
+        stderr.contains("no launch command configured"),
         "stderr: {stderr}"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/runa-cli/tests/state.rs
+++ b/runa-cli/tests/state.rs
@@ -168,6 +168,7 @@ fn state_accepts_exact_tracker_backed_work_unit_without_slug() {
         common::github_work_unit_json(163),
     )
     .unwrap();
+    common::append_github_forge_config(&project_dir, "tesserine", "runa");
 
     let output = runa_bin()
         .arg("state")
@@ -175,8 +176,8 @@ fn state_accepts_exact_tracker_backed_work_unit_without_slug() {
         .arg("work-unit-163")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(&project_dir)
         .output()
         .unwrap();

--- a/runa-cli/tests/step.rs
+++ b/runa-cli/tests/step.rs
@@ -272,6 +272,7 @@ fn step_dry_run_accepts_exact_tracker_backed_work_unit_without_slug() {
         common::github_work_unit_json(163),
     )
     .unwrap();
+    append_github_forge_config(&project_dir, "tesserine", "runa");
 
     let output = runa_bin()
         .arg("step")
@@ -280,8 +281,8 @@ fn step_dry_run_accepts_exact_tracker_backed_work_unit_without_slug() {
         .arg("work-unit-163")
         .env_remove("RUNA_FORGE_TYPE")
         .env_remove("RUNA_FORGE_TRACKER_ID")
-        .env("RUNA_FORGE_OWNER", "tesserine")
-        .env("RUNA_FORGE_NAME", "runa")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
         .current_dir(&project_dir)
         .output()
         .unwrap();
@@ -428,7 +429,7 @@ trigger = { type = "on_artifact", name = "constraints" }
 }
 
 fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
-    let config_path = project_dir.join(".runa/config.toml");
+    let config_path = project_dir.join(".runa/project.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
     let command_entries = command
         .iter()
@@ -437,36 +438,56 @@ fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
         .join("\n");
     fs::write(
         config_path,
-        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+        format!("{existing}\n[launch]\ncommand = [\n{command_entries}\n]\n"),
     )
     .unwrap();
 }
 fn append_transcript_config(project_dir: &Path, transcript_dir: &Path, redact_env: &[&str]) {
     let config_path = project_dir.join(".runa/config.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
+    fs::write(
+        &config_path,
+        format!(
+            "{existing}\n[transcript]\ndir = {:?}\n",
+            transcript_dir.display().to_string()
+        ),
+    )
+    .unwrap();
+
+    let project_config_path = project_dir.join(".runa/project.toml");
+    let existing_project = fs::read_to_string(&project_config_path).unwrap();
     let redact_entries = redact_env
         .iter()
         .map(|name| format!("{name:?}"))
         .collect::<Vec<_>>()
         .join(", ");
     fs::write(
-        config_path,
-        format!(
-            "{existing}\n[transcript]\ndir = {:?}\nredact_env = [{redact_entries}]\n",
-            transcript_dir.display().to_string()
-        ),
+        project_config_path,
+        format!("{existing_project}\n[transcript]\nredact_env = [{redact_entries}]\n"),
     )
     .unwrap();
 }
 
 fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
-    let config_path = project_dir.join(".runa/config.toml");
+    let config_path = project_dir.join(".runa/project.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
     fs::write(
         config_path,
-        format!("{existing}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\n"),
+        format!("{existing}\n[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\nhost = \"github.com\"\n"),
     )
     .unwrap();
+}
+
+fn default_project_target_payload() -> String {
+    r#"{"version":1,"forge_type":"github","repositories":[],"trackers":[]}"#.to_string()
+}
+
+fn default_mcp_env(project_dir: &Path) -> serde_json::Value {
+    serde_json::json!({
+        "RUNA_TARGET_PROJECT": default_project_target_payload(),
+        "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
+        "RUNA_WORKING_DIR": project_dir
+    })
 }
 
 fn transcript_event_files(root: &Path) -> Vec<std::path::PathBuf> {
@@ -708,11 +729,7 @@ fn step_dry_run_json_reports_ready_execution_plan_and_full_skill_status() {
     );
     assert_eq!(
         execution_plan[0]["mcp_config"]["env"],
-        serde_json::json!({
-            "RUNA_FORGE_TYPE": "github",
-            "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
-            "RUNA_WORKING_DIR": project_dir
-        })
+        default_mcp_env(&project_dir)
     );
     let mcp_command = execution_plan[0]["mcp_config"]["command"]
         .as_str()
@@ -1081,11 +1098,11 @@ fn step_without_dry_run_fails_when_agent_command_is_not_configured() {
     assert!(stderr.contains("command"), "stderr: {stderr}");
     assert!(stderr.contains("step"), "stderr: {stderr}");
     assert!(
-        stderr.contains("no agent command configured"),
+        stderr.contains("no launch command configured"),
         "stderr: {stderr}"
     );
-    assert!(stderr.contains("[agent]"), "stderr: {stderr}");
-    assert!(stderr.contains("config.toml"), "stderr: {stderr}");
+    assert!(stderr.contains("[launch]"), "stderr: {stderr}");
+    assert!(stderr.contains("project.toml"), "stderr: {stderr}");
 }
 #[test]
 fn step_without_dry_run_invokes_configured_agent_with_execution_prompt() {
@@ -1180,14 +1197,7 @@ fn step_without_dry_run_invokes_configured_agent_with_execution_prompt() {
         mcp_config["args"],
         serde_json::json!(["--protocol", "implement"])
     );
-    assert_eq!(
-        mcp_config["env"],
-        serde_json::json!({
-            "RUNA_FORGE_TYPE": "github",
-            "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
-            "RUNA_WORKING_DIR": project_dir
-        })
-    );
+    assert_eq!(mcp_config["env"], default_mcp_env(&project_dir));
 }
 #[test]
 fn step_without_dry_run_launches_claude_named_agent_agnostically() {
@@ -1243,14 +1253,7 @@ fn step_without_dry_run_launches_claude_named_agent_agnostically() {
         mcp_config["args"],
         serde_json::json!(["--protocol", "implement"])
     );
-    assert_eq!(
-        mcp_config["env"],
-        serde_json::json!({
-            "RUNA_FORGE_TYPE": "github",
-            "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
-            "RUNA_WORKING_DIR": project_dir
-        })
-    );
+    assert_eq!(mcp_config["env"], default_mcp_env(&project_dir));
     let mcp_command = mcp_config["command"]
         .as_str()
         .expect("mcp command should be a string");

--- a/runa-cli/tests/step.rs
+++ b/runa-cli/tests/step.rs
@@ -473,7 +473,7 @@ fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     let existing = fs::read_to_string(&config_path).unwrap();
     fs::write(
         config_path,
-        format!("{existing}\n[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\nhost = \"github.com\"\n"),
+        format!("{existing}\n[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\n"),
     )
     .unwrap();
 }

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -68,13 +68,13 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     apply_transcript_settings(&working_dir, &loaded.config);
     libagent::scan(&loaded.workspace_dir, &mut loaded.store)?;
     if let Some(work_unit) = cli.work_unit.as_deref() {
-        let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+        let identity = libagent::resolve_forge_identity(&loaded.config.target_project);
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     if cli.session {
         let handler = match cli.ticket.as_deref() {
             Some(ticket) => {
-                let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+                let identity = libagent::resolve_forge_identity(&loaded.config.target_project);
                 let ticket_ref = libagent::resolve_ticket_reference(ticket, &identity)?;
                 RunaHandler::new_session_entry(working_dir.clone(), config_ref, ticket_ref)?
             }
@@ -156,7 +156,7 @@ fn apply_transcript_settings(working_dir: &std::path::Path, config: &project::Co
     let settings = libagent::transcript::resolve_transcript_settings_with_forge(
         working_dir,
         &config.transcript,
-        &config.forge,
+        &config.target_project,
     );
     for (name, value) in libagent::transcript::transcript_env_from_settings(&settings) {
         unsafe { std::env::set_var(name, value) };

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -263,14 +263,18 @@ fn init_project(project_dir: &Path, manifest_path: &Path) {
         "initialized_at = \"2026-03-25T00:00:00Z\"\nruna_version = \"0.1.0\"\n",
     )
     .unwrap();
+    fs::write(
+        runa_dir.join("project.toml"),
+        "[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"runa\"\nowner = \"tesserine\"\nname = \"runa\"\nhost = \"github.com\"\n",
+    )
+    .unwrap();
 }
 
 fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
-    let config_path = project_dir.join(".runa/config.toml");
-    let existing = fs::read_to_string(&config_path).unwrap();
+    let config_path = project_dir.join(".runa/project.toml");
     fs::write(
         config_path,
-        format!("{existing}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\n"),
+        format!("[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\nhost = \"github.com\"\n"),
     )
     .unwrap();
 }
@@ -407,8 +411,8 @@ async fn session_mode_advertises_driver_verbs_and_current_output_tools() {
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -464,8 +468,8 @@ async fn session_mode_is_caller_agnostic_for_tools_readiness_and_context() {
                         .env("RUNA_CALLER_KIND", "interactive")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -483,8 +487,8 @@ async fn session_mode_is_caller_agnostic_for_tools_readiness_and_context() {
                         .env("RUNA_CALLER_KIND", "autonomous")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -566,8 +570,8 @@ async fn session_record_read_advance_records_execution_for_producing_step() {
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -649,8 +653,8 @@ async fn session_advance_records_context_time_input_provenance() {
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -741,8 +745,8 @@ async fn session_advance_reopens_current_step_when_context_input_changes() {
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -830,8 +834,8 @@ async fn session_advance_reopens_current_step_when_readiness_consumes_context_in
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -904,8 +908,8 @@ async fn session_advance_emits_tool_list_changed_when_current_step_changes() {
                     .arg("work-unit-166")
                     .env_remove("RUNA_FORGE_TYPE")
                     .env_remove("RUNA_FORGE_TRACKER_ID")
-                    .env("RUNA_FORGE_OWNER", "tesserine")
-                    .env("RUNA_FORGE_NAME", "runa")
+                    .env_remove("RUNA_FORGE_OWNER")
+                    .env_remove("RUNA_FORGE_NAME")
                     .current_dir(&project_dir);
             }),
         )
@@ -965,8 +969,8 @@ async fn session_advance_reconciles_deleted_output_before_recording_execution() 
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1048,8 +1052,8 @@ async fn session_advance_rejects_deleted_required_input_before_downstream_select
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1118,8 +1122,8 @@ async fn session_readiness_selects_later_ready_step_and_advertises_tools() {
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1190,8 +1194,8 @@ async fn session_readiness_rejects_newly_ready_step_with_unservable_required_out
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1262,8 +1266,8 @@ async fn session_readiness_emits_tool_list_changed_when_current_step_becomes_rea
                     .arg("work-unit-166")
                     .env_remove("RUNA_FORGE_TYPE")
                     .env_remove("RUNA_FORGE_TRACKER_ID")
-                    .env("RUNA_FORGE_OWNER", "tesserine")
-                    .env("RUNA_FORGE_NAME", "runa")
+                    .env_remove("RUNA_FORGE_OWNER")
+                    .env_remove("RUNA_FORGE_NAME")
                     .current_dir(&project_dir);
             }),
         )
@@ -1329,8 +1333,8 @@ async fn session_advance_error_preserves_current_step_when_next_step_is_unservab
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1411,8 +1415,8 @@ async fn session_advance_persistence_error_preserves_current_step_and_no_record(
                         .arg("work-unit-166")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1718,8 +1722,8 @@ async fn mcp_accepts_exact_tracker_backed_work_unit_without_slug() {
                         .arg("work-unit-163")
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1962,7 +1966,7 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
     assert!(events.contains("\"kind\":\"tool_result\""));
     assert!(events.contains("\"tool_name\":\"implementation\""));
     assert!(events.contains("\"schema_version\":2"));
-    assert!(events.contains("\"deployment\":\"project:sha256:"));
+    assert!(events.contains("\"deployment\":\"github:tesserine/runa\""));
     assert!(events.contains("\"run_id\":\"run-"));
 
     service.cancel().await.unwrap();
@@ -2000,8 +2004,8 @@ async fn session_driver_calls_append_transcript_events_when_enabled() {
                         .env("RUNA_TRANSCRIPT_DIR", &transcript_dir)
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )
@@ -2078,8 +2082,8 @@ async fn failed_session_driver_calls_append_transcript_result_when_enabled() {
                         .env("RUNA_TRANSCRIPT_DIR", &transcript_dir)
                         .env_remove("RUNA_FORGE_TYPE")
                         .env_remove("RUNA_FORGE_TRACKER_ID")
-                        .env("RUNA_FORGE_OWNER", "tesserine")
-                        .env("RUNA_FORGE_NAME", "runa")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
                         .current_dir(&project_dir);
                 }),
             )

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -265,7 +265,7 @@ fn init_project(project_dir: &Path, manifest_path: &Path) {
     .unwrap();
     fs::write(
         runa_dir.join("project.toml"),
-        "[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"runa\"\nowner = \"tesserine\"\nname = \"runa\"\nhost = \"github.com\"\n",
+        "[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"runa\"\nowner = \"tesserine\"\nname = \"runa\"\n",
     )
     .unwrap();
 }
@@ -274,7 +274,7 @@ fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     let config_path = project_dir.join(".runa/project.toml");
     fs::write(
         config_path,
-        format!("[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\nhost = \"github.com\"\n"),
+        format!("[target_project]\nforge_type = \"github\"\n\n[[target_project.repositories]]\nselector = \"{name}\"\nowner = \"{owner}\"\nname = \"{name}\"\n"),
     )
     .unwrap();
 }


### PR DESCRIPTION
## Coupled landing

This PR is one half of the coupled runa#196 + groundwork#418 change. It must land together with tesserine/groundwork#419; neither side should be merged alone.

Closes #196.

## Summary

- Split the project surface into portable `.runa/project.toml` and machine-local `.runa/config.toml`, with `runa init` generating `.runa/.gitignore` so only the portable project file is intended for commit.
- Replace the retired single-repository forge env atoms with typed project identity and the `RUNA_TARGET_PROJECT` payload, preserving the one-repository case.
- Rename the launch surface to `[launch].command` / `--launch-command`, reject the retired active config/env shape, and deliver project identity into agent context.
- Update `docs/interface-contract.md`, CLI docs, README, tests, and changelog for the public-surface reset.

## Validation

- `cargo test --workspace`

## Coupling note

The matching groundwork PR consumes this new payload in `tooling/forge_operations.py`. Merging this without tesserine/groundwork#419 breaks forge mechanics.
