### PR TITLE
[codex] Update forge address contract surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Semantic Versioning.
 
 ### Changed
 
+- Forge addressing now uses the canonical instance/resource contract. The
+  portable surface is `[forge.instances.*]`, `[[forge.repositories]]`, and
+  `[[forge.trackers]]`; launched agents and MCP servers receive the versioned
+  `RUNA_PROJECT_FORGE_ADDRESSES` payload. The retired `[forge]` and `[agent]`
+  config tables, `--agent-command`, and `RUNA_FORGE_*` identity atoms now
+  produce migration diagnostics that point at the new contract surface.
 - Transcript capture now treats `[transcript].dir` and `RUNA_TRANSCRIPT_DIR`
   as roots and writes events beneath deployment/work-unit/run paths. Events
   carry `deployment` and `run_id` fields, while existing redaction behavior is

--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ scoped evaluation remains inert and accepts the caller-supplied id as before.
 
 To start scoped work from nothing but a tracker ticket, `runa run --ticket <REF>`
 and `runa go --ticket <REF>` open a cold-start session from a forge ticket
-reference (a bare number, `#<N>`, `owner/repo#<N>`, an issue URL, or
-`sourcehut:<tracker_id>#<N>`). The runtime resolves the reference to an identity
-and serves the methodology's acquisition surface; the methodology reads the
-ticket and materializes the `work-unit`, after which the session is
-indistinguishable from one opened on a recorded work-unit. The runtime performs
-no forge read of its own.
+reference. A bare number or `#<N>` is accepted when the project has exactly one
+configured tracker; multi-tracker projects use `<tracker-selector>#<N>`. The
+runtime resolves the reference through the configured forge-address payload and
+serves the methodology's acquisition surface; the methodology reads the ticket
+and materializes the `work-unit`, after which the session is indistinguishable
+from one opened on a recorded work-unit. The runtime performs no forge read of
+its own.
 
 ## Quick Start
 
@@ -198,7 +199,7 @@ Both projects are in early development.
 | `runa state` | Evaluate and classify protocol readiness |
 | `runa doctor` | Check project health |
 | `runa step` | Execute the next ready protocol |
-| `runa run` | Walk the ready frontier to quiescence; live runs may override the agent command with `--agent-command -- <argv...>` |
+| `runa run` | Walk the ready frontier to quiescence |
 | `runa go` | Advance one scoped interactive session tick through the session MCP surface |
 | `runa-mcp` | MCP server for artifact production and session driver verbs |
 
@@ -206,14 +207,14 @@ See [CLI Reference](docs/cli-reference.md) for flags, exit codes, configuration,
 
 ## Configuration
 
-`runa init` creates `.runa/config.toml` with the methodology path. Operators
-may also set durable project defaults there for live agent command,
-transcript capture, and scoped forge identity. Environment variables such as
-`RUNA_TRANSCRIPT_DIR` and `RUNA_FORGE_*` remain per-invocation overrides;
-config is the project-local default.
+`runa init` creates project configuration under `.runa/`. Portable forge
+addresses live in `.runa/config.toml` as instances, repositories, and trackers;
+machine-local launch and path settings live in `.runa/local.toml`. Runa delivers
+the resolved forge-address set to agents and MCP servers through the
+`RUNA_PROJECT_FORGE_ADDRESSES` payload.
 
 Runa ships supported agent adapters for Codex and Claude Code in `adapters/`.
-Set `[agent].command` to `./adapters/agent-codex.sh` or
+Set `[launch].command` to `./adapters/agent-codex.sh` or
 `./adapters/agent-claude-code.sh`; the adapter translates `RUNA_MCP_CONFIG` for
 the selected runtime.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,35 +15,58 @@ For `runa init`, `--config` controls where the config file is written. For all o
 
 ### Durable Project Settings
 
-Durable project settings live in `.runa/config.toml`. Environment variables
-with matching runtime meaning remain per-invocation overrides.
+Portable project settings live in `.runa/config.toml`. Machine-local settings,
+including paths and launch commands, live in `.runa/local.toml`.
 
 ```toml
+[project]
+deployment = "runa"
+
 [transcript]
-dir = "transcripts"
 redact_env = ["SECRET_TOKEN", "API_KEY"]
 
-[forge]
+[forge.instances.github]
 type = "github"
+host = "github.com"
+
+[forge.instances.weforge]
+type = "sourcehut"
+git_host = "git.weforge.build"
+tracker_host = "todo.weforge.build"
+
+[[forge.repositories]]
+id = "runa"
+instance = "github"
 owner = "tesserine"
 name = "runa"
+
+[[forge.trackers]]
+id = "groundwork"
+instance = "weforge"
+owner = "tesserine"
+name = "groundwork"
 tracker_id = "4"
 ```
 
-`[transcript].dir` enables transcript capture and is resolved relative to the
-project directory when it is not absolute. `RUNA_TRANSCRIPT_DIR` overrides it
-for one invocation. `[transcript].redact_env` names environment variables whose
-current values should be redacted from transcript events.
-`RUNA_TRANSCRIPT_REDACT_ENV`, when set to a comma-separated list, overrides the
-configured list.
+```toml
+[launch]
+command = ["./adapters/agent-codex.sh", "--model", "gpt-5-codex"]
 
-`[forge]` supplies the active scoped work-unit deployment identity. Runa uses
-it when validating tracker-backed `work-unit` roots and injects the resolved
-`RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
-`RUNA_FORGE_TRACKER_ID` values into launched agent and MCP environments.
-Any non-empty matching `RUNA_FORGE_*` environment variable overrides the
-configured field for that invocation. The forge type still defaults to `github`
-when neither config nor env specifies one.
+[transcript]
+dir = "transcripts"
+```
+
+`[transcript].dir` enables transcript capture and is resolved from the
+machine-local file relative to the project directory when it is not absolute.
+`RUNA_TRANSCRIPT_DIR` overrides it for one invocation. Portable
+`[transcript].redact_env` names environment variables whose current values
+should be redacted from transcript events. `RUNA_TRANSCRIPT_REDACT_ENV`, when
+set to a comma-separated list, overrides the configured list.
+
+Forge addresses are configured as resources on declared instances. Each
+instance declares its type and service hosts; repositories and trackers
+reference an instance. Runa injects the resolved project address set into
+launched agents and MCP servers as `RUNA_PROJECT_FORGE_ADDRESSES`.
 
 ### Logging
 
@@ -61,22 +84,17 @@ filter = "info"   # any tracing env-filter directive
 
 ### Agent Execution
 
-Live `runa step` and `runa go` require an `[agent].command` entry in the
-config. Live `runa run` uses the same config entry by default, but a single
-invocation may override it with `--agent-command -- <argv tokens>`:
+Live `runa step`, `runa run`, and `runa go` require a `[launch].command`
+entry in `.runa/local.toml`:
 
 ```toml
-[agent]
+[launch]
 command = ["./adapters/agent-codex.sh", "--model", "gpt-5-codex"]
 ```
 
 ```toml
-[agent]
+[launch]
 command = ["./adapters/agent-claude-code.sh", "-p", "--dangerously-skip-permissions"]
-```
-
-```bash
-runa run --agent-command -- ./adapters/agent-codex.sh --model gpt-5-codex
 ```
 
 Runa executes the configured argv unmodified in the project root with stdout
@@ -89,16 +107,15 @@ child process. Runtime-specific translation, such as wrapping that payload in a
 client-specific config file, belongs to the runtime or adapter, not to runa.
 
 The supported runtime adapters live in `adapters/`: `agent-codex.sh` for Codex
-and `agent-claude-code.sh` for Claude Code. Point `[agent].command` at one of
+and `agent-claude-code.sh` for Claude Code. Point `[launch].command` at one of
 those scripts and pass runtime-specific options after the script path. The
 Codex adapter requires `jq` because Codex accepts external MCP servers through
 `-c mcp_servers.<name>.*` TOML overrides rather than a JSON config file. It
 registers each invocation under a process-scoped server name so an existing
 operator-defined `mcp_servers.runa` entry is left untouched.
-Migration note: older documentation used
-`./examples/agent-claude-code.sh` for Claude Code. That path no longer exists;
-repoint existing `[agent].command` values to
-`./adapters/agent-claude-code.sh`.
+Migration note: older documentation used a project config agent table and the
+`./examples/agent-claude-code.sh` path for Claude Code. Repoint launch command
+settings to `.runa/local.toml` and `./adapters/agent-claude-code.sh`.
 
 When transcript capture is enabled through `[transcript].dir` or
 `RUNA_TRANSCRIPT_DIR`, the configured path is the transcript root. Live
@@ -232,7 +249,7 @@ When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 
 With `--dry-run`, text output prints the next execution plus the grouped READY/BLOCKED/WAITING status view. The execution entry includes the protocol name, optional work unit, the trigger that activated it, an MCP server config, and the serialized agent-facing context payload (protocol name, optional work unit, instruction content, valid required and available accepted inputs with display paths and content hashes, and expected outputs split into `produces`, `may_produce`, and `required_output_choices`). Dry-run does not require a discoverable `runa-mcp` binary. If the in-scope graph contains a hard dependency cycle, `step` reports it as a warning, exposes the scope-filtered cycle in JSON, and keeps those participants out of `READY`.
 
-Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux host. If the initial scan finds no READY work, `step` performs one final re-scan and re-evaluates readiness before returning a no-work outcome. If that refreshed state exposes a READY candidate, the same invocation executes that one protocol. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit without requiring `runa-mcp`: exit `3` when work remains blocked, waiting, or trapped in a cycle, and exit `4` when no actionable work remains because outputs are already current. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), exports the candidate MCP launch config through `RUNA_MCP_CONFIG`, launches the configured agent argv unmodified, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
+Without `--dry-run`, `step` requires `[launch].command` in the local config and a Linux host. If the initial scan finds no READY work, `step` performs one final re-scan and re-evaluates readiness before returning a no-work outcome. If that refreshed state exposes a READY candidate, the same invocation executes that one protocol. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit without requiring `runa-mcp`: exit `3` when work remains blocked, waiting, or trapped in a cycle, and exit `4` when no actionable work remains because outputs are already current. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), exports the candidate MCP launch config through `RUNA_MCP_CONFIG`, launches the configured agent argv unmodified, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
 
 **Flags:**
 
@@ -254,7 +271,7 @@ Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux
 ### `runa run`
 
 ```bash
-runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--agent-command -- <argv tokens>] [--config <PATH>]
+runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--config <PATH>]
 ```
 
 The cascade command. Walks the READY frontier repeatedly until quiescence instead of stopping after one execution.
@@ -263,18 +280,18 @@ Without `--work-unit`, `run` considers only unscoped protocols. With `--work-uni
 
 With `--ticket <REF>` (mutually exclusive with `--work-unit`), `run` opens a
 cold-start session from a forge ticket reference. Accepted forms are a bare
-number, `#<N>`, `owner/repo#<N>`, a GitHub issue URL, or
-`sourcehut:<tracker_id>#<N>`; the asserted deployment must match the active
-`[forge]` deployment, and a bare reference inherits it. When the referenced
-work-unit already exists, `run` behaves as `--work-unit <id>` on it. Otherwise
-the methodology's acquisition surface (the sole unscoped producer of the
-`work-unit` artifact) runs first — under `--dry-run` it is projected as the
-`current, entry` step with the acquired work-unit's `take` projected after it;
-live, it executes (the runtime delivers the reference and `RUNA_ENTRY_TICKET`,
-never the ticket's content), and the cascade then continues scoped on the
-materialized work-unit. The cold-start dry-run JSON envelope is version `3` and
-adds a top-level `entry` object (`reference`, `ticket_number`,
-`acquisition_protocol`, `resolved_work_unit`).
+number, `#<N>`, or `<tracker-selector>#<N>`. A bare reference is accepted only
+when the project has exactly one configured tracker; multi-tracker projects
+require the qualified selector. When the referenced work-unit already exists,
+`run` behaves as `--work-unit <id>` on it. Otherwise the methodology's
+acquisition surface (the sole unscoped producer of the `work-unit` artifact)
+runs first — under `--dry-run` it is projected as the `current, entry` step
+with the acquired work-unit's `take` projected after it; live, it executes
+(the runtime delivers the reference, `RUNA_ENTRY_TICKET`, and
+`RUNA_PROJECT_FORGE_ADDRESSES`, never the ticket's content), and the cascade
+then continues scoped on the materialized work-unit. The cold-start dry-run
+JSON envelope is version `3` and adds a top-level `entry` object (`reference`,
+`ticket_number`, `acquisition_protocol`, `resolved_work_unit`).
 
 When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 `work-unit` instance id, with the same rejection behavior described for
@@ -282,7 +299,13 @@ When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 
 With `--dry-run`, projects the full optimistic cascade from the same scope-filtered execution order used by evaluation and planning, plus declared `produces` outputs, dependency edges, and the caller-supplied evaluation scope. `may_produce` outputs do not advance the projection unless they already exist on disk. Required output choice members are branch-dependent, so projection uses an already-present single member when one exists and otherwise does not synthesize a choice branch. Initially ready entries include MCP config and full context on first emission; downstream projected entries carry only protocol name, optional work unit, trigger, and projection kind. The projection never synthesizes artifact values, forks the store, bypasses schema validation, or discovers sibling work units from artifact state.
 
-Without `--dry-run`, requires a Linux host plus an effective agent command. `run` resolves that command in this order: `--agent-command -- <argv tokens>` when supplied, otherwise `[agent].command` from config, otherwise the existing `AgentCommandNotConfigured` error. If `--agent-command` is present but no usable argv tokens follow the `--`, `run` fails with `AgentCommandNotConfigured` and does not fall back to config. If no READY protocol is ever dispatched, `run` exits `4` (`nothing_ready`) instead of treating that invocation as `success`. Failed candidates are skipped for the rest of the invocation; any artifacts emitted before failure are still reconciled into workspace state for downstream readiness. Previously exhausted work reopens when a later reconciliation changes relevant inputs.
+Without `--dry-run`, requires a Linux host plus an effective launch command
+from `.runa/local.toml`. If no READY protocol is ever dispatched, `run` exits
+`4` (`nothing_ready`) instead of treating that invocation as `success`. Failed
+candidates are skipped for the rest of the invocation; any artifacts emitted
+before failure are still reconciled into workspace state for downstream
+readiness. Previously exhausted work reopens when a later reconciliation
+changes relevant inputs.
 
 **Interrupt behavior.** The first `Ctrl-C` is boundary-scoped: the current protocol run completes its scan and postcondition reconciliation. After that reconciliation, `run` exits `130` only if the interrupt prevented the next READY candidate from starting. If no further READY work remains, the quiescent topology outcome takes precedence. A second `Ctrl-C` forces immediate exit with status `130`; the isolated child process may continue running after `runa` terminates.
 
@@ -292,7 +315,6 @@ Without `--dry-run`, requires a Linux host plus an effective agent command. `run
 - `--json` — Dry-run only. Emits version `2` and otherwise uses the same envelope structure as `runa step --json`, but `execution_plan` may contain multiple entries including projected downstream work.
 - `--work-unit <ID>` — Plan or execute only scoped protocols for the delegated work unit `<ID>`.
 - `--ticket <REF>` — Open a cold-start session from a forge ticket reference. Mutually exclusive with `--work-unit`. An unparseable reference or one that disagrees with the active deployment exits `2`; a manifest with no single unscoped `work-unit` producer exits `6`; acquisition that produces no matching work-unit exits `5`.
-- `--agent-command -- <argv tokens>` — Override `[agent].command` for this live `run` invocation. Pass the agent argv after `--` so hyphen-prefixed tokens are forwarded unchanged.
 
 **Exit codes** (`4` is live-only; dry-run still reflects current topology state, not the projection):
 
@@ -378,9 +400,10 @@ resolves them from the local filesystem, so adapters do not depend on child
 process cwd to launch `runa-mcp`. Transcript environment variables are forwarded
 into the MCP config when transcript capture is enabled, which lets the MCP
 server append tool events under the same deployment/work-unit/run transcript
-path as the CLI execution events. Configured forge identity is forwarded the same way through
-`RUNA_FORGE_*` entries so tooling inside the agent session can
-use the project-local identity without user-global shell state.
+path as the CLI execution events. Configured forge addresses are forwarded in
+the same MCP config through `RUNA_PROJECT_FORGE_ADDRESSES`, so tooling inside
+the agent session can resolve configured resources without user-global shell
+state.
 
 **Environment variables:**
 
@@ -391,7 +414,6 @@ use the project-local identity without user-global shell state.
   override for one invocation.
 - `RUNA_TRANSCRIPT_DEPLOYMENT`, `RUNA_TRANSCRIPT_RUN_ID` — Internal transcript
   attribution values propagated by runa into child MCP servers.
-- `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`,
-  `RUNA_FORGE_TRACKER_ID` — Forge identity field overrides for one
-  invocation.
+- `RUNA_PROJECT_FORGE_ADDRESSES` — Versioned project forge-address payload
+  propagated by runa into launched agents and child MCP servers.
 - `RUST_LOG` — Tracing filter override for stderr diagnostics.

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -82,57 +82,83 @@ These compose through two operators:
 
 Nesting is permitted. `all_of(on_artifact("constraints"), any_of(on_change("review"), on_artifact("auto-approve")))` means: constraints must exist, and either a review change or an auto-approve artifact must be present.
 
-## Runtime-Owned Scoped Identity
+## Runtime-Owned Forge Addresses And Scoped Identity
 
 Scoped evaluation is a runtime capability. When the caller supplies
 `--work-unit <ID>`, runa validates that `<ID>` exactly matches a recorded
 `work-unit` artifact instance when any such instances exist. Tracker-looking
-aliases such as bare issue numbers are not accepted as scope identifiers.
+aliases such as ticket numbers or partial ids are not accepted as
+`--work-unit` identifiers.
 
-For tracker-backed delegated work, runa also owns the active deployment
-identity used by scoped work-unit validation. The durable operator surface is
-the project-local `[forge]` config section:
+For tracker-backed delegated work, runa owns the canonical forge-address
+contract. A forge address is a resource on a configured forge instance. The
+portable project config declares instances once, with each instance carrying
+its forge type and every service host that type requires; repositories and
+trackers reference those instances.
 
 ```toml
-[forge]
+[project]
+deployment = "runa"
+
+[forge.instances.github]
 type = "github"
+host = "github.com"
+
+[forge.instances.weforge]
+type = "sourcehut"
+git_host = "git.weforge.build"
+tracker_host = "todo.weforge.build"
+
+[[forge.repositories]]
+id = "runa"
+instance = "github"
 owner = "tesserine"
 name = "runa"
+
+[[forge.trackers]]
+id = "groundwork"
+instance = "weforge"
+owner = "tesserine"
+name = "groundwork"
 tracker_id = "4"
 ```
 
-The matching per-invocation override and launched-runtime environment surface
-is runa-owned: `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
-`RUNA_FORGE_TRACKER_ID`. Non-empty environment values override matching config
-fields, and `RUNA_FORGE_TYPE` defaults to `github` when omitted.
+The launched-runtime environment carries the resolved address set as the
+versioned `RUNA_PROJECT_FORGE_ADDRESSES` payload. The payload serializes the
+configured instances, repositories, trackers, and selected deployment address;
+consumers select configured resources by non-secret selector and resolve
+coordinates from the payload. The payload is the only forge-addressed runtime
+surface runa exports to agents and MCP children.
 
-Runa computes the active deployment identity from those atoms. For GitHub, the
-identity is `github:<owner>/<name>`. For SourceHut, the identity is
-`sourcehut:<tracker_id>`. Endpoint or host resolution is not part of scoped
-identity validation.
+Work-unit identity is formed over the full tracker address: instance identity,
+instance type, required service hosts, tracker resource, and ticket number.
+Two trackers with the same resource coordinates on different instances are
+therefore distinct. A bare `#N` or `N` ticket reference is accepted only when
+the project has exactly one configured tracker. Projects with multiple
+trackers require a qualified selector such as `<tracker-selector>#N`; a
+selector that does not name a configured tracker is rejected.
 
 When a valid recorded `work-unit` root contains a forge-tagged tracker handle,
 runa enforces the runtime checks that JSON Schema cannot express: the canonical
-instance id's tracker number agrees with the handle number, duplicate tracker
-roots are rejected, and the handle deployment identity agrees with the active
-runtime deployment identity. The methodology still owns the `work-unit` schema
-and the semantics of the artifact content; runa owns only the scope identity
-checks described here.
+instance id's tracker number agrees with the handle number, duplicate full
+tracker identities are rejected, and the handle identity agrees with the
+resolved full tracker address. The methodology still owns the `work-unit`
+schema and the semantics of the artifact content; runa owns only the scope
+identity checks described here.
 
 ### Entry References and the Acquisition Surface
 
 A session may be opened from a forge ticket reference instead of a recorded
 `work-unit` instance id, via `runa run --ticket <REF>` or
-`runa go --ticket <REF>`. The accepted reference forms are a bare ticket number,
-`#<N>`, `owner/repo#<N>`, a GitHub issue URL, or `sourcehut:<tracker_id>#<N>`.
-runa parses the reference and normalizes it to a tracker identity
-(`github:<owner>/<name>:<N>` or `sourcehut:<tracker_id>:<N>`); a reference that
-asserts a deployment other than the active one is rejected, and a bare reference
-inherits the active deployment identity. **runa never reads ticket content** —
-the reference carries identity only, and the methodology performs all forge
-reads through its own mechanics. During entry, runa exports `RUNA_ENTRY_TICKET`
-(the ticket number) alongside the `RUNA_FORGE_*` atoms so those mechanics can
-resolve the ticket.
+`runa go --ticket <REF>`. The accepted reference forms are a bare ticket
+number, `#<N>`, or `<tracker-selector>#<N>`. runa parses the reference and
+normalizes it to the selected configured tracker plus ticket number; a bare
+reference inherits the only configured tracker and is rejected as ambiguous
+when more than one tracker exists. **runa never reads ticket content** — the
+reference carries identity only, and the methodology performs all forge reads
+through its own mechanics. During entry, runa exports `RUNA_ENTRY_TICKET`
+(the ticket number) and the project forge-address payload so those mechanics
+can resolve the ticket from the selected configured tracker.
 
 The acquisition surface runa serves is the single unscoped protocol whose
 declared outputs (`produces`, `may_produce`, or required output choice members)

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -120,7 +120,7 @@ impl fmt::Display for EntryError {
             ),
             EntryError::UnsupportedForge { forge_type } => write!(
                 f,
-                "active forge type '{forge_type}' is not supported for a bare ticket reference; use an explicit 'owner/repo#N' (github) or 'sourcehut:<tracker_id>#N' form, or set a supported RUNA_FORGE_TYPE"
+                "active forge type '{forge_type}' is not supported for a bare ticket reference; use a qualified selector such as 'owner/repo#N' (github) or 'sourcehut:<tracker_id>#N', or configure a supported forge address"
             ),
             EntryError::Unresolved { reference } => write!(
                 f,

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -67,8 +67,9 @@ pub use scan::{
 };
 pub use scoped_identity::{
     ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
-    resolve_forge_environment, resolve_forge_identity, validate_scoped_work_unit,
-    validate_scoped_work_unit_with_identity, validate_tracker_consistency,
+    resolve_forge_address_payload, resolve_forge_environment, resolve_forge_identity,
+    validate_scoped_work_unit, validate_scoped_work_unit_with_identity,
+    validate_tracker_consistency,
 };
 pub use selection::{
     Candidate, CandidateKey, CandidateStatus, ClassifiedCandidate, EvaluationScope,

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -41,7 +41,7 @@ impl LoggingConfig {
     }
 }
 
-/// The `[agent]` section of `.runa/config.toml`.
+/// Runtime launch command settings in `.runa/config.toml`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -69,7 +69,8 @@ impl TranscriptConfig {
     }
 }
 
-/// The `[forge]` section of `.runa/config.toml`.
+/// Legacy forge identity settings retained for compatibility while runtime
+/// surfaces move to the forge-address payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ForgeConfig {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -15,9 +15,8 @@
 //! - For valid tracker-backed roots: the canonical instance id's tracker
 //!   number must agree with the handle number; duplicate tracker
 //!   identities across roots are rejected; and the handle's deployment
-//!   identity must agree with the active deployment resolved from the
-//!   config-backed `RUNA_FORGE_*` atoms (`github:<owner>/<name>` or
-//!   `sourcehut:<tracker_id>`).
+//!   identity must agree with the active forge address resolved from the
+//!   project payload (`github:<owner>/<name>` or `sourcehut:<tracker_id>`).
 //! - Endpoint and host resolution are deliberately outside scoped identity
 //!   validation; identity is textual agreement, not network reachability.
 //!
@@ -26,7 +25,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::project::ForgeConfig;
 use crate::store::{ArtifactStore, ValidationStatus};
@@ -35,6 +34,7 @@ pub const RUNA_FORGE_TYPE: &str = "RUNA_FORGE_TYPE";
 pub const RUNA_FORGE_OWNER: &str = "RUNA_FORGE_OWNER";
 pub const RUNA_FORGE_NAME: &str = "RUNA_FORGE_NAME";
 pub const RUNA_FORGE_TRACKER_ID: &str = "RUNA_FORGE_TRACKER_ID";
+pub const RUNA_PROJECT_FORGE_ADDRESSES: &str = "RUNA_PROJECT_FORGE_ADDRESSES";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedForgeIdentity {
@@ -71,6 +71,60 @@ impl ResolvedForgeIdentity {
                 Ok(format!("sourcehut:{tracker_id}"))
             }
             other => Ok(other.to_string()),
+        }
+    }
+
+    fn address_payload(&self) -> Option<String> {
+        let instance = "default";
+        match self.forge_type.as_str() {
+            "github" => {
+                let owner = self.owner.as_deref()?;
+                let name = self.name.as_deref()?;
+                Some(
+                    json!({
+                        "version": 1,
+                        "instances": {
+                            "default": {
+                                "type": "github",
+                                "host": "github.com",
+                            }
+                        },
+                        "repositories": [{
+                            "id": "default",
+                            "instance": instance,
+                            "owner": owner,
+                            "name": name,
+                        }],
+                        "trackers": [],
+                    })
+                    .to_string(),
+                )
+            }
+            "sourcehut" => {
+                let tracker_id = self.tracker_id.as_deref()?;
+                Some(
+                    json!({
+                        "version": 1,
+                        "instances": {
+                            "default": {
+                                "type": "sourcehut",
+                                "git_host": "git.sr.ht",
+                                "tracker_host": "todo.sr.ht",
+                            }
+                        },
+                        "repositories": [],
+                        "trackers": [{
+                            "id": "default",
+                            "instance": instance,
+                            "owner": self.owner.as_deref().unwrap_or(""),
+                            "name": self.name.as_deref().unwrap_or(""),
+                            "tracker_id": tracker_id,
+                        }],
+                    })
+                    .to_string(),
+                )
+            }
+            _ => None,
         }
     }
 
@@ -217,6 +271,12 @@ pub fn find_work_unit_by_tracker_identity(store: &ArtifactStore, target: &str) -
 }
 
 pub fn resolve_forge_identity(config: &ForgeConfig) -> ResolvedForgeIdentity {
+    if let Ok(payload) = std::env::var(RUNA_PROJECT_FORGE_ADDRESSES) {
+        if let Some(identity) = resolve_forge_identity_from_payload(&payload) {
+            return identity;
+        }
+    }
+
     ResolvedForgeIdentity {
         forge_type: resolve_atom(RUNA_FORGE_TYPE, config.forge_type.as_deref())
             .unwrap_or_else(|| "github".to_string()),
@@ -226,8 +286,74 @@ pub fn resolve_forge_identity(config: &ForgeConfig) -> ResolvedForgeIdentity {
     }
 }
 
+pub fn resolve_forge_address_payload(config: &ForgeConfig) -> Option<String> {
+    std::env::var(RUNA_PROJECT_FORGE_ADDRESSES)
+        .ok()
+        .and_then(|value| normalize_atom(Some(value.as_str())))
+        .or_else(|| resolve_forge_identity(config).address_payload())
+}
+
 pub fn resolve_forge_environment(config: &ForgeConfig) -> HashMap<String, String> {
     resolve_forge_identity(config).environment()
+}
+
+fn resolve_forge_identity_from_payload(payload: &str) -> Option<ResolvedForgeIdentity> {
+    let payload = serde_json::from_str::<Value>(payload).ok()?;
+    let instances = payload.get("instances")?.as_object()?;
+    let repositories = payload
+        .get("repositories")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let trackers = payload
+        .get("trackers")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+
+    match (repositories, trackers) {
+        ([repository], []) => identity_from_resource(instances, repository, false),
+        ([], [tracker]) => identity_from_resource(instances, tracker, true),
+        _ => None,
+    }
+}
+
+fn identity_from_resource(
+    instances: &serde_json::Map<String, Value>,
+    resource: &Value,
+    tracker: bool,
+) -> Option<ResolvedForgeIdentity> {
+    let resource = resource.as_object()?;
+    let instance_id = resource.get("instance")?.as_str()?;
+    let instance = instances.get(instance_id)?.as_object()?;
+    let forge_type = instance.get("type")?.as_str()?.to_string();
+    let owner = resource
+        .get("owner")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let name = resource
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let tracker_id = if tracker {
+        resource.get("tracker_id").and_then(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .or_else(|| value.as_u64().map(|number| number.to_string()))
+        })
+    } else {
+        None
+    };
+
+    Some(ResolvedForgeIdentity {
+        forge_type,
+        owner,
+        name,
+        tracker_id,
+    })
 }
 
 fn resolve_atom(variable: &'static str, config_value: Option<&str>) -> Option<String> {

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -73,7 +73,7 @@ impl fmt::Display for StepError {
             StepError::Json(err) => write!(f, "{err}"),
             StepError::AgentCommandNotConfigured => write!(
                 f,
-                "no agent command configured in config.toml; add [agent] command = [\"binary\", ...]"
+                "no launch command configured in config.toml; add [launch] command = [\"binary\", ...]"
             ),
             StepError::JsonRequiresDryRun => {
                 write!(f, "--json is only supported with --dry-run")
@@ -425,19 +425,8 @@ pub(crate) fn resolved_runtime_env(
             .into_iter()
             .collect();
 
-    let forge_environment = libagent::resolve_forge_environment(&config.forge);
-    for name in [
-        "RUNA_FORGE_TYPE",
-        "RUNA_FORGE_OWNER",
-        "RUNA_FORGE_NAME",
-        "RUNA_FORGE_TRACKER_ID",
-    ] {
-        if let Some(value) = forge_environment
-            .get(name)
-            .filter(|value| !value.is_empty())
-        {
-            env.insert(name.to_string(), value.clone());
-        }
+    if let Some(payload) = libagent::resolve_forge_address_payload(&config.forge) {
+        env.insert("RUNA_PROJECT_FORGE_ADDRESSES".to_string(), payload);
     }
 
     env
@@ -1720,7 +1709,7 @@ cat >/dev/null
     }
 
     #[test]
-    fn resolved_runtime_env_materializes_default_github_forge_type_from_config_identity() {
+    fn resolved_runtime_env_materializes_forge_address_payload_from_config_identity() {
         let _lock = transcript_env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1748,17 +1737,24 @@ cat >/dev/null
 
         let env = resolved_runtime_env(temp.path(), &config);
 
-        assert_eq!(env.get("RUNA_FORGE_TYPE"), Some(&"github".to_string()));
-        assert_eq!(env.get("RUNA_FORGE_OWNER"), Some(&"tesserine".to_string()));
-        assert_eq!(env.get("RUNA_FORGE_NAME"), Some(&"runa".to_string()));
+        let payload: serde_json::Value = serde_json::from_str(
+            env.get("RUNA_PROJECT_FORGE_ADDRESSES")
+                .expect("runtime env should include forge address payload"),
+        )
+        .expect("forge address payload should be valid JSON");
+        assert_eq!(payload["version"], 1);
+        assert_eq!(payload["instances"]["default"]["type"], "github");
+        assert_eq!(payload["repositories"][0]["owner"], "tesserine");
+        assert_eq!(payload["repositories"][0]["name"], "runa");
+        assert!(env.get("RUNA_FORGE_OWNER").is_none());
     }
 
     #[test]
     fn build_mcp_config_includes_supplied_runtime_environment() {
-        let runtime_env = BTreeMap::from([
-            ("RUNA_FORGE_OWNER".to_string(), "tesserine".to_string()),
-            ("RUNA_FORGE_NAME".to_string(), "runa".to_string()),
-        ]);
+        let runtime_env = BTreeMap::from([(
+            "RUNA_PROJECT_FORGE_ADDRESSES".to_string(),
+            r#"{"version":1,"instances":{},"repositories":[],"trackers":[]}"#.to_string(),
+        )]);
 
         let config = build_mcp_config(
             "/tmp/bin/runa-mcp",
@@ -1770,10 +1766,9 @@ cat >/dev/null
         );
 
         assert_eq!(
-            config.env.get("RUNA_FORGE_OWNER"),
-            Some(&"tesserine".to_string())
+            config.env.get("RUNA_PROJECT_FORGE_ADDRESSES"),
+            Some(&r#"{"version":1,"instances":{},"repositories":[],"trackers":[]}"#.to_string())
         );
-        assert_eq!(config.env.get("RUNA_FORGE_NAME"), Some(&"runa".to_string()));
     }
 
     #[test]

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -92,11 +92,11 @@ struct RunArgs {
     #[arg(long, conflicts_with = "work_unit")]
     ticket: Option<String>,
 
-    /// Override the live agent command; pass argv after `--`, for example `--agent-command -- <argv tokens>`
-    #[arg(long = "agent-command")]
+    /// Deprecated live agent command override.
+    #[arg(long = "agent-command", hide = true)]
     agent_command: bool,
 
-    /// Agent argv passed through after `--` when `--agent-command` is set
+    /// Agent argv passed through after `--` for the deprecated override.
     #[arg(
         num_args = 0..,
         last = true,

--- a/runa-cli/tests/workspace_contract.rs
+++ b/runa-cli/tests/workspace_contract.rs
@@ -147,6 +147,59 @@ fn workspace_packages_inherit_the_workspace_version() {
 }
 
 #[test]
+fn forge_address_contract_docs_describe_current_surface() {
+    let interface = read_workspace_file("docs/interface-contract.md");
+    for retired in [
+        "[forge]",
+        "RUNA_FORGE_TYPE",
+        "RUNA_FORGE_OWNER",
+        "RUNA_FORGE_NAME",
+        "RUNA_FORGE_TRACKER_ID",
+        "RUNA_FORGE_*",
+    ] {
+        assert!(
+            !interface.contains(retired),
+            "interface contract should not document retired forge surface {retired}"
+        );
+    }
+    for required in [
+        "[forge.instances.",
+        "[[forge.repositories]]",
+        "[[forge.trackers]]",
+        "RUNA_PROJECT_FORGE_ADDRESSES",
+        "bare `#N`",
+        "qualified selector",
+    ] {
+        assert!(
+            interface.contains(required),
+            "interface contract should document current forge surface {required}"
+        );
+    }
+
+    let changelog = read_workspace_file("CHANGELOG.md");
+    let unreleased = changelog
+        .split("## [Unreleased]")
+        .nth(1)
+        .and_then(|tail| tail.split("\n## [").next())
+        .expect("CHANGELOG.md should have an Unreleased section");
+    for required in [
+        "[forge]",
+        "[agent]",
+        "--agent-command",
+        "RUNA_FORGE_*",
+        "[forge.instances.*]",
+        "[[forge.repositories]]",
+        "[[forge.trackers]]",
+        "RUNA_PROJECT_FORGE_ADDRESSES",
+    ] {
+        assert!(
+            unreleased.contains(required),
+            "Unreleased changelog should name forge-address migration surface {required}"
+        );
+    }
+}
+
+#[test]
 fn release_adoption_verification_script_is_repo_tracked_operational_substrate() {
     let script_path = workspace_root().join("scripts/verify-release-adoption.sh");
     let script = std::fs::read_to_string(&script_path)


### PR DESCRIPTION
## Summary

This is the runa side of the coupled runa#199 / groundwork#420 change. It updates the contract-of-record and durable documentation to describe forge addresses as instance/resource coordinates, and records the retired and added surfaces in the Unreleased changelog.

It also adds a narrow runtime bridge so launched environments receive `RUNA_PROJECT_FORGE_ADDRESSES` and scoped validation can resolve identity from that payload while legacy atom compatibility remains internal fallback behavior.

## Validation

- `cargo test -p runa-cli --test workspace_contract`
- `cargo test -p runa-cli commands::step::tests::`
- `cargo test -p libagent scoped_identity::tests::`
- `cargo build -p runa-cli`
- Swept `README.md` and `docs/` for retired forge surfaces: `[forge]`, `[agent]`, `--agent-command`, `RUNA_FORGE_*`

## Coupling

Must land with tesserine/groundwork#420 mechanics update so the consumer resolves forge coordinates through the delivered payload contract.