### PR TITLE
Define authoritative forge-address contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run workspace tests
+        env:
+          RUST_TEST_THREADS: "1"
         run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run workspace tests
+        run: cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Both projects are in early development.
 | `runa state` | Evaluate and classify protocol readiness |
 | `runa doctor` | Check project health |
 | `runa step` | Execute the next ready protocol |
-| `runa run` | Walk the ready frontier to quiescence; live runs may override the agent command with `--agent-command -- <argv...>` |
+| `runa run` | Walk the ready frontier to quiescence |
 | `runa go` | Advance one scoped interactive session tick through the session MCP surface |
 | `runa-mcp` | MCP server for artifact production and session driver verbs |
 
@@ -207,13 +207,13 @@ See [CLI Reference](docs/cli-reference.md) for flags, exit codes, configuration,
 ## Configuration
 
 `runa init` creates `.runa/config.toml` with the methodology path. Operators
-may also set durable project defaults there for live agent command,
-transcript capture, and scoped forge identity. Environment variables such as
-`RUNA_TRANSCRIPT_DIR` and `RUNA_FORGE_*` remain per-invocation overrides;
-config is the project-local default.
+may also set machine-local defaults there for live agent command and transcript
+capture. Portable forge topology lives in `.runa/project.toml`; when present,
+runa derives forge identities and exports the validated `RUNA_FORGE_ADDRESSES`
+payload to launched runtimes.
 
 Runa ships supported agent adapters for Codex and Claude Code in `adapters/`.
-Set `[agent].command` to `./adapters/agent-codex.sh` or
+Set `[runtime].command` to `./adapters/agent-codex.sh` or
 `./adapters/agent-claude-code.sh`; the adapter translates `RUNA_MCP_CONFIG` for
 the selected runtime.
 

--- a/contracts/forge-address/conformance.json
+++ b/contracts/forge-address/conformance.json
@@ -1,0 +1,118 @@
+{
+  "schema": "forge-address.schema.json",
+  "valid": {
+    "payloads": [
+      {
+        "name": "multi-forge",
+        "value": {
+          "schema_version": "1.0.0",
+          "instances": [
+            {
+              "name": "github-enterprise",
+              "type": "github",
+              "host": "github.example.com"
+            },
+            {
+              "name": "srht",
+              "type": "sourcehut",
+              "git_host": "git.weforge.build",
+              "tracker_host": "todo.weforge.build"
+            }
+          ],
+          "repositories": [
+            {
+              "name": "runa",
+              "instance": "github-enterprise",
+              "owner": "tesserine",
+              "repository": "runa",
+              "identity": "github:github.example.com/tesserine/runa"
+            },
+            {
+              "name": "groundwork-srht",
+              "instance": "srht",
+              "owner": "~operator",
+              "repository": "groundwork",
+              "identity": "sourcehut:git.weforge.build/~operator/groundwork"
+            }
+          ],
+          "trackers": [
+            {
+              "name": "runa",
+              "type": "github",
+              "instance": "github-enterprise",
+              "repository": "runa",
+              "identity": "github:github.example.com/tesserine/runa"
+            },
+            {
+              "name": "groundwork",
+              "type": "sourcehut",
+              "instance": "srht",
+              "owner": "~operator",
+              "tracker": "groundwork",
+              "tracker_id": 4,
+              "identity": "sourcehut:todo.weforge.build/~operator/groundwork:4"
+            }
+          ]
+        }
+      }
+    ],
+    "handles": [
+      {
+        "name": "runa-199",
+        "value": {
+          "tracker": "runa",
+          "tracker_identity": "github:github.example.com/tesserine/runa",
+          "work_unit_identity": "github:github.example.com/tesserine/runa#199",
+          "number": 199
+        }
+      },
+      {
+        "name": "groundwork-420",
+        "value": {
+          "tracker": "groundwork",
+          "tracker_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4",
+          "work_unit_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4#420",
+          "number": 420
+        }
+      }
+    ]
+  },
+  "invalid": {
+    "payloads": [
+      {
+        "name": "sourcehut-missing-tracker-host",
+        "value": {
+          "schema_version": "1.0.0",
+          "instances": [
+            {
+              "name": "srht",
+              "type": "sourcehut",
+              "git_host": "git.weforge.build"
+            }
+          ],
+          "repositories": [],
+          "trackers": []
+        }
+      }
+    ],
+    "handles": [
+      {
+        "name": "stored-independent-identity-disagrees",
+        "value": {
+          "tracker": "groundwork",
+          "tracker_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4",
+          "work_unit_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4#421",
+          "number": 420
+        }
+      },
+      {
+        "name": "legacy-github-url-handle",
+        "value": {
+          "forge_tag": "github",
+          "url": "https://github.com/tesserine/runa/issues/199",
+          "number": 199
+        }
+      }
+    ]
+  }
+}

--- a/contracts/forge-address/forge-address.schema.json
+++ b/contracts/forge-address/forge-address.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/tesserine/runa/main/contracts/forge-address/forge-address.schema.json",
+  "title": "Forge Address Contract",
+  "description": "Authoritative language-neutral schema for runa forge address payloads and work-unit handles.",
+  "type": "object",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/address_payload"
+    },
+    {
+      "$ref": "#/$defs/work_unit_handle"
+    }
+  ],
+  "$defs": {
+    "address_payload": {
+      "type": "object",
+      "required": ["schema_version", "instances", "repositories", "trackers"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": {
+          "const": "1.0.0"
+        },
+        "instances": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/instance"
+          }
+        },
+        "repositories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/repository"
+          }
+        },
+        "trackers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/tracker"
+          }
+        }
+      }
+    },
+    "instance": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/github_instance"
+        },
+        {
+          "$ref": "#/$defs/sourcehut_instance"
+        }
+      ]
+    },
+    "github_instance": {
+      "type": "object",
+      "required": ["name", "type", "host"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "github"
+        },
+        "host": {
+          "$ref": "#/$defs/host"
+        }
+      }
+    },
+    "sourcehut_instance": {
+      "type": "object",
+      "required": ["name", "type", "git_host", "tracker_host"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "sourcehut"
+        },
+        "git_host": {
+          "$ref": "#/$defs/host"
+        },
+        "tracker_host": {
+          "$ref": "#/$defs/host"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "required": ["name", "instance", "owner", "repository", "identity"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "instance": {
+          "$ref": "#/$defs/name"
+        },
+        "owner": {
+          "$ref": "#/$defs/owner"
+        },
+        "repository": {
+          "$ref": "#/$defs/name"
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      }
+    },
+    "tracker": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/github_tracker"
+        },
+        {
+          "$ref": "#/$defs/sourcehut_tracker"
+        }
+      ]
+    },
+    "github_tracker": {
+      "type": "object",
+      "required": ["name", "type", "instance", "repository", "identity"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "github"
+        },
+        "instance": {
+          "$ref": "#/$defs/name"
+        },
+        "repository": {
+          "$ref": "#/$defs/name"
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      }
+    },
+    "sourcehut_tracker": {
+      "type": "object",
+      "required": ["name", "type", "instance", "owner", "tracker", "tracker_id", "identity"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "sourcehut"
+        },
+        "instance": {
+          "$ref": "#/$defs/name"
+        },
+        "owner": {
+          "$ref": "#/$defs/sourcehut_owner"
+        },
+        "tracker": {
+          "$ref": "#/$defs/name"
+        },
+        "tracker_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      }
+    },
+    "work_unit_handle": {
+      "type": "object",
+      "required": ["tracker", "tracker_identity", "work_unit_identity", "number"],
+      "additionalProperties": false,
+      "properties": {
+        "tracker": {
+          "$ref": "#/$defs/name"
+        },
+        "tracker_identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "work_unit_identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourcehut_owner": {
+      "type": "string",
+      "pattern": "^~?[A-Za-z0-9][A-Za-z0-9_.-]*$"
+    },
+    "host": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9.-]+$"
+    },
+    "identity": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,15 +19,33 @@ Durable project settings live in `.runa/config.toml`. Environment variables
 with matching runtime meaning remain per-invocation overrides.
 
 ```toml
+[runtime]
+command = ["./adapters/agent-codex.sh", "--model", "gpt-5-codex"]
+
 [transcript]
 dir = "transcripts"
 redact_env = ["SECRET_TOKEN", "API_KEY"]
+```
 
-[forge]
+Portable forge topology lives in `.runa/project.toml`:
+
+```toml
+[[forge.instances]]
+name = "github"
 type = "github"
-owner = "tesserine"
+host = "github.com"
+
+[[forge.repositories]]
 name = "runa"
-tracker_id = "4"
+instance = "github"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github"
+repository = "runa"
 ```
 
 `[transcript].dir` enables transcript capture and is resolved relative to the
@@ -37,13 +55,11 @@ current values should be redacted from transcript events.
 `RUNA_TRANSCRIPT_REDACT_ENV`, when set to a comma-separated list, overrides the
 configured list.
 
-`[forge]` supplies the active scoped work-unit deployment identity. Runa uses
-it when validating tracker-backed `work-unit` roots and injects the resolved
-`RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
-`RUNA_FORGE_TRACKER_ID` values into launched agent and MCP environments.
-Any non-empty matching `RUNA_FORGE_*` environment variable overrides the
-configured field for that invocation. The forge type still defaults to `github`
-when neither config nor env specifies one.
+`.runa/project.toml` supplies the active scoped work-unit deployment identity.
+Runa validates the topology against the forge-address contract, uses the
+derived identities for tracker-backed `work-unit` roots, and injects the
+validated `RUNA_FORGE_ADDRESSES` JSON payload into launched agent and MCP
+environments.
 
 ### Logging
 
@@ -61,22 +77,17 @@ filter = "info"   # any tracing env-filter directive
 
 ### Agent Execution
 
-Live `runa step` and `runa go` require an `[agent].command` entry in the
-config. Live `runa run` uses the same config entry by default, but a single
-invocation may override it with `--agent-command -- <argv tokens>`:
+Live `runa step`, `runa go`, and `runa run` require a `[runtime].command` entry
+in the config:
 
 ```toml
-[agent]
+[runtime]
 command = ["./adapters/agent-codex.sh", "--model", "gpt-5-codex"]
 ```
 
 ```toml
-[agent]
+[runtime]
 command = ["./adapters/agent-claude-code.sh", "-p", "--dangerously-skip-permissions"]
-```
-
-```bash
-runa run --agent-command -- ./adapters/agent-codex.sh --model gpt-5-codex
 ```
 
 Runa executes the configured argv unmodified in the project root with stdout
@@ -89,7 +100,7 @@ child process. Runtime-specific translation, such as wrapping that payload in a
 client-specific config file, belongs to the runtime or adapter, not to runa.
 
 The supported runtime adapters live in `adapters/`: `agent-codex.sh` for Codex
-and `agent-claude-code.sh` for Claude Code. Point `[agent].command` at one of
+and `agent-claude-code.sh` for Claude Code. Point `[runtime].command` at one of
 those scripts and pass runtime-specific options after the script path. The
 Codex adapter requires `jq` because Codex accepts external MCP servers through
 `-c mcp_servers.<name>.*` TOML overrides rather than a JSON config file. It
@@ -97,7 +108,7 @@ registers each invocation under a process-scoped server name so an existing
 operator-defined `mcp_servers.runa` entry is left untouched.
 Migration note: older documentation used
 `./examples/agent-claude-code.sh` for Claude Code. That path no longer exists;
-repoint existing `[agent].command` values to
+repoint existing `[runtime].command` values to
 `./adapters/agent-claude-code.sh`.
 
 When transcript capture is enabled through `[transcript].dir` or
@@ -232,7 +243,7 @@ When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 
 With `--dry-run`, text output prints the next execution plus the grouped READY/BLOCKED/WAITING status view. The execution entry includes the protocol name, optional work unit, the trigger that activated it, an MCP server config, and the serialized agent-facing context payload (protocol name, optional work unit, instruction content, valid required and available accepted inputs with display paths and content hashes, and expected outputs split into `produces`, `may_produce`, and `required_output_choices`). Dry-run does not require a discoverable `runa-mcp` binary. If the in-scope graph contains a hard dependency cycle, `step` reports it as a warning, exposes the scope-filtered cycle in JSON, and keeps those participants out of `READY`.
 
-Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux host. If the initial scan finds no READY work, `step` performs one final re-scan and re-evaluates readiness before returning a no-work outcome. If that refreshed state exposes a READY candidate, the same invocation executes that one protocol. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit without requiring `runa-mcp`: exit `3` when work remains blocked, waiting, or trapped in a cycle, and exit `4` when no actionable work remains because outputs are already current. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), exports the candidate MCP launch config through `RUNA_MCP_CONFIG`, launches the configured agent argv unmodified, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
+Without `--dry-run`, `step` requires `[runtime].command` in the config and a Linux host. If the initial scan finds no READY work, `step` performs one final re-scan and re-evaluates readiness before returning a no-work outcome. If that refreshed state exposes a READY candidate, the same invocation executes that one protocol. Only when the refreshed state still has no actionable work does it print `No READY protocols.` and exit without requiring `runa-mcp`: exit `3` when work remains blocked, waiting, or trapped in a cycle, and exit `4` when no actionable work remains because outputs are already current. Otherwise, it resolves `runa-mcp` (preferring a sibling binary next to the running `runa` executable, falling back to `PATH`), exports the candidate MCP launch config through `RUNA_MCP_CONFIG`, launches the configured agent argv unmodified, re-scans the workspace, enforces postconditions, and prints the refreshed status view.
 
 **Flags:**
 
@@ -254,7 +265,7 @@ Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux
 ### `runa run`
 
 ```bash
-runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--agent-command -- <argv tokens>] [--config <PATH>]
+runa run [--dry-run] [--json] [--work-unit <ID> | --ticket <REF>] [--config <PATH>]
 ```
 
 The cascade command. Walks the READY frontier repeatedly until quiescence instead of stopping after one execution.
@@ -265,7 +276,7 @@ With `--ticket <REF>` (mutually exclusive with `--work-unit`), `run` opens a
 cold-start session from a forge ticket reference. Accepted forms are a bare
 number, `#<N>`, `owner/repo#<N>`, a GitHub issue URL, or
 `sourcehut:<tracker_id>#<N>`; the asserted deployment must match the active
-`[forge]` deployment, and a bare reference inherits it. When the referenced
+project topology, and a bare reference inherits it. When the referenced
 work-unit already exists, `run` behaves as `--work-unit <id>` on it. Otherwise
 the methodology's acquisition surface (the sole unscoped producer of the
 `work-unit` artifact) runs first — under `--dry-run` it is projected as the
@@ -282,7 +293,7 @@ When recorded `work-unit` artifacts exist, `<ID>` must be the exact canonical
 
 With `--dry-run`, projects the full optimistic cascade from the same scope-filtered execution order used by evaluation and planning, plus declared `produces` outputs, dependency edges, and the caller-supplied evaluation scope. `may_produce` outputs do not advance the projection unless they already exist on disk. Required output choice members are branch-dependent, so projection uses an already-present single member when one exists and otherwise does not synthesize a choice branch. Initially ready entries include MCP config and full context on first emission; downstream projected entries carry only protocol name, optional work unit, trigger, and projection kind. The projection never synthesizes artifact values, forks the store, bypasses schema validation, or discovers sibling work units from artifact state.
 
-Without `--dry-run`, requires a Linux host plus an effective agent command. `run` resolves that command in this order: `--agent-command -- <argv tokens>` when supplied, otherwise `[agent].command` from config, otherwise the existing `AgentCommandNotConfigured` error. If `--agent-command` is present but no usable argv tokens follow the `--`, `run` fails with `AgentCommandNotConfigured` and does not fall back to config. If no READY protocol is ever dispatched, `run` exits `4` (`nothing_ready`) instead of treating that invocation as `success`. Failed candidates are skipped for the rest of the invocation; any artifacts emitted before failure are still reconciled into workspace state for downstream readiness. Previously exhausted work reopens when a later reconciliation changes relevant inputs.
+Without `--dry-run`, requires a Linux host plus `[runtime].command` in config. If no READY protocol is ever dispatched, `run` exits `4` (`nothing_ready`) instead of treating that invocation as `success`. Failed candidates are skipped for the rest of the invocation; any artifacts emitted before failure are still reconciled into workspace state for downstream readiness. Previously exhausted work reopens when a later reconciliation changes relevant inputs.
 
 **Interrupt behavior.** The first `Ctrl-C` is boundary-scoped: the current protocol run completes its scan and postcondition reconciliation. After that reconciliation, `run` exits `130` only if the interrupt prevented the next READY candidate from starting. If no further READY work remains, the quiescent topology outcome takes precedence. A second `Ctrl-C` forces immediate exit with status `130`; the isolated child process may continue running after `runa` terminates.
 
@@ -292,7 +303,6 @@ Without `--dry-run`, requires a Linux host plus an effective agent command. `run
 - `--json` — Dry-run only. Emits version `2` and otherwise uses the same envelope structure as `runa step --json`, but `execution_plan` may contain multiple entries including projected downstream work.
 - `--work-unit <ID>` — Plan or execute only scoped protocols for the delegated work unit `<ID>`.
 - `--ticket <REF>` — Open a cold-start session from a forge ticket reference. Mutually exclusive with `--work-unit`. An unparseable reference or one that disagrees with the active deployment exits `2`; a manifest with no single unscoped `work-unit` producer exits `6`; acquisition that produces no matching work-unit exits `5`.
-- `--agent-command -- <argv tokens>` — Override `[agent].command` for this live `run` invocation. Pass the agent argv after `--` so hyphen-prefixed tokens are forwarded unchanged.
 
 **Exit codes** (`4` is live-only; dry-run still reflects current topology state, not the projection):
 
@@ -391,7 +401,6 @@ use the project-local identity without user-global shell state.
   override for one invocation.
 - `RUNA_TRANSCRIPT_DEPLOYMENT`, `RUNA_TRANSCRIPT_RUN_ID` — Internal transcript
   attribution values propagated by runa into child MCP servers.
-- `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`,
-  `RUNA_FORGE_TRACKER_ID` — Forge identity field overrides for one
-  invocation.
+- `RUNA_FORGE_ADDRESSES` — Validated forge-address payload injected by runa
+  when `.runa/project.toml` is present.
 - `RUST_LOG` — Tracing filter override for stderr diagnostics.

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -90,26 +90,36 @@ Scoped evaluation is a runtime capability. When the caller supplies
 aliases such as bare issue numbers are not accepted as scope identifiers.
 
 For tracker-backed delegated work, runa also owns the active deployment
-identity used by scoped work-unit validation. The durable operator surface is
-the project-local `[forge]` config section:
+identity used by scoped work-unit validation. The durable portable surface is
+the project-local `.runa/project.toml` forge topology:
 
 ```toml
-[forge]
+[[forge.instances]]
+name = "github"
 type = "github"
-owner = "tesserine"
+host = "github.com"
+
+[[forge.repositories]]
 name = "runa"
-tracker_id = "4"
+instance = "github"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github"
+repository = "runa"
 ```
 
-The matching per-invocation override and launched-runtime environment surface
-is runa-owned: `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
-`RUNA_FORGE_TRACKER_ID`. Non-empty environment values override matching config
-fields, and `RUNA_FORGE_TYPE` defaults to `github` when omitted.
+The launched-runtime environment surface is the runa-owned
+`RUNA_FORGE_ADDRESSES` JSON payload. Runa derives repository, tracker, and
+work-unit identities from the project topology and validates the payload before
+emitting it.
 
-Runa computes the active deployment identity from those atoms. For GitHub, the
-identity is `github:<owner>/<name>`. For SourceHut, the identity is
-`sourcehut:<tracker_id>`. Endpoint or host resolution is not part of scoped
-identity validation.
+For GitHub, repository and tracker identities are
+`github:<host>/<owner>/<repository>`. For SourceHut, tracker identities include
+the tracker host, owner, tracker name, and tracker id.
 
 When a valid recorded `work-unit` root contains a forge-tagged tracker handle,
 runa enforces the runtime checks that JSON Schema cannot express: the canonical

--- a/libagent/src/context.rs
+++ b/libagent/src/context.rs
@@ -61,6 +61,8 @@ pub struct EntryDelivery {
     pub ticket_number: u64,
     /// Canonical tracker identity, e.g. `github:tesserine/runa:188`.
     pub tracker_identity: String,
+    /// Canonical work-unit identity for this ticket.
+    pub work_unit_identity: String,
 }
 
 /// Artifact type names the agent is expected to produce for this protocol invocation.
@@ -739,7 +741,8 @@ mod tests {
             entry: Some(EntryDelivery {
                 reference: "github:tesserine/runa#188".into(),
                 ticket_number: 188,
-                tracker_identity: "github:tesserine/runa:188".into(),
+                tracker_identity: "github:github.com/tesserine/runa".into(),
+                work_unit_identity: "github:github.com/tesserine/runa#188".into(),
             }),
             expected_outputs: ExpectedOutputs {
                 produces: vec!["work-unit".into()],

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -31,13 +31,14 @@ pub const RUNA_ENTRY_TICKET: &str = "RUNA_ENTRY_TICKET";
 
 /// A forge ticket reference resolved against the active deployment identity.
 ///
-/// `tracker_identity` is the canonical match key (`github:<owner>/<name>:<n>`
-/// or `sourcehut:<tracker_id>:<n>`), identical to what a recorded work-unit
-/// handle yields. `display` is the operator-facing rendering.
+/// `tracker_identity` is the canonical tracker root. `work_unit_identity` is
+/// the exact identity a recorded work-unit handle yields. `display` is the
+/// operator-facing rendering.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TicketRef {
     pub number: u64,
     pub tracker_identity: String,
+    pub work_unit_identity: String,
     pub display: String,
 }
 
@@ -278,18 +279,22 @@ fn require_atom<'a>(value: Option<&'a str>, variable: &'static str) -> Result<&'
 }
 
 fn github_ticket(owner: &str, name: &str, number: u64) -> TicketRef {
+    let tracker_identity = format!("github:github.com/{owner}/{name}");
     TicketRef {
         number,
-        tracker_identity: format!("github:{owner}/{name}:{number}"),
-        display: format!("github:{owner}/{name}#{number}"),
+        work_unit_identity: format!("{tracker_identity}#{number}"),
+        display: format!("{tracker_identity}#{number}"),
+        tracker_identity,
     }
 }
 
 fn sourcehut_ticket(tracker_id: &str, number: u64) -> TicketRef {
+    let tracker_identity = format!("sourcehut:{tracker_id}");
     TicketRef {
         number,
-        tracker_identity: format!("sourcehut:{tracker_id}:{number}"),
+        work_unit_identity: format!("{tracker_identity}#{number}"),
         display: format!("sourcehut:{tracker_id}#{number}"),
+        tracker_identity,
     }
 }
 
@@ -397,7 +402,7 @@ pub fn resolve_promise(
     ticket: &TicketRef,
 ) -> Result<Option<String>, ScopedWorkUnitError> {
     validate_tracker_consistency(store, identity)?;
-    match find_work_unit_by_tracker_identity(store, &ticket.tracker_identity) {
+    match find_work_unit_by_tracker_identity(store, &ticket.work_unit_identity) {
         Some(instance_id) => Ok(Some(instance_id)),
         None if store.has_any_scan_gap_for_type(WORK_UNIT_ARTIFACT_TYPE) => {
             Err(ScopedWorkUnitError::WorkUnitScanIncomplete)
@@ -450,15 +455,23 @@ mod tests {
         let ticket =
             resolve_ticket_reference("188", &github_identity("tesserine", "runa")).unwrap();
         assert_eq!(ticket.number, 188);
-        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:188");
-        assert_eq!(ticket.display, "github:tesserine/runa#188");
+        assert_eq!(ticket.tracker_identity, "github:github.com/tesserine/runa");
+        assert_eq!(
+            ticket.work_unit_identity,
+            "github:github.com/tesserine/runa#188"
+        );
+        assert_eq!(ticket.display, "github:github.com/tesserine/runa#188");
     }
 
     #[test]
     fn hash_number_inherits_deployment() {
         let ticket =
             resolve_ticket_reference("#14", &github_identity("tesserine", "runa")).unwrap();
-        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:14");
+        assert_eq!(ticket.tracker_identity, "github:github.com/tesserine/runa");
+        assert_eq!(
+            ticket.work_unit_identity,
+            "github:github.com/tesserine/runa#14"
+        );
     }
 
     #[test]
@@ -466,7 +479,11 @@ mod tests {
         let ticket =
             resolve_ticket_reference("tesserine/runa#14", &github_identity("tesserine", "runa"))
                 .unwrap();
-        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:14");
+        assert_eq!(ticket.tracker_identity, "github:github.com/tesserine/runa");
+        assert_eq!(
+            ticket.work_unit_identity,
+            "github:github.com/tesserine/runa#14"
+        );
     }
 
     #[test]
@@ -477,7 +494,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(ticket.number, 188);
-        assert_eq!(ticket.tracker_identity, "github:tesserine/runa:188");
+        assert_eq!(ticket.tracker_identity, "github:github.com/tesserine/runa");
+        assert_eq!(
+            ticket.work_unit_identity,
+            "github:github.com/tesserine/runa#188"
+        );
     }
 
     #[test]
@@ -493,7 +514,8 @@ mod tests {
     #[test]
     fn sourcehut_form_matches_active_tracker() {
         let ticket = resolve_ticket_reference("sourcehut:4#9", &sourcehut_identity("4")).unwrap();
-        assert_eq!(ticket.tracker_identity, "sourcehut:4:9");
+        assert_eq!(ticket.tracker_identity, "sourcehut:4");
+        assert_eq!(ticket.work_unit_identity, "sourcehut:4#9");
         assert_eq!(ticket.display, "sourcehut:4#9");
     }
 
@@ -508,7 +530,8 @@ mod tests {
     #[test]
     fn bare_number_under_sourcehut_inherits_tracker() {
         let ticket = resolve_ticket_reference("9", &sourcehut_identity("4")).unwrap();
-        assert_eq!(ticket.tracker_identity, "sourcehut:4:9");
+        assert_eq!(ticket.tracker_identity, "sourcehut:4");
+        assert_eq!(ticket.work_unit_identity, "sourcehut:4#9");
     }
 
     #[test]

--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -422,6 +422,7 @@ mod tests {
             owner: Some(owner.to_string()),
             name: Some(name.to_string()),
             tracker_id: None,
+            canonical_deployment_identity: None,
         }
     }
 
@@ -431,6 +432,7 @@ mod tests {
             owner: None,
             name: None,
             tracker_id: Some(tracker_id.to_string()),
+            canonical_deployment_identity: None,
         }
     }
 
@@ -541,6 +543,7 @@ mod tests {
             owner: None,
             name: Some("runa".to_string()),
             tracker_id: None,
+            canonical_deployment_identity: None,
         };
         let error = resolve_ticket_reference("14", &identity).unwrap_err();
         assert!(matches!(
@@ -559,6 +562,7 @@ mod tests {
             owner: Some("tesserine".to_string()),
             name: Some("runa".to_string()),
             tracker_id: None,
+            canonical_deployment_identity: None,
         };
 
         assert!(matches!(

--- a/libagent/src/forge_address.rs
+++ b/libagent/src/forge_address.rs
@@ -1,0 +1,554 @@
+//! Authoritative forge-address schema helpers.
+//!
+//! The JSON Schema under `contracts/forge-address/` is the public contract.
+//! This module is runa's Rust projection of the same contract: it validates
+//! produced payloads/handles against the schema and performs the semantic
+//! checks JSON Schema cannot express, such as computed work-unit identity.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+const FORGE_ADDRESS_SCHEMA: &str =
+    include_str!("../../contracts/forge-address/forge-address.schema.json");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgeAddressError {
+    message: String,
+}
+
+impl ForgeAddressError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ForgeAddressError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ForgeAddressError {}
+
+#[derive(Debug, Deserialize)]
+struct ProjectDocument {
+    #[serde(default)]
+    forge: ForgeTopology,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ForgeTopology {
+    #[serde(default)]
+    instances: Vec<Instance>,
+    #[serde(default)]
+    repositories: Vec<Repository>,
+    #[serde(default)]
+    trackers: Vec<Tracker>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Instance {
+    name: String,
+    #[serde(rename = "type")]
+    instance_type: String,
+    host: Option<String>,
+    git_host: Option<String>,
+    tracker_host: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Repository {
+    name: String,
+    instance: String,
+    owner: String,
+    repository: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Tracker {
+    name: String,
+    #[serde(rename = "type")]
+    tracker_type: String,
+    instance: String,
+    repository: Option<String>,
+    owner: Option<String>,
+    tracker: Option<String>,
+    tracker_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedInstance {
+    name: String,
+    instance_type: String,
+    host: Option<String>,
+    git_host: Option<String>,
+    tracker_host: Option<String>,
+}
+
+pub fn schema() -> Value {
+    serde_json::from_str(FORGE_ADDRESS_SCHEMA).expect("forge-address schema is valid JSON")
+}
+
+pub fn validate_against_schema(value: &Value) -> Result<(), ForgeAddressError> {
+    let schema = schema();
+    let validator = jsonschema::validator_for(&schema).map_err(|error| {
+        ForgeAddressError::new(format!("invalid forge-address schema: {error}"))
+    })?;
+    let errors: Vec<String> = validator
+        .iter_errors(value)
+        .map(|error| format!("{}: {}", error.instance_path(), error))
+        .collect();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ForgeAddressError::new(format!(
+            "forge-address contract violation: {}",
+            errors.join("; ")
+        )))
+    }
+}
+
+pub fn validate_work_unit_handle(value: &Value) -> Result<(), ForgeAddressError> {
+    validate_against_schema(value)?;
+    let tracker_identity = required_string(value, "tracker_identity")?;
+    let work_unit_identity = required_string(value, "work_unit_identity")?;
+    let number = value
+        .get("number")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| ForgeAddressError::new("work-unit handle number must be an integer"))?;
+    let expected = format!("{tracker_identity}#{number}");
+    if work_unit_identity != expected {
+        return Err(ForgeAddressError::new(format!(
+            "work_unit_identity must be derived as {expected}"
+        )));
+    }
+    Ok(())
+}
+
+pub fn work_unit_handle(tracker: &str, tracker_identity: &str, number: u64) -> Value {
+    json!({
+        "tracker": tracker,
+        "tracker_identity": tracker_identity,
+        "work_unit_identity": format!("{tracker_identity}#{number}"),
+        "number": number
+    })
+}
+
+pub fn resolve_project_payload(path: &Path) -> Result<Value, ForgeAddressError> {
+    let content = std::fs::read_to_string(path).map_err(|error| {
+        ForgeAddressError::new(format!("cannot read {}: {error}", path.display()))
+    })?;
+    let project: ProjectDocument = toml::from_str(&content).map_err(|error| {
+        ForgeAddressError::new(format!("failed to parse {}: {error}", path.display()))
+    })?;
+    let payload = resolve_topology(project.forge)?;
+    validate_against_schema(&payload)?;
+    Ok(payload)
+}
+
+fn resolve_topology(topology: ForgeTopology) -> Result<Value, ForgeAddressError> {
+    let mut instances = BTreeMap::new();
+    let mut instance_values = Vec::new();
+    for instance in topology.instances {
+        let resolved = resolve_instance(instance)?;
+        if instances
+            .insert(resolved.name.clone(), resolved.clone())
+            .is_some()
+        {
+            return Err(ForgeAddressError::new("duplicate forge instance name"));
+        }
+        instance_values.push(instance_value(&resolved));
+    }
+
+    let mut repositories = BTreeMap::new();
+    let mut repository_values = Vec::new();
+    for repository in topology.repositories {
+        let instance = instances.get(&repository.instance).ok_or_else(|| {
+            ForgeAddressError::new(format!(
+                "repository `{}` references unknown instance `{}`",
+                repository.name, repository.instance
+            ))
+        })?;
+        let identity = repository_identity(instance, &repository.owner, &repository.repository)?;
+        if repositories
+            .insert(
+                repository.name.clone(),
+                (repository.instance.clone(), identity.clone()),
+            )
+            .is_some()
+        {
+            return Err(ForgeAddressError::new("duplicate repository name"));
+        }
+        repository_values.push(json!({
+            "name": repository.name,
+            "instance": repository.instance,
+            "owner": canonical_owner(instance, &repository.owner),
+            "repository": repository.repository,
+            "identity": identity
+        }));
+    }
+
+    let mut tracker_names = BTreeSet::new();
+    let mut tracker_values = Vec::new();
+    for tracker in topology.trackers {
+        if !tracker_names.insert(tracker.name.clone()) {
+            return Err(ForgeAddressError::new("duplicate tracker name"));
+        }
+        let instance = instances.get(&tracker.instance).ok_or_else(|| {
+            ForgeAddressError::new(format!(
+                "tracker `{}` references unknown instance `{}`",
+                tracker.name, tracker.instance
+            ))
+        })?;
+        match tracker.tracker_type.as_str() {
+            "github" => {
+                let repository_name = tracker.repository.ok_or_else(|| {
+                    ForgeAddressError::new(format!(
+                        "github tracker `{}` must reference a repository",
+                        tracker.name
+                    ))
+                })?;
+                let (repository_instance, identity) =
+                    repositories.get(&repository_name).ok_or_else(|| {
+                        ForgeAddressError::new(format!(
+                            "github tracker `{}` references unknown repository `{repository_name}`",
+                            tracker.name
+                        ))
+                    })?;
+                if repository_instance != &tracker.instance {
+                    return Err(ForgeAddressError::new(format!(
+                        "github tracker `{}` and repository `{repository_name}` use different instances",
+                        tracker.name
+                    )));
+                }
+                tracker_values.push(json!({
+                    "name": tracker.name,
+                    "type": "github",
+                    "instance": tracker.instance,
+                    "repository": repository_name,
+                    "identity": identity
+                }));
+            }
+            "sourcehut" => {
+                let owner = tracker.owner.ok_or_else(|| {
+                    ForgeAddressError::new(format!(
+                        "sourcehut tracker `{}` missing owner",
+                        tracker.name
+                    ))
+                })?;
+                let tracker_name = tracker.tracker.ok_or_else(|| {
+                    ForgeAddressError::new(format!(
+                        "sourcehut tracker `{}` missing tracker",
+                        tracker.name
+                    ))
+                })?;
+                let tracker_id = tracker.tracker_id.ok_or_else(|| {
+                    ForgeAddressError::new(format!(
+                        "sourcehut tracker `{}` missing tracker_id",
+                        tracker.name
+                    ))
+                })?;
+                let identity =
+                    sourcehut_tracker_identity(instance, &owner, &tracker_name, tracker_id)?;
+                tracker_values.push(json!({
+                    "name": tracker.name,
+                    "type": "sourcehut",
+                    "instance": tracker.instance,
+                    "owner": canonical_owner(instance, &owner),
+                    "tracker": tracker_name,
+                    "tracker_id": tracker_id,
+                    "identity": identity
+                }));
+            }
+            other => {
+                return Err(ForgeAddressError::new(format!(
+                    "unsupported tracker type `{other}`"
+                )));
+            }
+        }
+    }
+
+    Ok(json!({
+        "schema_version": "1.0.0",
+        "instances": instance_values,
+        "repositories": repository_values,
+        "trackers": tracker_values
+    }))
+}
+
+fn resolve_instance(instance: Instance) -> Result<ResolvedInstance, ForgeAddressError> {
+    match instance.instance_type.as_str() {
+        "github" => {
+            let host = required(instance.host, "github instance host")?;
+            Ok(ResolvedInstance {
+                name: instance.name,
+                instance_type: instance.instance_type,
+                host: Some(host),
+                git_host: None,
+                tracker_host: None,
+            })
+        }
+        "sourcehut" => {
+            let git_host = required(instance.git_host, "sourcehut instance git_host")?;
+            let tracker_host = required(instance.tracker_host, "sourcehut instance tracker_host")?;
+            Ok(ResolvedInstance {
+                name: instance.name,
+                instance_type: instance.instance_type,
+                host: None,
+                git_host: Some(git_host),
+                tracker_host: Some(tracker_host),
+            })
+        }
+        other => Err(ForgeAddressError::new(format!(
+            "unsupported forge instance type `{other}`"
+        ))),
+    }
+}
+
+fn instance_value(instance: &ResolvedInstance) -> Value {
+    match instance.instance_type.as_str() {
+        "github" => json!({
+            "name": instance.name,
+            "type": "github",
+            "host": instance.host.as_ref().expect("github host resolved")
+        }),
+        "sourcehut" => json!({
+            "name": instance.name,
+            "type": "sourcehut",
+            "git_host": instance.git_host.as_ref().expect("sourcehut git_host resolved"),
+            "tracker_host": instance.tracker_host.as_ref().expect("sourcehut tracker_host resolved")
+        }),
+        _ => unreachable!("unsupported instance resolved"),
+    }
+}
+
+fn repository_identity(
+    instance: &ResolvedInstance,
+    owner: &str,
+    repository: &str,
+) -> Result<String, ForgeAddressError> {
+    match instance.instance_type.as_str() {
+        "github" => Ok(format!(
+            "github:{}/{}/{}",
+            instance.host.as_ref().expect("github host resolved"),
+            owner,
+            repository
+        )),
+        "sourcehut" => Ok(format!(
+            "sourcehut:{}/{}/{}",
+            instance
+                .git_host
+                .as_ref()
+                .expect("sourcehut git_host resolved"),
+            canonical_sourcehut_owner(owner),
+            repository
+        )),
+        other => Err(ForgeAddressError::new(format!(
+            "repository cannot use instance type `{other}`"
+        ))),
+    }
+}
+
+fn sourcehut_tracker_identity(
+    instance: &ResolvedInstance,
+    owner: &str,
+    tracker: &str,
+    tracker_id: u64,
+) -> Result<String, ForgeAddressError> {
+    if instance.instance_type != "sourcehut" {
+        return Err(ForgeAddressError::new(
+            "sourcehut tracker must use a sourcehut instance",
+        ));
+    }
+    Ok(format!(
+        "sourcehut:{}/{}/{}:{}",
+        instance
+            .tracker_host
+            .as_ref()
+            .expect("sourcehut tracker_host resolved"),
+        canonical_sourcehut_owner(owner),
+        tracker,
+        tracker_id
+    ))
+}
+
+fn canonical_owner(instance: &ResolvedInstance, owner: &str) -> String {
+    if instance.instance_type == "sourcehut" {
+        canonical_sourcehut_owner(owner)
+    } else {
+        owner.to_string()
+    }
+}
+
+fn canonical_sourcehut_owner(owner: &str) -> String {
+    let bare = owner.trim_start_matches('~');
+    format!("~{bare}")
+}
+
+fn required(value: Option<String>, name: &str) -> Result<String, ForgeAddressError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| ForgeAddressError::new(format!("missing required {name}")))
+}
+
+fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, ForgeAddressError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeAddressError::new(format!("work-unit handle missing {field}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conformance_fixture() -> Value {
+        serde_json::from_str(include_str!(
+            "../../contracts/forge-address/conformance.json"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn validates_computed_work_unit_identity() {
+        let handle = work_unit_handle("runa", "github:github.example.com/tesserine/runa", 199);
+
+        validate_work_unit_handle(&handle).unwrap();
+    }
+
+    #[test]
+    fn rejects_stored_work_unit_identity_that_disagrees_with_parts() {
+        let handle = json!({
+            "tracker": "runa",
+            "tracker_identity": "github:github.example.com/tesserine/runa",
+            "work_unit_identity": "github:github.example.com/tesserine/runa#200",
+            "number": 199
+        });
+
+        let error = validate_work_unit_handle(&handle).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("work_unit_identity must be derived"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn resolves_project_topology_into_schema_valid_payload() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let project = directory.path().join("project.toml");
+        std::fs::write(
+            &project,
+            r#"
+[[forge.instances]]
+name = "github-enterprise"
+type = "github"
+host = "github.example.com"
+
+[[forge.instances]]
+name = "srht"
+type = "sourcehut"
+git_host = "git.weforge.build"
+tracker_host = "todo.weforge.build"
+
+[[forge.repositories]]
+name = "runa"
+instance = "github-enterprise"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.repositories]]
+name = "groundwork-srht"
+instance = "srht"
+owner = "operator"
+repository = "groundwork"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github-enterprise"
+repository = "runa"
+
+[[forge.trackers]]
+name = "groundwork"
+type = "sourcehut"
+instance = "srht"
+owner = "operator"
+tracker = "groundwork"
+tracker_id = 4
+"#,
+        )
+        .unwrap();
+
+        let payload = resolve_project_payload(&project).unwrap();
+
+        assert_eq!(payload["schema_version"], "1.0.0");
+        assert_eq!(
+            payload["trackers"][1]["identity"],
+            "sourcehut:todo.weforge.build/~operator/groundwork:4"
+        );
+        validate_against_schema(&payload).unwrap();
+    }
+
+    #[test]
+    fn rejects_sourcehut_instance_missing_required_host() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let project = directory.path().join("project.toml");
+        std::fs::write(
+            &project,
+            r#"
+[[forge.instances]]
+name = "srht"
+type = "sourcehut"
+git_host = "git.weforge.build"
+"#,
+        )
+        .unwrap();
+
+        let error = resolve_project_payload(&project).unwrap_err();
+
+        assert!(error.to_string().contains("tracker_host"), "{error}");
+    }
+
+    #[test]
+    fn conformance_fixture_valid_examples_pass_contract() {
+        let fixture = conformance_fixture();
+        for example in fixture["valid"]["payloads"].as_array().unwrap() {
+            validate_against_schema(&example["value"]).unwrap_or_else(|error| {
+                panic!("valid payload {} failed: {error}", example["name"])
+            });
+        }
+        for example in fixture["valid"]["handles"].as_array().unwrap() {
+            validate_work_unit_handle(&example["value"])
+                .unwrap_or_else(|error| panic!("valid handle {} failed: {error}", example["name"]));
+        }
+    }
+
+    #[test]
+    fn conformance_fixture_invalid_examples_fail_contract() {
+        let fixture = conformance_fixture();
+        for example in fixture["invalid"]["payloads"].as_array().unwrap() {
+            assert!(
+                validate_against_schema(&example["value"]).is_err(),
+                "invalid payload {} passed",
+                example["name"]
+            );
+        }
+        for example in fixture["invalid"]["handles"].as_array().unwrap() {
+            assert!(
+                validate_work_unit_handle(&example["value"]).is_err(),
+                "invalid handle {} passed",
+                example["name"]
+            );
+        }
+    }
+}

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -72,8 +72,9 @@ pub use scan::{
 };
 pub use scoped_identity::{
     ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
-    resolve_forge_environment, resolve_forge_identity, validate_scoped_work_unit,
-    validate_scoped_work_unit_with_identity, validate_tracker_consistency,
+    resolve_forge_environment, resolve_forge_identity, resolve_scoped_forge_identity,
+    validate_scoped_work_unit, validate_scoped_work_unit_with_identity,
+    validate_tracker_consistency,
 };
 pub use selection::{
     Candidate, CandidateKey, CandidateStatus, ClassifiedCandidate, EvaluationScope,

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -21,6 +21,7 @@ pub(crate) mod completion;
 pub mod context;
 pub mod enforcement;
 pub mod entry;
+pub mod forge_address;
 pub mod graph;
 pub mod logging;
 pub mod manifest;
@@ -47,6 +48,10 @@ pub use entry::{
     AcquisitionBlock, EntryError, RUNA_ENTRY_TICKET, TicketRef, check_acquisition_admissible,
     discover_acquisition_surface, resolve_promise, resolve_ticket_reference,
 };
+pub use forge_address::{
+    ForgeAddressError, resolve_project_payload, schema as forge_address_schema,
+    validate_against_schema as validate_forge_address, validate_work_unit_handle, work_unit_handle,
+};
 pub use graph::{CycleError, DependencyGraph, GraphError};
 pub use logging::{LoggingError, ResolvedLoggingConfig, configure_tracing, resolve_logging_config};
 pub use manifest::ManifestError;
@@ -55,8 +60,8 @@ pub use model::{
     UnscopedOutputRequiresWorkUnitError, validate_output_scope,
 };
 pub use project::{
-    Config, ForgeConfig, LoadedProject, LogFormat, LoggingConfig, ProjectError, State,
-    TranscriptConfig,
+    Config, ForgeConfig, LoadedProject, LogFormat, LoggingConfig, ProjectError, RuntimeConfig,
+    State, TranscriptConfig,
 };
 pub use projection::{
     ProjectionCandidate, ProjectionClass, project_cascade, project_entry_cascade,

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -41,14 +41,14 @@ impl LoggingConfig {
     }
 }
 
-/// The `[agent]` section of `.runa/config.toml`.
+/// The `[runtime]` section of `.runa/config.toml`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct AgentConfig {
+pub struct RuntimeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<Vec<String>>,
 }
 
-impl AgentConfig {
+impl RuntimeConfig {
     fn is_default(&self) -> bool {
         self == &Self::default()
     }
@@ -69,7 +69,7 @@ impl TranscriptConfig {
     }
 }
 
-/// The `[forge]` section of `.runa/config.toml`.
+/// Internal resolved forge identity used by legacy scoped-selection code.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ForgeConfig {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
@@ -94,8 +94,8 @@ pub struct Config {
     pub methodology_path: String,
     #[serde(default, skip_serializing_if = "LoggingConfig::is_default")]
     pub logging: LoggingConfig,
-    #[serde(default, skip_serializing_if = "AgentConfig::is_default")]
-    pub agent: AgentConfig,
+    #[serde(default, skip_serializing_if = "RuntimeConfig::is_default")]
+    pub runtime: RuntimeConfig,
     #[serde(default, skip_serializing_if = "TranscriptConfig::is_default")]
     pub transcript: TranscriptConfig,
     #[serde(default, skip_serializing_if = "ForgeConfig::is_default")]
@@ -245,6 +245,18 @@ pub fn read_config(
                 .to_string(),
         ));
     }
+    if config_value.get("agent").is_some() {
+        return Err(ProjectError::ConfigParseFailed(
+            "'[agent]' has been removed; configure machine-local execution with '[runtime] command = [...]'"
+                .to_string(),
+        ));
+    }
+    if config_value.get("forge").is_some() {
+        return Err(ProjectError::ConfigParseFailed(
+            "'[forge]' has been removed; configure portable forge topology in '.runa/project.toml'"
+                .to_string(),
+        ));
+    }
     config_value
         .try_into()
         .map_err(|e| ProjectError::ConfigParseFailed(e.to_string()))
@@ -258,7 +270,8 @@ pub fn load(
     working_dir: &Path,
     config_override: Option<&Path>,
 ) -> Result<LoadedProject, ProjectError> {
-    let config = read_config(working_dir, config_override)?;
+    let mut config = read_config(working_dir, config_override)?;
+    derive_internal_forge_from_project_topology(working_dir, &mut config)?;
 
     // Verify state.toml exists (project was initialized).
     let runa_dir = working_dir.join(RUNA_DIR);
@@ -293,6 +306,78 @@ pub fn load(
         store,
         workspace_dir,
     })
+}
+
+fn derive_internal_forge_from_project_topology(
+    working_dir: &Path,
+    config: &mut Config,
+) -> Result<(), ProjectError> {
+    if !config.forge.is_default() {
+        return Ok(());
+    }
+    let project_path = working_dir.join(RUNA_DIR).join("project.toml");
+    if !project_path.exists() {
+        return Ok(());
+    }
+    let payload = crate::resolve_project_payload(&project_path)
+        .map_err(|error| ProjectError::ConfigParseFailed(error.to_string()))?;
+    let Some(trackers) = payload.get("trackers").and_then(|value| value.as_array()) else {
+        return Ok(());
+    };
+    let Some(tracker) = trackers.first().and_then(|value| value.as_object()) else {
+        return Ok(());
+    };
+    match tracker.get("type").and_then(|value| value.as_str()) {
+        Some("github") => {
+            let Some(repository_name) = tracker.get("repository").and_then(|value| value.as_str())
+            else {
+                return Ok(());
+            };
+            let repository = payload
+                .get("repositories")
+                .and_then(|value| value.as_array())
+                .and_then(|repositories| {
+                    repositories.iter().find(|repository| {
+                        repository.get("name").and_then(|value| value.as_str())
+                            == Some(repository_name)
+                    })
+                })
+                .and_then(|value| value.as_object());
+            if let Some(repository) = repository {
+                config.forge = ForgeConfig {
+                    forge_type: Some("github".to_string()),
+                    owner: repository
+                        .get("owner")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string),
+                    name: repository
+                        .get("repository")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string),
+                    tracker_id: None,
+                };
+            }
+        }
+        Some("sourcehut") => {
+            config.forge = ForgeConfig {
+                forge_type: Some("sourcehut".to_string()),
+                owner: tracker
+                    .get("owner")
+                    .and_then(|value| value.as_str())
+                    .map(|owner| owner.trim_start_matches('~').to_string()),
+                name: tracker
+                    .get("tracker")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string),
+                tracker_id: tracker
+                    .get("tracker_id")
+                    .and_then(|value| value.as_i64())
+                    .map(|value| value.to_string()),
+            };
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -340,7 +425,7 @@ trigger = { type = "on_change", name = "constraints" }
         let config = Config {
             methodology_path: canonical.display().to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
+            runtime: RuntimeConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
         };
@@ -403,7 +488,7 @@ trigger = { type = "on_change", name = "constraints" }
         let config = Config {
             methodology_path: canonical.display().to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
+            runtime: RuntimeConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
         };
@@ -486,7 +571,7 @@ artifacts_dir = "custom-artifacts"
         let config = Config {
             methodology_path: canonical.display().to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
+            runtime: RuntimeConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
         };
@@ -597,7 +682,7 @@ methodology_path = "/tmp/methodology.toml"
 
         assert_eq!(config.logging.format, LogFormat::Text);
         assert_eq!(config.logging.filter, None);
-        assert_eq!(config.agent.command, None);
+        assert_eq!(config.runtime.command, None);
     }
 
     #[test]
@@ -615,12 +700,36 @@ filter = "info"
 
         assert_eq!(config.logging.format, LogFormat::Json);
         assert_eq!(config.logging.filter.as_deref(), Some("info"));
-        assert_eq!(config.agent.command, None);
+        assert_eq!(config.runtime.command, None);
     }
 
     #[test]
-    fn config_with_agent_table_parses_command() {
+    fn config_with_runtime_table_parses_command() {
         let config: Config = toml::from_str(
+            r#"
+methodology_path = "/tmp/methodology.toml"
+
+[runtime]
+command = ["agent-runtime", "exec"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.runtime.command,
+            Some(vec!["agent-runtime".to_string(), "exec".to_string()])
+        );
+    }
+
+    #[test]
+    fn read_config_rejects_legacy_agent_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
             r#"
 methodology_path = "/tmp/methodology.toml"
 
@@ -630,10 +739,9 @@ command = ["agent-runtime", "exec"]
         )
         .unwrap();
 
-        assert_eq!(
-            config.agent.command,
-            Some(vec!["agent-runtime".to_string(), "exec".to_string()])
-        );
+        let err = read_config(&working, None).unwrap_err();
+
+        assert!(err.to_string().contains("[agent]"), "{err}");
     }
 
     #[test]
@@ -664,11 +772,36 @@ tracker_id = "4"
     }
 
     #[test]
+    fn read_config_rejects_legacy_forge_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let working = dir.path().join("project");
+        fs::create_dir(&working).unwrap();
+        let runa_dir = working.join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
+            r#"
+methodology_path = "/tmp/methodology.toml"
+
+[forge]
+type = "github"
+owner = "tesserine"
+name = "runa"
+"#,
+        )
+        .unwrap();
+
+        let err = read_config(&working, None).unwrap_err();
+
+        assert!(err.to_string().contains("[forge]"), "{err}");
+    }
+
+    #[test]
     fn config_serializes_and_deserializes_new_durable_runtime_settings() {
         let config = Config {
             methodology_path: "/tmp/methodology.toml".to_string(),
             logging: LoggingConfig::default(),
-            agent: AgentConfig::default(),
+            runtime: RuntimeConfig::default(),
             transcript: TranscriptConfig {
                 dir: Some("transcripts".to_string()),
                 redact_env: vec!["SECRET_TOKEN".to_string()],

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -25,6 +25,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::path::Path;
 
 use serde_json::Value;
 
@@ -42,6 +43,7 @@ pub struct ResolvedForgeIdentity {
     pub owner: Option<String>,
     pub name: Option<String>,
     pub tracker_id: Option<String>,
+    pub canonical_deployment_identity: Option<String>,
 }
 
 impl ResolvedForgeIdentity {
@@ -59,6 +61,9 @@ impl ResolvedForgeIdentity {
     }
 
     fn active_deployment_identity(&self) -> Result<String, ScopedWorkUnitError> {
+        if let Some(identity) = self.canonical_deployment_identity.as_deref() {
+            return Ok(identity.to_string());
+        }
         match self.forge_type.as_str() {
             "github" => {
                 let owner = self.required_atom(RUNA_FORGE_OWNER, self.owner.as_deref())?;
@@ -223,11 +228,39 @@ pub fn resolve_forge_identity(config: &ForgeConfig) -> ResolvedForgeIdentity {
         owner: resolve_atom(RUNA_FORGE_OWNER, config.owner.as_deref()),
         name: resolve_atom(RUNA_FORGE_NAME, config.name.as_deref()),
         tracker_id: resolve_atom(RUNA_FORGE_TRACKER_ID, config.tracker_id.as_deref()),
+        canonical_deployment_identity: None,
     }
+}
+
+pub fn resolve_scoped_forge_identity(
+    working_dir: &Path,
+    config: &ForgeConfig,
+) -> ResolvedForgeIdentity {
+    let mut identity = resolve_forge_identity(config);
+    identity.canonical_deployment_identity = canonical_tracker_identity(working_dir);
+    identity
 }
 
 pub fn resolve_forge_environment(config: &ForgeConfig) -> HashMap<String, String> {
     resolve_forge_identity(config).environment()
+}
+
+fn canonical_tracker_identity(working_dir: &Path) -> Option<String> {
+    let project_path = working_dir.join(".runa").join("project.toml");
+    if !project_path.exists() {
+        return None;
+    }
+    crate::resolve_project_payload(&project_path)
+        .ok()
+        .and_then(|payload| {
+            payload
+                .get("trackers")
+                .and_then(Value::as_array)
+                .and_then(|trackers| trackers.first())
+                .and_then(|tracker| tracker.get("identity"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
 }
 
 fn resolve_atom(variable: &'static str, config_value: Option<&str>) -> Option<String> {
@@ -482,6 +515,29 @@ mod tests {
         })
     }
 
+    fn handled_work_unit(handle: serde_json::Value) -> serde_json::Value {
+        json!({
+            "title": "Canonical scope",
+            "description": "Validate canonical scoped identity",
+            "acceptance_criteria": ["Reject mismatched handles"],
+            "handle": handle
+        })
+    }
+
+    fn conformance_handle(name: &str) -> serde_json::Value {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../contracts/forge-address/conformance.json"
+        ))
+        .unwrap();
+        fixture["valid"]["handles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|example| example["name"] == name)
+            .unwrap_or_else(|| panic!("missing conformance handle {name}"))["value"]
+            .clone()
+    }
+
     fn github_identity(repository: &str) -> ResolvedForgeIdentity {
         let (owner, name) = repository.split_once('/').unwrap();
         ResolvedForgeIdentity {
@@ -489,6 +545,7 @@ mod tests {
             owner: Some(owner.to_string()),
             name: Some(name.to_string()),
             tracker_id: None,
+            canonical_deployment_identity: None,
         }
     }
 
@@ -498,6 +555,20 @@ mod tests {
             owner: None,
             name: None,
             tracker_id: Some(tracker_id.to_string()),
+            canonical_deployment_identity: None,
+        }
+    }
+
+    fn canonical_identity(identity: &str) -> ResolvedForgeIdentity {
+        ResolvedForgeIdentity {
+            forge_type: identity
+                .split_once(':')
+                .map_or(identity, |(forge_type, _)| forge_type)
+                .to_string(),
+            owner: None,
+            name: None,
+            tracker_id: None,
+            canonical_deployment_identity: Some(identity.to_string()),
         }
     }
 
@@ -603,6 +674,48 @@ mod tests {
     }
 
     #[test]
+    fn scoped_forge_identity_uses_project_topology_tracker_identity() {
+        let _env = EnvGuard::set(&[
+            ("RUNA_FORGE_TYPE", "github"),
+            ("RUNA_FORGE_OWNER", "wrong"),
+            ("RUNA_FORGE_NAME", "wrong"),
+            ("RUNA_FORGE_TRACKER_ID", "9"),
+        ]);
+        let tmp = TempDir::new().unwrap();
+        let runa_dir = tmp.path().join(".runa");
+        std::fs::create_dir_all(&runa_dir).unwrap();
+        std::fs::write(
+            runa_dir.join("project.toml"),
+            r#"
+[[forge.instances]]
+name = "github-enterprise"
+type = "github"
+host = "github.example.com"
+
+[[forge.repositories]]
+name = "runa"
+instance = "github-enterprise"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github-enterprise"
+repository = "runa"
+"#,
+        )
+        .unwrap();
+
+        let identity = resolve_scoped_forge_identity(tmp.path(), &ForgeConfig::default());
+
+        assert_eq!(
+            identity.active_deployment_identity().unwrap(),
+            "github:github.example.com/tesserine/runa"
+        );
+    }
+
+    #[test]
     fn exact_work_unit_id_without_slug_accepts_matching_github_deployment() {
         let tmp = TempDir::new().unwrap();
         let mut store = work_unit_store(&tmp);
@@ -617,6 +730,58 @@ mod tests {
             &store,
             "work-unit-163",
             &github_identity("tesserine/runa"),
+        );
+
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn exact_work_unit_id_accepts_canonical_non_default_github_tracker_identity() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = work_unit_store(&tmp);
+        let artifact = handled_work_unit(conformance_handle("runa-199"));
+        let artifact_path = tmp.path().join("work-unit-199-scope.json");
+        std::fs::write(&artifact_path, artifact.to_string()).unwrap();
+        store
+            .record_with_timestamp(
+                "work-unit",
+                "work-unit-199-scope",
+                &artifact_path,
+                &artifact,
+                1,
+            )
+            .unwrap();
+
+        let result = validate_scoped_work_unit_with_identity(
+            &store,
+            "work-unit-199-scope",
+            &canonical_identity("github:github.example.com/tesserine/runa"),
+        );
+
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn exact_work_unit_id_accepts_canonical_sourcehut_tracker_host_identity() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = work_unit_store(&tmp);
+        let artifact = handled_work_unit(conformance_handle("groundwork-420"));
+        let artifact_path = tmp.path().join("work-unit-420-scope.json");
+        std::fs::write(&artifact_path, artifact.to_string()).unwrap();
+        store
+            .record_with_timestamp(
+                "work-unit",
+                "work-unit-420-scope",
+                &artifact_path,
+                &artifact,
+                1,
+            )
+            .unwrap();
+
+        let result = validate_scoped_work_unit_with_identity(
+            &store,
+            "work-unit-420-scope",
+            &canonical_identity("sourcehut:todo.weforge.build/~operator/groundwork:4"),
         );
 
         assert_eq!(result, Ok(()));

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -63,7 +63,7 @@ impl ResolvedForgeIdentity {
             "github" => {
                 let owner = self.required_atom(RUNA_FORGE_OWNER, self.owner.as_deref())?;
                 let name = self.required_atom(RUNA_FORGE_NAME, self.name.as_deref())?;
-                Ok(format!("github:{owner}/{name}"))
+                Ok(format!("github:github.com/{owner}/{name}"))
             }
             "sourcehut" => {
                 let tracker_id =
@@ -339,6 +339,16 @@ fn validate_deployment_identity(
 
     let handle_identity = deployment_identity_for_handle(handle)?;
     let active_identity = identity.active_deployment_identity()?;
+    if handle.get("tracker_identity").is_some() {
+        if handle_identity != active_identity {
+            return Err(ScopedWorkUnitError::DeploymentDisagreement {
+                instance_id: instance_id.to_string(),
+                handle_identity,
+                active_identity,
+            });
+        }
+        return Ok(());
+    }
     if handle_forge != identity.forge_type || handle_identity != active_identity {
         return Err(ScopedWorkUnitError::DeploymentDisagreement {
             instance_id: instance_id.to_string(),
@@ -353,6 +363,9 @@ fn validate_deployment_identity(
 fn deployment_identity_for_handle(
     handle: &serde_json::Map<String, Value>,
 ) -> Result<String, ScopedWorkUnitError> {
+    if let Some(tracker_identity) = handle.get("tracker_identity").and_then(Value::as_str) {
+        return Ok(tracker_identity.to_string());
+    }
     match handle
         .get("forge_tag")
         .and_then(Value::as_str)
@@ -366,7 +379,7 @@ fn deployment_identity_for_handle(
                     .unwrap_or_default(),
             )
             .unwrap_or_default();
-            Ok(format!("github:{repository}"))
+            Ok(format!("github:github.com/{repository}"))
         }
         "sourcehut" => {
             let tracker_id = handle
@@ -380,11 +393,14 @@ fn deployment_identity_for_handle(
 }
 
 fn tracker_identity(handle: &serde_json::Map<String, Value>) -> Option<String> {
+    if let Some(work_unit_identity) = handle.get("work_unit_identity").and_then(Value::as_str) {
+        return Some(work_unit_identity.to_string());
+    }
     match handle.get("forge_tag").and_then(Value::as_str)? {
         "github" => {
             let repository = github_repository(handle.get("url")?.as_str()?)?;
             let number = handle.get("number")?.as_u64()?;
-            Some(format!("github:{repository}:{number}"))
+            Some(format!("github:github.com/{repository}#{number}"))
         }
         "sourcehut" => {
             let tracker_id = handle.get("tracker_id")?.as_u64()?;

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -441,6 +441,7 @@ impl SessionState {
                 reference: ticket.display.clone(),
                 ticket_number: ticket.number,
                 tracker_identity: ticket.tracker_identity.clone(),
+                work_unit_identity: ticket.work_unit_identity.clone(),
             });
         }
         let rendered = render_context_prompt(&context);
@@ -1035,9 +1036,31 @@ trigger = { type = "on_artifact", name = "work-unit" }
         fs::write(
             runa_dir.join("config.toml"),
             format!(
-                "methodology_path = {:?}\n\n[forge]\ntype = \"github\"\nowner = \"tesserine\"\nname = \"runa\"\n",
+                "methodology_path = {:?}\n",
                 manifest_path.display().to_string()
             ),
+        )
+        .unwrap();
+        fs::write(
+            runa_dir.join("project.toml"),
+            r#"
+[[forge.instances]]
+name = "github"
+type = "github"
+host = "github.com"
+
+[[forge.repositories]]
+name = "runa"
+instance = "github"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github"
+repository = "runa"
+"#,
         )
         .unwrap();
         fs::write(
@@ -1057,7 +1080,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
         fs::create_dir_all(workspace.join("work-unit")).unwrap();
         fs::write(
             workspace.join("work-unit/work-unit-14-cold-start.json"),
-            r#"{"title":"Cold start","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}"#,
+            r#"{"title":"Cold start","handle":{"tracker":"runa","tracker_identity":"github:github.com/tesserine/runa","work_unit_identity":"github:github.com/tesserine/runa#14","number":14}}"#,
         )
         .unwrap();
     }
@@ -1065,8 +1088,9 @@ trigger = { type = "on_artifact", name = "work-unit" }
     fn ticket_14() -> crate::TicketRef {
         crate::TicketRef {
             number: 14,
-            tracker_identity: "github:tesserine/runa:14".to_string(),
-            display: "github:tesserine/runa#14".to_string(),
+            tracker_identity: "github:github.com/tesserine/runa".to_string(),
+            work_unit_identity: "github:github.com/tesserine/runa#14".to_string(),
+            display: "github:github.com/tesserine/runa#14".to_string(),
         }
     }
 

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -315,7 +315,7 @@ impl SessionState {
         let mut loaded = crate::project::load(&working_dir, config_override)?;
         let scan_result = crate::scan(&loaded.workspace_dir, &mut loaded.store)?;
         let scan_findings = crate::collect_scan_findings(&scan_result, &loaded.workspace_dir);
-        let identity = crate::resolve_forge_identity(&loaded.config.forge);
+        let identity = crate::resolve_scoped_forge_identity(&working_dir, &loaded.config.forge);
 
         // Resolve the promise first. Re-entry (the work-unit already exists)
         // degrades to an ordinary bound session and needs no acquisition surface;
@@ -605,7 +605,8 @@ impl SessionState {
         require_current_ready: bool,
     ) -> Result<ReconciledScan, SessionError> {
         let scan_result = self.scan_workspace()?;
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let identity =
+            crate::resolve_scoped_forge_identity(&self.working_dir, &self.loaded.config.forge);
         match &self.scope {
             SessionScope::Bound(work_unit) => {
                 crate::validate_scoped_work_unit_with_identity(
@@ -689,7 +690,8 @@ impl SessionState {
     /// work-unit ([`EntryError::Unresolved`]) or the recorded work-unit fails
     /// scoped-identity validation.
     fn bind_promise(&mut self) -> Result<(), SessionError> {
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let identity =
+            crate::resolve_scoped_forge_identity(&self.working_dir, &self.loaded.config.forge);
         let ticket = match &self.scope {
             SessionScope::Promised { ticket, .. } => ticket.clone(),
             SessionScope::Bound(_) => return Ok(()),

--- a/libagent/src/validation.rs
+++ b/libagent/src/validation.rs
@@ -99,7 +99,7 @@ pub fn validate_artifact(
             detail: e.to_string(),
         })?;
 
-    let violations: Vec<Violation> = validator
+    let mut violations: Vec<Violation> = validator
         .iter_errors(artifact_data)
         .map(|e| Violation {
             artifact_type: artifact_type.name.clone(),
@@ -110,12 +110,53 @@ pub fn validate_artifact(
         .collect();
 
     if violations.is_empty() {
+        violations.extend(semantic_violations(artifact_data, artifact_type));
+    }
+
+    if violations.is_empty() {
         Ok(())
     } else {
         Err(ValidationError::InvalidArtifact {
             artifact_type: artifact_type.name.clone(),
             violations,
         })
+    }
+}
+
+fn semantic_violations(artifact_data: &Value, artifact_type: &ArtifactType) -> Vec<Violation> {
+    if artifact_type.name != "work-unit"
+        || !schema_references_work_unit_handle(&artifact_type.schema)
+    {
+        return Vec::new();
+    }
+    let Some(handle) = artifact_data.get("handle") else {
+        return Vec::new();
+    };
+    match crate::validate_work_unit_handle(handle) {
+        Ok(()) => Vec::new(),
+        Err(error) => vec![Violation {
+            artifact_type: artifact_type.name.clone(),
+            description: error.to_string(),
+            schema_path: "/$defs/work_unit_handle".to_string(),
+            instance_path: "/handle".to_string(),
+        }],
+    }
+}
+
+fn schema_references_work_unit_handle(schema: &Value) -> bool {
+    match schema {
+        Value::Object(map) => {
+            if map
+                .get("$ref")
+                .and_then(Value::as_str)
+                .is_some_and(|reference| reference.ends_with("#/$defs/work_unit_handle"))
+            {
+                return true;
+            }
+            map.values().any(schema_references_work_unit_handle)
+        }
+        Value::Array(values) => values.iter().any(schema_references_work_unit_handle),
+        _ => false,
     }
 }
 
@@ -333,6 +374,55 @@ mod tests {
                 assert!(!detail.is_empty());
             }
             other => panic!("expected InvalidSchema, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn work_unit_handle_identity_disagreement_fails_after_schema_validation() {
+        let at = make_artifact_type(
+            "work-unit",
+            json!({
+                "type": "object",
+                "required": ["title", "description", "acceptance_criteria", "handle"],
+                "properties": {
+                    "title": { "type": "string" },
+                    "description": { "type": "string" },
+                    "acceptance_criteria": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    },
+                    "handle": {
+                        "$ref": "forge-address.schema.json#/$defs/work_unit_handle"
+                    }
+                }
+            }),
+        );
+        let data = json!({
+            "title": "Bad identity",
+            "description": "Stored identity disagrees with its parts.",
+            "acceptance_criteria": ["Reject the disagreement"],
+            "handle": {
+                "tracker": "groundwork",
+                "tracker_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4",
+                "work_unit_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4#421",
+                "number": 420
+            }
+        });
+
+        let err = validate_artifact(&data, &at).unwrap_err();
+
+        match err {
+            ValidationError::InvalidArtifact { violations, .. } => {
+                assert_eq!(violations.len(), 1);
+                assert_eq!(violations[0].instance_path, "/handle");
+                assert!(
+                    violations[0]
+                        .description
+                        .contains("work_unit_identity must be derived"),
+                    "{violations:?}"
+                );
+            }
+            other => panic!("expected InvalidArtifact, got: {other}"),
         }
     }
 

--- a/libagent/src/validation.rs
+++ b/libagent/src/validation.rs
@@ -78,12 +78,26 @@ pub fn validate_artifact(
     artifact_data: &Value,
     artifact_type: &ArtifactType,
 ) -> Result<(), ValidationError> {
-    let validator = jsonschema::validator_for(&artifact_type.schema).map_err(|e| {
-        ValidationError::InvalidSchema {
+    let forge_address_schema = crate::forge_address_schema();
+    let validator = jsonschema::options()
+        .with_resources(
+            [
+                (
+                    "forge-address.schema.json",
+                    jsonschema::Resource::from_contents(forge_address_schema.clone()),
+                ),
+                (
+                    "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/forge-address.schema.json",
+                    jsonschema::Resource::from_contents(forge_address_schema),
+                ),
+            ]
+            .into_iter(),
+        )
+        .build(&artifact_type.schema)
+        .map_err(|e| ValidationError::InvalidSchema {
             artifact_type: artifact_type.name.clone(),
             detail: e.to_string(),
-        }
-    })?;
+        })?;
 
     let violations: Vec<Violation> = validator
         .iter_errors(artifact_data)

--- a/runa-cli/src/commands/entry.rs
+++ b/runa-cli/src/commands/entry.rs
@@ -96,6 +96,7 @@ pub(crate) fn acquisition_planned_entry(
         reference: ticket.display.clone(),
         ticket_number: ticket.number,
         tracker_identity: ticket.tracker_identity.clone(),
+        work_unit_identity: ticket.work_unit_identity.clone(),
     });
     PlannedEntry {
         protocol: acquisition.name.clone(),

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -222,7 +222,8 @@ fn run_bound(
 ) -> Result<StepOutcome, StepError> {
     let agent_command = configured_agent_command(working_dir, config_override)?;
     let (loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
-    super::validate_scoped_work_unit(&loaded, Some(work_unit)).map_err(StepError::from)?;
+    super::validate_scoped_work_unit(&loaded, working_dir, Some(work_unit))
+        .map_err(StepError::from)?;
     let scope = libagent::EvaluationScope::Scoped(work_unit);
     let state =
         crate::commands::step::evaluate_execution_state(&loaded, working_dir, &scan_result, scope);

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -17,7 +17,7 @@ fn configured_agent_command(
         .map_err(CommandError::from)
         .map_err(StepError::from)?;
     config
-        .agent
+        .runtime
         .command
         .filter(|command| {
             !command.is_empty() && !command.first().is_some_and(|part| part.is_empty())

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -117,7 +117,7 @@ pub fn run(
     let config = Config {
         methodology_path: canonical_path.display().to_string(),
         logging: crate::project::LoggingConfig::default(),
-        agent: crate::project::AgentConfig::default(),
+        runtime: crate::project::RuntimeConfig::default(),
         transcript: crate::project::TranscriptConfig::default(),
         forge: crate::project::ForgeConfig::default(),
     };

--- a/runa-cli/src/commands/mod.rs
+++ b/runa-cli/src/commands/mod.rs
@@ -72,10 +72,11 @@ pub fn load_and_scan(
 
 pub fn validate_scoped_work_unit(
     loaded: &LoadedProject,
+    working_dir: &Path,
     work_unit: Option<&str>,
 ) -> Result<(), CommandError> {
     if let Some(work_unit) = work_unit {
-        let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+        let identity = libagent::resolve_scoped_forge_identity(working_dir, &loaded.config.forge);
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     Ok(())

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -212,7 +212,7 @@ fn resolve_agent_command(
         .map_err(StepError::from)
         .map_err(RunError::from)?;
     config
-        .agent
+        .runtime
         .command
         .filter(|command| is_usable_agent_command(command))
         .ok_or(RunError::from(StepError::AgentCommandNotConfigured))

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -570,7 +570,7 @@ fn run_with_scope(
     cli_agent_command_present: bool,
     cli_agent_command_argv: &[String],
 ) -> Result<RunOutcome, RunError> {
-    super::validate_scoped_work_unit(&loaded, work_unit.as_deref())
+    super::validate_scoped_work_unit(&loaded, working_dir, work_unit.as_deref())
         .map_err(StepError::from)
         .map_err(RunError::from)?;
     let scope = match work_unit.as_deref() {

--- a/runa-cli/src/commands/state.rs
+++ b/runa-cli/src/commands/state.rs
@@ -51,7 +51,7 @@ pub fn run(
     work_unit: Option<&str>,
 ) -> Result<(), StateError> {
     let (loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
-    super::validate_scoped_work_unit(&loaded, work_unit)?;
+    super::validate_scoped_work_unit(&loaded, working_dir, work_unit)?;
     let scan_findings = protocol_eval::collect_scan_findings(&scan_result, &loaded.workspace_dir);
     let scope = match work_unit {
         Some(work_unit) => libagent::EvaluationScope::Scoped(work_unit),

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -73,7 +73,7 @@ impl fmt::Display for StepError {
             StepError::Json(err) => write!(f, "{err}"),
             StepError::AgentCommandNotConfigured => write!(
                 f,
-                "no agent command configured in config.toml; add [agent] command = [\"binary\", ...]"
+                "no agent command configured in config.toml; add [runtime] command = [\"binary\", ...]"
             ),
             StepError::JsonRequiresDryRun => {
                 write!(f, "--json is only supported with --dry-run")
@@ -425,19 +425,15 @@ pub(crate) fn resolved_runtime_env(
             .into_iter()
             .collect();
 
-    let forge_environment = libagent::resolve_forge_environment(&config.forge);
-    for name in [
-        "RUNA_FORGE_TYPE",
-        "RUNA_FORGE_OWNER",
-        "RUNA_FORGE_NAME",
-        "RUNA_FORGE_TRACKER_ID",
-    ] {
-        if let Some(value) = forge_environment
-            .get(name)
-            .filter(|value| !value.is_empty())
-        {
-            env.insert(name.to_string(), value.clone());
-        }
+    let project_toml = working_dir.join(".runa").join("project.toml");
+    if project_toml.exists() {
+        let payload = libagent::resolve_project_payload(&project_toml).unwrap_or_else(|error| {
+            panic!(
+                "failed to validate forge address payload from {} before emission: {error}",
+                project_toml.display()
+            )
+        });
+        env.insert("RUNA_FORGE_ADDRESSES".to_string(), payload.to_string());
     }
 
     env
@@ -894,7 +890,7 @@ fn run_internal(
         let config = crate::project::read_config(working_dir, config_override)
             .map_err(CommandError::from)
             .map_err(StepError::from)?;
-        let command = config.agent.command.filter(|command| {
+        let command = config.runtime.command.filter(|command| {
             !command.is_empty() && !command.first().is_some_and(|part| part.is_empty())
         });
         if command.is_none() {
@@ -1720,23 +1716,40 @@ cat >/dev/null
     }
 
     #[test]
-    fn resolved_runtime_env_materializes_default_github_forge_type_from_config_identity() {
+    fn resolved_runtime_env_materializes_valid_forge_address_payload_from_project_topology() {
         let _lock = transcript_env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let _env = EnvGuard::unset(&[
-            "RUNA_FORGE_TYPE",
-            "RUNA_FORGE_OWNER",
-            "RUNA_FORGE_NAME",
-            "RUNA_FORGE_TRACKER_ID",
-            "RUNA_TRANSCRIPT_DIR",
-            "RUNA_TRANSCRIPT_REDACT_ENV",
-        ]);
+        let _env = EnvGuard::unset(&["RUNA_TRANSCRIPT_DIR", "RUNA_TRANSCRIPT_REDACT_ENV"]);
         let temp = tempfile::tempdir().unwrap();
+        let runa_dir = temp.path().join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("project.toml"),
+            r#"
+[[forge.instances]]
+name = "github"
+type = "github"
+host = "github.example.com"
+
+[[forge.repositories]]
+name = "runa"
+instance = "github"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github"
+repository = "runa"
+"#,
+        )
+        .unwrap();
         let config = libagent::Config {
             methodology_path: "methodology.toml".to_string(),
             logging: libagent::LoggingConfig::default(),
-            agent: libagent::project::AgentConfig::default(),
+            runtime: libagent::project::RuntimeConfig::default(),
             transcript: libagent::TranscriptConfig::default(),
             forge: libagent::ForgeConfig {
                 forge_type: None,
@@ -1748,16 +1761,22 @@ cat >/dev/null
 
         let env = resolved_runtime_env(temp.path(), &config);
 
-        assert_eq!(env.get("RUNA_FORGE_TYPE"), Some(&"github".to_string()));
-        assert_eq!(env.get("RUNA_FORGE_OWNER"), Some(&"tesserine".to_string()));
-        assert_eq!(env.get("RUNA_FORGE_NAME"), Some(&"runa".to_string()));
+        let payload: serde_json::Value =
+            serde_json::from_str(env.get("RUNA_FORGE_ADDRESSES").unwrap()).unwrap();
+        assert_eq!(
+            payload["trackers"][0]["identity"],
+            "github:github.example.com/tesserine/runa"
+        );
+        libagent::validate_forge_address(&payload).unwrap();
     }
 
     #[test]
     fn build_mcp_config_includes_supplied_runtime_environment() {
         let runtime_env = BTreeMap::from([
-            ("RUNA_FORGE_OWNER".to_string(), "tesserine".to_string()),
-            ("RUNA_FORGE_NAME".to_string(), "runa".to_string()),
+            (
+                "RUNA_FORGE_ADDRESSES".to_string(),
+                r#"{"schema_version":"1.0.0","instances":[{"name":"github","type":"github","host":"github.example.com"}],"repositories":[],"trackers":[]}"#.to_string(),
+            ),
         ]);
 
         let config = build_mcp_config(
@@ -1770,10 +1789,9 @@ cat >/dev/null
         );
 
         assert_eq!(
-            config.env.get("RUNA_FORGE_OWNER"),
-            Some(&"tesserine".to_string())
+            config.env.get("RUNA_FORGE_ADDRESSES"),
+            runtime_env.get("RUNA_FORGE_ADDRESSES")
         );
-        assert_eq!(config.env.get("RUNA_FORGE_NAME"), Some(&"runa".to_string()));
     }
 
     #[test]

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -863,7 +863,7 @@ fn run_internal(
     }
 
     let (mut loaded, scan_result) = super::load_and_scan(working_dir, config_override)?;
-    super::validate_scoped_work_unit(&loaded, work_unit).map_err(StepError::from)?;
+    super::validate_scoped_work_unit(&loaded, working_dir, work_unit).map_err(StepError::from)?;
     let scope = match work_unit {
         Some(work_unit) => libagent::EvaluationScope::Scoped(work_unit),
         None => libagent::EvaluationScope::Unscoped,

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -1398,13 +1398,12 @@ mod tests {
         fs::write(
             path,
             r#"#!/bin/sh
-set -eu
-cat >/dev/null
-exec 3>"$1"
-readlink "/proc/$$/fd/1" >&3
-readlink "/proc/$$/fd/2" >&3
-exec 3>&-
-"#,
+	set -eu
+	cat >/dev/null
+	stdout_fd=$(readlink "/proc/$$/fd/1")
+	stderr_fd=$(readlink "/proc/$$/fd/2")
+	printf '%s\n%s\n' "$stdout_fd" "$stderr_fd" >"$1"
+	"#,
         )
         .unwrap();
     }

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -91,20 +91,6 @@ struct RunArgs {
     /// Open the cascade from a forge ticket reference (cold-start entry)
     #[arg(long, conflicts_with = "work_unit")]
     ticket: Option<String>,
-
-    /// Override the live agent command; pass argv after `--`, for example `--agent-command -- <argv tokens>`
-    #[arg(long = "agent-command")]
-    agent_command: bool,
-
-    /// Agent argv passed through after `--` when `--agent-command` is set
-    #[arg(
-        num_args = 0..,
-        last = true,
-        allow_hyphen_values = true,
-        requires = "agent_command",
-        value_name = "ARGV"
-    )]
-    agent_command_argv: Vec<String>,
 }
 
 fn main() {
@@ -225,8 +211,8 @@ fn main() {
                 args.json,
                 args.work_unit.as_deref(),
                 args.ticket.as_deref(),
-                args.agent_command,
-                &args.agent_command_argv,
+                false,
+                &[],
             ) {
                 Ok(outcome) => {
                     let exit_code = outcome.exit_code();

--- a/runa-cli/tests/common/mod.rs
+++ b/runa-cli/tests/common/mod.rs
@@ -71,17 +71,33 @@ pub fn scoped_work_unit_schemas() -> &'static [(&'static str, &'static str)] {
 #[allow(dead_code)]
 pub fn github_work_unit_json(number: u64) -> String {
     format!(
-        r#"{{"title":"Scope","description":"Enforce canonical scope","acceptance_criteria":["Reject aliases"],"handle":{{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/{number}","number":{number}}}}}"#
+        r#"{{"title":"Scope","description":"Enforce canonical scope","acceptance_criteria":["Reject aliases"],"handle":{{"tracker":"runa","tracker_identity":"github:github.com/tesserine/runa","work_unit_identity":"github:github.com/tesserine/runa#{number}","number":{number}}}}}"#
     )
 }
 
 #[allow(dead_code)]
 pub fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     fs::write(
-        project_dir.join(".runa/config.toml"),
+        project_dir.join(".runa/project.toml"),
         format!(
-            "{}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\n",
-            fs::read_to_string(project_dir.join(".runa/config.toml")).unwrap()
+            r#"
+[[forge.instances]]
+name = "github"
+type = "github"
+host = "github.com"
+
+[[forge.repositories]]
+name = "{name}"
+instance = "github"
+owner = "{owner}"
+repository = "{name}"
+
+[[forge.trackers]]
+name = "{name}"
+type = "github"
+instance = "github"
+repository = "{name}"
+"#
         ),
     )
     .unwrap();

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -221,12 +221,12 @@ payload=$(cat)
 case "$payload" in
   *"# Protocol: decompose"*)
     case "$payload" in
-      *"## Session entry"*"github:tesserine/runa#14"*) : ;;
+      *"## Session entry"*"github:github.com/tesserine/runa#14"*) : ;;
       *) printf '%s\n' "$payload" > "$log_file.no-entry"; exit 23 ;;
     esac
     printf 'decompose\n' >> "$log_file"
     mkdir -p .runa/workspace/work-unit
-    printf '%s\n' '{"title":"Cold start","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}' > .runa/workspace/work-unit/work-unit-14-cold-start.json
+    printf '%s\n' '{"title":"Cold start","handle":{"tracker":"runa","tracker_identity":"github:github.com/tesserine/runa","work_unit_identity":"github:github.com/tesserine/runa#14","number":14}}' > .runa/workspace/work-unit/work-unit-14-cold-start.json
     ;;
   *"# Protocol: take"*)
     printf 'take\n' >> "$log_file"
@@ -259,7 +259,7 @@ case "$payload" in
   *"# Protocol: decompose"*)
     printf 'decompose\n' >> "$log_file"
     mkdir -p .runa/workspace/work-unit
-    printf '%s\n' '{"title":"Other","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/99","number":99}}' > .runa/workspace/work-unit/work-unit-99-other.json
+    printf '%s\n' '{"title":"Other","handle":{"tracker":"runa","tracker_identity":"github:github.com/tesserine/runa","work_unit_identity":"github:github.com/tesserine/runa#99","number":99}}' > .runa/workspace/work-unit/work-unit-99-other.json
     ;;
   *)
     printf '%s\n' "$payload" > "$log_file.unexpected"
@@ -283,7 +283,7 @@ fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
         .join("\n");
     fs::write(
         config_path,
-        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+        format!("{existing}\n[runtime]\ncommand = [\n{command_entries}\n]\n"),
     )
     .unwrap();
 }
@@ -310,7 +310,10 @@ fn run_ticket_dry_run_projects_acquisition_then_take() {
     );
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["version"], 3, "{value:#}");
-    assert_eq!(value["entry"]["reference"], "github:tesserine/runa#14");
+    assert_eq!(
+        value["entry"]["reference"],
+        "github:github.com/tesserine/runa#14"
+    );
     assert_eq!(value["entry"]["ticket_number"], 14);
     assert_eq!(value["entry"]["acquisition_protocol"], "decompose");
 
@@ -321,7 +324,7 @@ fn run_ticket_dry_run_projects_acquisition_then_take() {
     // The acquisition step carries the entry reference in its context.
     assert_eq!(
         plan[0]["context"]["entry"]["reference"],
-        "github:tesserine/runa#14"
+        "github:github.com/tesserine/runa#14"
     );
     assert_eq!(plan[1]["protocol"], "take");
     assert_eq!(plan[1]["projection"], "projected");
@@ -778,7 +781,7 @@ fn taint_work_unit_scan(project_dir: &Path) {
     let unreadable = wu_dir.join("hidden.json");
     fs::write(
         &unreadable,
-        r#"{"title":"hidden","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}"#,
+        r#"{"title":"hidden","handle":{"tracker":"runa","tracker_identity":"github:github.com/tesserine/runa","work_unit_identity":"github:github.com/tesserine/runa#14","number":14}}"#,
     )
     .unwrap();
     fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
@@ -894,7 +897,7 @@ set -eu
     printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"entry-test","version":"1.0.0"}}}'
     printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
     printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"next-protocol-context","arguments":{}}}'
-    printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"work-unit","arguments":{"instance_id":"work-unit-14-cold-start","title":"Cold start","handle":{"forge_tag":"github","url":"https://github.com/tesserine/runa/issues/14","number":14}}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"work-unit","arguments":{"instance_id":"work-unit-14-cold-start","title":"Cold start","handle":{"tracker":"runa","tracker_identity":"github:github.com/tesserine/runa","work_unit_identity":"github:github.com/tesserine/runa#14","number":14}}}}'
     printf '%s\n' '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"advance","arguments":{}}}'
     sleep 1
 } | "$1" --session --ticket '#14' > "$2"
@@ -927,7 +930,7 @@ fi
     // session binds — advance reports `take` as the next step.
     assert!(transcript.contains("## Session entry"), "{transcript}");
     assert!(
-        transcript.contains("github:tesserine/runa#14"),
+        transcript.contains("github:github.com/tesserine/runa#14"),
         "{transcript}"
     );
     // advance reports `take` as the bound next step.

--- a/runa-cli/tests/go.rs
+++ b/runa-cli/tests/go.rs
@@ -33,7 +33,7 @@ fn init_project(project_dir: &Path, manifest_path: &Path) {
 fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
     let config_path = project_dir.join(".runa/config.toml");
     let mut config = fs::read_to_string(&config_path).unwrap();
-    config.push_str("\n[agent]\ncommand = [");
+    config.push_str("\n[runtime]\ncommand = [");
     for (index, part) in command.iter().enumerate() {
         if index > 0 {
             config.push_str(", ");

--- a/runa-cli/tests/run.rs
+++ b/runa-cli/tests/run.rs
@@ -460,7 +460,7 @@ fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
         .join("\n");
     fs::write(
         config_path,
-        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+        format!("{existing}\n[runtime]\ncommand = [\n{command_entries}\n]\n"),
     )
     .unwrap();
 }
@@ -469,16 +469,6 @@ fn write_single_protocol_agent(dir: &Path) -> PathBuf {
     fs::write(
         &script_path,
         "#!/bin/sh\nlog_file=\"$1\"\npayload=$(cat)\ncase \"$payload\" in\n  *\"# Protocol: implement\"*)\n    printf 'implement\\n' >> \"$log_file\"\n    mkdir -p .runa/workspace/implementation\n    printf '%s\\n' '{\"done\":true}' > .runa/workspace/implementation/impl-1.json\n    ;;\n  *)\n    printf '%s\\n' \"$payload\" > \"$log_file.unexpected\"\n    exit 19\n    ;;\nesac\n",
-    )
-    .unwrap();
-    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
-    script_path
-}
-fn write_arg_logging_single_protocol_agent(dir: &Path) -> PathBuf {
-    let script_path = dir.join("arg-logging-single-protocol-agent.sh");
-    fs::write(
-        &script_path,
-        "#!/bin/sh\nlog_file=\"$1\"\nargs_file=\"$2\"\nshift 2\nprintf '%s\\n' \"$@\" > \"$args_file\"\npayload=$(cat)\ncase \"$payload\" in\n  *\"# Protocol: implement\"*)\n    printf 'implement\\n' >> \"$log_file\"\n    mkdir -p .runa/workspace/implementation\n    printf '%s\\n' '{\"done\":true}' > .runa/workspace/implementation/impl-1.json\n    ;;\n  *)\n    printf '%s\\n' \"$payload\" > \"$log_file.unexpected\"\n    exit 19\n    ;;\nesac\n",
     )
     .unwrap();
     fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
@@ -663,154 +653,7 @@ trigger = { type = "on_artifact", name = "constraints" }
     assert!(workspace.join("implementation/impl-1.json").is_file());
 }
 #[test]
-fn run_without_dry_run_cli_agent_command_overrides_configured_agent_command() {
-    let dir = tempfile::tempdir().unwrap();
-    let bool_schema =
-        r#"{"type":"object","required":["done"],"properties":{"done":{"type":"boolean"}}}"#;
-    let manifest_path = common::write_methodology(
-        dir.path(),
-        r#"
-name = "groundwork"
-
-[[artifact_types]]
-name = "constraints"
-
-[[artifact_types]]
-name = "implementation"
-
-[[protocols]]
-name = "implement"
-requires = ["constraints"]
-produces = ["implementation"]
-trigger = { type = "on_artifact", name = "constraints" }
-"#,
-        &[
-            (
-                "constraints",
-                r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
-            ),
-            ("implementation", bool_schema),
-        ],
-        &["implement"],
-    );
-
-    let project_dir = dir.path().join("project");
-    fs::create_dir(&project_dir).unwrap();
-    init_project(&project_dir, &manifest_path);
-
-    let workspace = project_dir.join(".runa/workspace");
-    fs::create_dir_all(workspace.join("constraints")).unwrap();
-    fs::write(
-        workspace.join("constraints/spec-1.json"),
-        r#"{"title":"ship run"}"#,
-    )
-    .unwrap();
-
-    let config_log_path = dir.path().join("configured.log");
-    let cli_log_path = dir.path().join("cli.log");
-    let configured_agent = write_single_protocol_agent(dir.path());
-    let cli_agent = write_single_protocol_agent(dir.path());
-    append_agent_command_config(
-        &project_dir,
-        &[configured_agent.as_path(), config_log_path.as_path()],
-    );
-
-    let output = runa_bin()
-        .arg("run")
-        .arg("--agent-command")
-        .arg("--")
-        .arg(&cli_agent)
-        .arg(&cli_log_path)
-        .current_dir(&project_dir)
-        .output()
-        .unwrap();
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let cli_executed = fs::read_to_string(&cli_log_path).unwrap();
-    assert_eq!(cli_executed, "implement\n");
-    assert!(!config_log_path.exists(), "configured agent should not run");
-    assert!(workspace.join("implementation/impl-1.json").is_file());
-}
-#[test]
-fn run_without_dry_run_cli_agent_command_preserves_hyphenated_tokens() {
-    let dir = tempfile::tempdir().unwrap();
-    let bool_schema =
-        r#"{"type":"object","required":["done"],"properties":{"done":{"type":"boolean"}}}"#;
-    let manifest_path = common::write_methodology(
-        dir.path(),
-        r#"
-name = "groundwork"
-
-[[artifact_types]]
-name = "constraints"
-
-[[artifact_types]]
-name = "implementation"
-
-[[protocols]]
-name = "implement"
-requires = ["constraints"]
-produces = ["implementation"]
-trigger = { type = "on_artifact", name = "constraints" }
-"#,
-        &[
-            (
-                "constraints",
-                r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
-            ),
-            ("implementation", bool_schema),
-        ],
-        &["implement"],
-    );
-
-    let project_dir = dir.path().join("project");
-    fs::create_dir(&project_dir).unwrap();
-    init_project(&project_dir, &manifest_path);
-
-    let workspace = project_dir.join(".runa/workspace");
-    fs::create_dir_all(workspace.join("constraints")).unwrap();
-    fs::write(
-        workspace.join("constraints/spec-1.json"),
-        r#"{"title":"ship run"}"#,
-    )
-    .unwrap();
-
-    let log_path = dir.path().join("executed.log");
-    let args_path = dir.path().join("argv.log");
-    let agent_path = write_arg_logging_single_protocol_agent(dir.path());
-
-    let output = runa_bin()
-        .arg("run")
-        .arg("--agent-command")
-        .arg("--")
-        .arg(&agent_path)
-        .arg(&log_path)
-        .arg(&args_path)
-        .arg("--dangerously-skip-permissions")
-        .arg("-p")
-        .current_dir(&project_dir)
-        .output()
-        .unwrap();
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let argv = fs::read_to_string(&args_path).unwrap();
-    assert_eq!(argv, "--dangerously-skip-permissions\n-p\n");
-    let executed = fs::read_to_string(&log_path).unwrap();
-    assert_eq!(executed, "implement\n");
-    assert!(workspace.join("implementation/impl-1.json").is_file());
-}
-#[test]
-fn run_without_dry_run_rejects_empty_cli_agent_command_even_when_configured() {
+fn run_rejects_removed_agent_command_flag_even_when_runtime_command_is_configured() {
     let dir = tempfile::tempdir().unwrap();
     let bool_schema =
         r#"{"type":"object","required":["done"],"properties":{"done":{"type":"boolean"}}}"#;
@@ -868,12 +711,9 @@ trigger = { type = "on_artifact", name = "constraints" }
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(6), "{output:?}");
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("no agent command configured"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("unexpected argument"), "stderr: {stderr}");
     assert!(!config_log_path.exists(), "configured agent should not run");
     assert!(!workspace.join("implementation/impl-1.json").exists());
 }
@@ -944,11 +784,11 @@ fn run_help_describes_agent_command_passthrough() {
     assert!(output.status.success(), "{output:?}");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Usage: runa run [OPTIONS] [-- [ARGV]...]"),
+        stdout.contains("Usage: runa run [OPTIONS]"),
         "stdout: {stdout}"
     );
-    assert!(stdout.contains("--agent-command"), "stdout: {stdout}");
-    assert!(stdout.contains("-- <argv"), "stdout: {stdout}");
+    assert!(!stdout.contains("--agent-command"), "stdout: {stdout}");
+    assert!(!stdout.contains("-- <argv"), "stdout: {stdout}");
     assert!(
         !stdout.contains("Usage: runa run [OPTIONS] [ARGV]..."),
         "stdout: {stdout}"
@@ -1014,10 +854,6 @@ trigger = { type = "on_artifact", name = "constraints" }
     assert_eq!(output.status.code(), Some(2), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unexpected argument"), "stderr: {stderr}");
-    assert!(
-        stderr.contains(agent_path.to_string_lossy().as_ref()),
-        "stderr: {stderr}"
-    );
     assert!(!log_path.exists(), "agent should not run");
     assert!(!workspace.join("implementation/impl-1.json").exists());
 }
@@ -1082,10 +918,6 @@ trigger = { type = "on_artifact", name = "constraints" }
     assert_eq!(output.status.code(), Some(2), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unexpected argument"), "stderr: {stderr}");
-    assert!(
-        stderr.contains(agent_path.to_string_lossy().as_ref()),
-        "stderr: {stderr}"
-    );
     assert!(!log_path.exists(), "agent should not run");
     assert!(!workspace.join("implementation/impl-1.json").exists());
 }
@@ -1610,7 +1442,7 @@ fn run_without_dry_run_with_no_ready_protocols_still_requires_agent_command() {
     );
 }
 #[test]
-fn run_without_dry_run_rejects_empty_cli_agent_command_when_no_protocols_are_ready() {
+fn run_rejects_removed_agent_command_flag_before_checking_ready_work() {
     let (dir, project_dir) = setup_quiescent_run_project();
     let config_log_path = dir.path().join("configured.log");
     let agent_path = write_single_protocol_agent(dir.path());
@@ -1627,12 +1459,9 @@ fn run_without_dry_run_rejects_empty_cli_agent_command_when_no_protocols_are_rea
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(6), "{output:?}");
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("no agent command configured"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("unexpected argument"), "stderr: {stderr}");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Run outcome: nothing_ready"),

--- a/runa-cli/tests/step.rs
+++ b/runa-cli/tests/step.rs
@@ -437,7 +437,7 @@ fn append_agent_command_config(project_dir: &Path, command: &[&Path]) {
         .join("\n");
     fs::write(
         config_path,
-        format!("{existing}\n[agent]\ncommand = [\n{command_entries}\n]\n"),
+        format!("{existing}\n[runtime]\ncommand = [\n{command_entries}\n]\n"),
     )
     .unwrap();
 }
@@ -460,13 +460,48 @@ fn append_transcript_config(project_dir: &Path, transcript_dir: &Path, redact_en
 }
 
 fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
-    let config_path = project_dir.join(".runa/config.toml");
-    let existing = fs::read_to_string(&config_path).unwrap();
     fs::write(
-        config_path,
-        format!("{existing}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\n"),
+        project_dir.join(".runa/project.toml"),
+        format!(
+            r#"
+[[forge.instances]]
+name = "github"
+type = "github"
+host = "github.com"
+
+[[forge.repositories]]
+name = "{name}"
+instance = "github"
+owner = "{owner}"
+repository = "{name}"
+
+[[forge.trackers]]
+name = "{name}"
+type = "github"
+instance = "github"
+repository = "{name}"
+"#
+        ),
     )
     .unwrap();
+}
+
+fn assert_mcp_env_has_project_paths_only(env: &serde_json::Value, project_dir: &Path) {
+    assert_eq!(
+        env["RUNA_CONFIG"],
+        serde_json::Value::String(
+            project_dir
+                .join(".runa/config.toml")
+                .to_string_lossy()
+                .to_string()
+        )
+    );
+    assert_eq!(
+        env["RUNA_WORKING_DIR"],
+        serde_json::Value::String(project_dir.to_string_lossy().to_string())
+    );
+    assert!(env.get("RUNA_FORGE_ADDRESSES").is_none(), "{env}");
+    assert_eq!(env.as_object().unwrap().len(), 2);
 }
 
 fn transcript_event_files(root: &Path) -> Vec<std::path::PathBuf> {
@@ -706,14 +741,7 @@ fn step_dry_run_json_reports_ready_execution_plan_and_full_skill_status() {
         execution_plan[0]["mcp_config"]["args"],
         serde_json::json!(["--protocol", "implement"])
     );
-    assert_eq!(
-        execution_plan[0]["mcp_config"]["env"],
-        serde_json::json!({
-            "RUNA_FORGE_TYPE": "github",
-            "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
-            "RUNA_WORKING_DIR": project_dir
-        })
-    );
+    assert_mcp_env_has_project_paths_only(&execution_plan[0]["mcp_config"]["env"], &project_dir);
     let mcp_command = execution_plan[0]["mcp_config"]["command"]
         .as_str()
         .expect("mcp command should be a string");
@@ -1084,7 +1112,7 @@ fn step_without_dry_run_fails_when_agent_command_is_not_configured() {
         stderr.contains("no agent command configured"),
         "stderr: {stderr}"
     );
-    assert!(stderr.contains("[agent]"), "stderr: {stderr}");
+    assert!(stderr.contains("[runtime]"), "stderr: {stderr}");
     assert!(stderr.contains("config.toml"), "stderr: {stderr}");
 }
 #[test]
@@ -1180,14 +1208,7 @@ fn step_without_dry_run_invokes_configured_agent_with_execution_prompt() {
         mcp_config["args"],
         serde_json::json!(["--protocol", "implement"])
     );
-    assert_eq!(
-        mcp_config["env"],
-        serde_json::json!({
-            "RUNA_FORGE_TYPE": "github",
-            "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
-            "RUNA_WORKING_DIR": project_dir
-        })
-    );
+    assert_mcp_env_has_project_paths_only(&mcp_config["env"], &project_dir);
 }
 #[test]
 fn step_without_dry_run_launches_claude_named_agent_agnostically() {
@@ -1243,14 +1264,7 @@ fn step_without_dry_run_launches_claude_named_agent_agnostically() {
         mcp_config["args"],
         serde_json::json!(["--protocol", "implement"])
     );
-    assert_eq!(
-        mcp_config["env"],
-        serde_json::json!({
-            "RUNA_FORGE_TYPE": "github",
-            "RUNA_CONFIG": project_dir.join(".runa/config.toml"),
-            "RUNA_WORKING_DIR": project_dir
-        })
-    );
+    assert_mcp_env_has_project_paths_only(&mcp_config["env"], &project_dir);
     let mcp_command = mcp_config["command"]
         .as_str()
         .expect("mcp command should be a string");

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -68,7 +68,7 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     apply_transcript_settings(&working_dir, &loaded.config);
     libagent::scan(&loaded.workspace_dir, &mut loaded.store)?;
     if let Some(work_unit) = cli.work_unit.as_deref() {
-        let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+        let identity = libagent::resolve_scoped_forge_identity(&working_dir, &loaded.config.forge);
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     if cli.session {

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -266,11 +266,28 @@ fn init_project(project_dir: &Path, manifest_path: &Path) {
 }
 
 fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
-    let config_path = project_dir.join(".runa/config.toml");
-    let existing = fs::read_to_string(&config_path).unwrap();
     fs::write(
-        config_path,
-        format!("{existing}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\n"),
+        project_dir.join(".runa/project.toml"),
+        format!(
+            r#"
+[[forge.instances]]
+name = "github"
+type = "github"
+host = "github.com"
+
+[[forge.repositories]]
+name = "{name}"
+instance = "github"
+owner = "{owner}"
+repository = "{name}"
+
+[[forge.trackers]]
+name = "{name}"
+type = "github"
+instance = "github"
+repository = "{name}"
+"#
+        ),
     )
     .unwrap();
 }


### PR DESCRIPTION
## Summary

Defines runa as the authoritative home for the forge-address contract delivered for tesserine/runa#199.

- Adds `contracts/forge-address/forge-address.schema.json` and conformance fixtures for the address payload and work-unit handle.
- Derives `RUNA_FORGE_ADDRESSES` from `.runa/project.toml`, validates it before emission, and rejects legacy `[agent]`, `[forge]`, and `--agent-command` surfaces.
- Keeps identity generation in runa and updates ticket-entry/session handling to distinguish tracker identity from work-unit identity.
- Updates docs and tests for `[runtime]`, `.runa/project.toml`, and the single payload environment surface.

## Coordinated Landing

This PR must land with tesserine/groundwork#423. Groundwork consumes this schema surface and pins its derived copy to commit `4334e53aed9826ed250eabeec8c1a423dcebdf8a`; landing only this PR breaks the consumer until the paired groundwork change lands.

## Verification

- `cargo fmt --all`
- `cargo test --workspace`
