### PR TITLE
runa#203: add forge capability connector surface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,13 +163,13 @@ output-tool surface.
 
 ### `handler.rs`
 
-`ServerHandler` implementation. `RunaHandler` derives one MCP tool per output artifact type (`produces` + required output choice members + viable `may_produce`), with tool input schemas derived from artifact type JSON Schemas (with `work_unit` stripped). `validate_protocol_scope` rejects scoped protocols without `--work-unit` and unscoped protocols with one. `validate_output_types` remains a defense-in-depth guard for required output schemas unsupported by MCP tool generation, while sharing the same unscoped-output `work_unit` predicate used by manifest parsing. In fixed-protocol mode, `call_tool` validates artifacts before writing, then writes to the workspace and records in the store. In session mode, the handler also exposes `readiness`, `next-protocol-context`, and `advance`; output tools always derive from the current step, and any declared output type for that step that collides with a reserved driver name is refused before the step is entered.
+`ServerHandler` implementation. `RunaHandler` derives one MCP tool per output artifact type (`produces` + required output choice members + viable `may_produce`), with tool input schemas derived from artifact type JSON Schemas (with `work_unit` stripped). Configured forge connectors contribute the forge-capability v1.1.0 operation tools to the same composed MCP registry, where role-qualified aliases resolve exposed names and collisions are refused. `validate_protocol_scope` rejects scoped protocols without `--work-unit` and unscoped protocols with one. `validate_output_types` remains a defense-in-depth guard for required output schemas unsupported by MCP tool generation, while sharing the same unscoped-output `work_unit` predicate used by manifest parsing. In fixed-protocol mode, `call_tool` validates artifacts before writing, then writes to the workspace and records in the store. In session mode, the handler also exposes `readiness`, `next-protocol-context`, and `advance`; output tools always derive from the current step, and any declared output type for that step that collides with a reserved driver name is refused before the step is entered.
 
 ## `.runa/` Directory Layout
 
 ```
 .runa/
-  config.toml                   # Created by `runa init`: methodology_path, optional logging, agent.command, transcript, forge defaults
+  config.toml                   # Created by `runa init`: methodology_path, optional logging, agent.command, transcript, forge and connector defaults
   state.toml                    # Created by `runa init`: initialized_at, runa_version
   workspace/                    # Artifact workspace (non-configurable)
     {type_name}/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Semantic Versioning.
 
 ### Added
 
+- Forge-capability v1.1.0 connector surface for `runa-mcp`: configured GitHub
+  and SourceHut connectors advertise the eight forge operations as structured
+  MCP tools, support role-qualified aliases, and accept canonical ticket
+  reference forms through connector-only deployment config.
 - README ecosystem links corrected: commons described as the
   convention/ADR authority with principles at their canonical home
   `pentaxis93/principles` (#181), and the agentd/groundwork links moved to
@@ -77,6 +81,8 @@ Semantic Versioning.
 
 ### Changed
 
+- `runa-mcp` now builds on `rmcp` 1.7 while preserving the existing
+  driver/output artifact tool surface.
 - Durable transcript capture settings and scoped forge identity can now live in
   `.runa/config.toml`, with `RUNA_TRANSCRIPT_*` and `RUNA_FORGE_*`
   environment variables retained as per-invocation overrides. Resolved forge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,11 +211,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -285,15 +294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix",
  "windows-sys",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -301,11 +310,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -315,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -427,12 +435,6 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -619,7 +621,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -893,18 +895,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
@@ -1056,14 +1046,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1107,13 +1097,13 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
- "nix 0.30.1",
+ "nix",
  "tokio",
  "tracing",
  "windows",
@@ -1215,14 +1205,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "0.2.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
+ "async-trait",
  "base64",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
  "rmcp-macros",
@@ -1238,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.2.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1265,17 +1256,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "runa-forge"
+version = "0.2.0-rc.1"
+dependencies = [
+ "jsonschema",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-connectors"
+version = "0.2.0-rc.1"
+dependencies = [
+ "libagent",
+ "runa-forge",
+ "runa-forge-github",
+ "runa-forge-sourcehut",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-github"
+version = "0.2.0-rc.1"
+dependencies = [
+ "runa-forge",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-sourcehut"
+version = "0.2.0-rc.1"
+dependencies = [
+ "runa-forge",
+ "serde_json",
+]
+
+[[package]]
 name = "runa-mcp"
 version = "0.2.0-rc.1"
 dependencies = [
  "clap",
  "libagent",
  "rmcp",
+ "runa-forge",
+ "runa-forge-connectors",
+ "runa-toolset",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "runa-toolset"
+version = "0.2.0-rc.1"
+dependencies = [
+ "rmcp",
+ "serde_json",
 ]
 
 [[package]]
@@ -1299,12 +1337,13 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1312,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1865,37 +1904,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1906,19 +1931,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -1946,33 +1971,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -1981,16 +1991,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1999,7 +2000,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2008,16 +2009,16 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,14 @@
 [workspace]
-members = ["runa-cli", "libagent", "runa-mcp"]
+members = [
+    "runa-cli",
+    "libagent",
+    "runa-mcp",
+    "runa-toolset",
+    "runa-forge",
+    "runa-forge-github",
+    "runa-forge-sourcehut",
+    "runa-forge-connectors",
+]
 resolver = "3"
 
 [workspace.package]
@@ -16,9 +25,14 @@ tempfile = "3"
 jsonschema = { version = "0.45", default-features = false }
 toml = "0.8"
 sha2 = "0.10"
-rmcp = { version = "0.2", features = ["transport-io", "server"] }
+rmcp = { version = "1.7", features = ["transport-io", "server"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 ctrlc = "3.4"
 libc = "0.2"
+runa-toolset = { path = "runa-toolset" }
+runa-forge = { path = "runa-forge" }
+runa-forge-github = { path = "runa-forge-github" }
+runa-forge-sourcehut = { path = "runa-forge-sourcehut" }
+runa-forge-connectors = { path = "runa-forge-connectors" }

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ See [CLI Reference](docs/cli-reference.md) for flags, exit codes, configuration,
 
 `runa init` creates `.runa/config.toml` with the methodology path. Operators
 may also set durable project defaults there for live agent command,
-transcript capture, and scoped forge identity. Environment variables such as
-`RUNA_TRANSCRIPT_DIR` and `RUNA_FORGE_*` remain per-invocation overrides;
-config is the project-local default.
+transcript capture, scoped forge identity, and forge connector MCP tools.
+Environment variables such as `RUNA_TRANSCRIPT_DIR` and `RUNA_FORGE_*` remain
+per-invocation overrides; config is the project-local default.
 
 Runa ships supported agent adapters for Codex and Claude Code in `adapters/`.
 Set `[agent].command` to `./adapters/agent-codex.sh` or

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,6 +28,17 @@ type = "github"
 owner = "tesserine"
 name = "runa"
 tracker_id = "4"
+
+[connectors.forge]
+provider = "github"
+
+[connectors.forge.github]
+owner = "tesserine"
+name = "runa"
+credential = { env = "GITHUB_TOKEN" }
+
+[mcp.tool_aliases]
+"forge/read-ticket" = "forge-read-ticket"
 ```
 
 `[transcript].dir` enables transcript capture and is resolved relative to the
@@ -44,6 +55,16 @@ it when validating tracker-backed `work-unit` roots and injects the resolved
 Any non-empty matching `RUNA_FORGE_*` environment variable overrides the
 configured field for that invocation. The forge type still defaults to `github`
 when neither config nor env specifies one.
+
+`[connectors.forge]` enables forge-capability MCP tools for the selected
+provider. The `github` provider requires `owner` and `name`; the `sourcehut`
+provider requires `tracker_id` and `endpoint`. Connector credentials may point
+at an environment variable or command and are resolved only by the connector
+operation that needs them. When `[forge]` is absent, connector scope also
+supplies the deployment identity for `--work-unit` validation and
+`--ticket` reference parsing. `[mcp.tool_aliases]` maps role-qualified tool
+names such as `forge/read-ticket` to exposed MCP names such as
+`forge-read-ticket`.
 
 ### Logging
 
@@ -363,9 +384,9 @@ runa-mcp --protocol <name> [--work-unit <name>]
 runa-mcp --session (--work-unit <name> | --ticket <ref>)
 ```
 
-In fixed-protocol mode, the server loads the project, scans the workspace, resolves the named protocol from the manifest, validates that its declared scope matches the presence or absence of `--work-unit`, validates canonical `work-unit` identity for scoped sessions, validates that its required output types can be served as MCP tools, and serves that protocol's output tools over stdio. Each output artifact type (`produces`, required output choice members, and viable `may_produce`) becomes one MCP tool. The tool input schema is the artifact type's JSON Schema with the `work_unit` field removed — the server injects `work_unit` automatically from the `--work-unit` argument.
+In fixed-protocol mode, the server loads the project, scans the workspace, resolves the named protocol from the manifest, validates that its declared scope matches the presence or absence of `--work-unit`, validates canonical `work-unit` identity for scoped sessions, validates that its required output types can be served as MCP tools, and serves that protocol's output tools over stdio. Each output artifact type (`produces`, required output choice members, and viable `may_produce`) becomes one MCP tool. The tool input schema is the artifact type's JSON Schema with the `work_unit` field removed — the server injects `work_unit` automatically from the `--work-unit` argument. When a forge connector is configured, the server also advertises the eight forge-capability v1.1.0 operations as structured-output tools, composed through the same alias/collision rules.
 
-In session mode, the server serves one scoped work-unit session in a single MCP connection, opened either with `--work-unit <name>` (a recorded work-unit) or `--ticket <ref>` (a forge ticket reference for cold-start entry). With `--ticket`, the session begins in a promised scope serving the methodology's acquisition surface; once the agent materializes the `work-unit`, `advance` binds the session to it and the tool list flips to the bound step's tools. The runtime resolves the reference to an identity only and performs no forge read. The tool list always includes the driver tools `readiness`, `next-protocol-context`, and `advance`, plus the output tools for the current ready step. A current step is refused if any declared output type for that step would collide with one of those reserved driver tool names. Every driver verb rescans and revalidates the scoped work-unit identity before reporting, serving, or advancing. `readiness` reports the same status classification as `runa state` for the session scope, and selects the first non-exhausted ready step when the session has no current step. `next-protocol-context` verifies that the current step still satisfies readiness authority for its trigger and preconditions, and returns both the structured context and rendered prompt for the current step without advancing it. `advance` verifies that the current step still satisfies readiness authority for its trigger and preconditions, enforces postconditions for the current step, uses staged execution metadata to select and validate the next ready step, and only then persists that metadata and advances the session. Any driver verb that changes the current step emits `notifications/tools/list_changed` so caching MCP clients can rediscover the current step's output tools. Output tools validate and write artifacts exactly as in fixed-protocol mode; recording an output does not advance the session.
+In session mode, the server serves one scoped work-unit session in a single MCP connection, opened either with `--work-unit <name>` (a recorded work-unit) or `--ticket <ref>` (a forge ticket reference for cold-start entry). With `--ticket`, the session begins in a promised scope serving the methodology's acquisition surface; once the agent materializes the `work-unit`, `advance` binds the session to it and the tool list flips to the bound step's tools. The runtime resolves the reference to an identity only and performs no forge read. The tool list always includes the driver tools `readiness`, `next-protocol-context`, and `advance`, plus the output tools for the current ready step and any configured forge connector tools. A current step is refused if any declared output type for that step would collide with one of those reserved driver tool names. Every driver verb rescans and revalidates the scoped work-unit identity before reporting, serving, or advancing. `readiness` reports the same status classification as `runa state` for the session scope, and selects the first non-exhausted ready step when the session has no current step. `next-protocol-context` verifies that the current step still satisfies readiness authority for its trigger and preconditions, and returns both the structured context and rendered prompt for the current step without advancing it. `advance` verifies that the current step still satisfies readiness authority for its trigger and preconditions, enforces postconditions for the current step, uses staged execution metadata to select and validate the next ready step, and only then persists that metadata and advances the session. Any driver verb that changes the current step emits `notifications/tools/list_changed` so caching MCP clients can rediscover the current step's output tools. Output tools validate and write artifacts exactly as in fixed-protocol mode; recording an output does not advance the session.
 
 `runa step` currently continues to use fixed-protocol mode. `runa go` uses
 session mode. Neither command spawns `runa-mcp` directly. Before launching the

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -67,8 +67,9 @@ pub use scan::{
 };
 pub use scoped_identity::{
     ResolvedForgeIdentity, ScopedWorkUnitError, find_work_unit_by_tracker_identity,
-    resolve_forge_environment, resolve_forge_identity, validate_scoped_work_unit,
-    validate_scoped_work_unit_with_identity, validate_tracker_consistency,
+    resolve_forge_environment, resolve_forge_identity, resolve_project_forge_identity,
+    validate_scoped_work_unit, validate_scoped_work_unit_with_identity,
+    validate_tracker_consistency,
 };
 pub use selection::{
     Candidate, CandidateKey, CandidateStatus, ClassifiedCandidate, EvaluationScope,

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -4,6 +4,7 @@
 //! manifest, builds the dependency graph, and initializes the artifact store.
 //! See [`load`] for the main entry point.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -88,6 +89,92 @@ impl ForgeConfig {
     }
 }
 
+/// Credential lookup for connector-backed integrations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConnectorCredentialConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+}
+
+/// GitHub forge connector configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GithubForgeConnectorConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_remote: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential: Option<ConnectorCredentialConfig>,
+}
+
+/// SourceHut forge connector configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SourcehutForgeConnectorConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracker_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee_user_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential: Option<ConnectorCredentialConfig>,
+}
+
+/// Forge connector selection and provider-specific configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ForgeConnectorsConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github: Option<GithubForgeConnectorConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sourcehut: Option<SourcehutForgeConnectorConfig>,
+}
+
+impl ForgeConnectorsConfig {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+/// Optional connector configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConnectorsConfig {
+    #[serde(default, skip_serializing_if = "ForgeConnectorsConfig::is_default")]
+    pub forge: ForgeConnectorsConfig,
+}
+
+impl ConnectorsConfig {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+/// MCP server-specific configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct McpConfig {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub tool_aliases: HashMap<String, String>,
+}
+
+impl McpConfig {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
 /// On-disk format for `.runa/config.toml` — operator configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
@@ -100,6 +187,10 @@ pub struct Config {
     pub transcript: TranscriptConfig,
     #[serde(default, skip_serializing_if = "ForgeConfig::is_default")]
     pub forge: ForgeConfig,
+    #[serde(default, skip_serializing_if = "ConnectorsConfig::is_default")]
+    pub connectors: ConnectorsConfig,
+    #[serde(default, skip_serializing_if = "McpConfig::is_default")]
+    pub mcp: McpConfig,
 }
 
 /// On-disk format for `.runa/state.toml` — initialization metadata managed by runa.
@@ -343,6 +434,8 @@ trigger = { type = "on_change", name = "constraints" }
             agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
+            connectors: ConnectorsConfig::default(),
+            mcp: McpConfig::default(),
         };
         fs::write(
             runa_dir.join("config.toml"),
@@ -406,6 +499,8 @@ trigger = { type = "on_change", name = "constraints" }
             agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
+            connectors: ConnectorsConfig::default(),
+            mcp: McpConfig::default(),
         };
         fs::write(&external_config_path, toml::to_string(&config).unwrap()).unwrap();
 
@@ -489,6 +584,8 @@ artifacts_dir = "custom-artifacts"
             agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
+            connectors: ConnectorsConfig::default(),
+            mcp: McpConfig::default(),
         };
         fs::write(
             runa_dir.join("config.toml"),
@@ -518,6 +615,62 @@ artifacts_dir = "custom-artifacts"
 
         let resolved = resolve_config(&working, Some(&override_path)).unwrap();
         assert_eq!(resolved, override_path);
+    }
+
+    #[test]
+    fn read_config_accepts_forge_connector_blocks_and_mcp_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let runa_dir = dir.path().join(".runa");
+        fs::create_dir_all(&runa_dir).unwrap();
+        fs::write(
+            runa_dir.join("config.toml"),
+            r#"
+methodology_path = "/tmp/methodology/manifest.toml"
+
+[connectors.forge]
+provider = "github"
+
+[connectors.forge.github]
+owner = "tesserine"
+name = "runa"
+api_base_url = "https://api.github.com"
+web_base_url = "https://github.com"
+git_remote = "origin"
+credential = { env = "GITHUB_TOKEN" }
+
+[connectors.forge.sourcehut]
+owner = "operator"
+name = "weforge"
+tracker_id = 4
+endpoint = "weforge.build"
+credential = { env = "WEFORGE_OPERATOR_PAT" }
+
+[mcp.tool_aliases]
+"forge/read-ticket" = "forge-read-ticket"
+"#,
+        )
+        .unwrap();
+
+        let config = read_config(dir.path(), None).unwrap();
+        assert_eq!(config.connectors.forge.provider.as_deref(), Some("github"));
+        let github = config.connectors.forge.github.as_ref().unwrap();
+        assert_eq!(github.owner.as_deref(), Some("tesserine"));
+        assert_eq!(github.name.as_deref(), Some("runa"));
+        assert_eq!(
+            github.credential.as_ref().unwrap().env.as_deref(),
+            Some("GITHUB_TOKEN")
+        );
+        let sourcehut = config.connectors.forge.sourcehut.as_ref().unwrap();
+        assert_eq!(sourcehut.tracker_id, Some(4));
+        assert_eq!(sourcehut.endpoint.as_deref(), Some("weforge.build"));
+        assert_eq!(
+            config
+                .mcp
+                .tool_aliases
+                .get("forge/read-ticket")
+                .map(String::as_str),
+            Some("forge-read-ticket")
+        );
     }
 
     #[test]
@@ -679,6 +832,8 @@ tracker_id = "4"
                 name: Some("runa".to_string()),
                 tracker_id: Some("4".to_string()),
             },
+            connectors: ConnectorsConfig::default(),
+            mcp: McpConfig::default(),
         };
 
         let serialized = toml::to_string(&config).unwrap();

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -28,7 +28,7 @@ use std::fmt;
 
 use serde_json::Value;
 
-use crate::project::ForgeConfig;
+use crate::project::{Config, ForgeConfig};
 use crate::store::{ArtifactStore, ValidationStatus};
 
 pub const RUNA_FORGE_TYPE: &str = "RUNA_FORGE_TYPE";
@@ -223,6 +223,47 @@ pub fn resolve_forge_identity(config: &ForgeConfig) -> ResolvedForgeIdentity {
         owner: resolve_atom(RUNA_FORGE_OWNER, config.owner.as_deref()),
         name: resolve_atom(RUNA_FORGE_NAME, config.name.as_deref()),
         tracker_id: resolve_atom(RUNA_FORGE_TRACKER_ID, config.tracker_id.as_deref()),
+    }
+}
+
+pub fn resolve_project_forge_identity(config: &Config) -> ResolvedForgeIdentity {
+    if forge_config_has_identity(&config.forge) {
+        return resolve_forge_identity(&config.forge);
+    }
+    let fallback = connector_forge_config(config);
+    resolve_forge_identity(&fallback)
+}
+
+fn forge_config_has_identity(config: &ForgeConfig) -> bool {
+    config.forge_type.is_some()
+        || config.owner.is_some()
+        || config.name.is_some()
+        || config.tracker_id.is_some()
+}
+
+fn connector_forge_config(config: &Config) -> ForgeConfig {
+    match config.connectors.forge.provider.as_deref() {
+        Some("github") => {
+            let github = config.connectors.forge.github.as_ref();
+            ForgeConfig {
+                forge_type: Some("github".to_string()),
+                owner: github.and_then(|github| github.owner.clone()),
+                name: github.and_then(|github| github.name.clone()),
+                tracker_id: None,
+            }
+        }
+        Some("sourcehut") => {
+            let sourcehut = config.connectors.forge.sourcehut.as_ref();
+            ForgeConfig {
+                forge_type: Some("sourcehut".to_string()),
+                owner: sourcehut.and_then(|sourcehut| sourcehut.owner.clone()),
+                name: sourcehut.and_then(|sourcehut| sourcehut.name.clone()),
+                tracker_id: sourcehut
+                    .and_then(|sourcehut| sourcehut.tracker_id)
+                    .map(|tracker_id| tracker_id.to_string()),
+            }
+        }
+        _ => config.forge.clone(),
     }
 }
 

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -315,7 +315,7 @@ impl SessionState {
         let mut loaded = crate::project::load(&working_dir, config_override)?;
         let scan_result = crate::scan(&loaded.workspace_dir, &mut loaded.store)?;
         let scan_findings = crate::collect_scan_findings(&scan_result, &loaded.workspace_dir);
-        let identity = crate::resolve_forge_identity(&loaded.config.forge);
+        let identity = crate::resolve_project_forge_identity(&loaded.config);
 
         // Resolve the promise first. Re-entry (the work-unit already exists)
         // degrades to an ordinary bound session and needs no acquisition surface;
@@ -604,7 +604,7 @@ impl SessionState {
         require_current_ready: bool,
     ) -> Result<ReconciledScan, SessionError> {
         let scan_result = self.scan_workspace()?;
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let identity = crate::resolve_project_forge_identity(&self.loaded.config);
         match &self.scope {
             SessionScope::Bound(work_unit) => {
                 crate::validate_scoped_work_unit_with_identity(
@@ -688,7 +688,7 @@ impl SessionState {
     /// work-unit ([`EntryError::Unresolved`]) or the recorded work-unit fails
     /// scoped-identity validation.
     fn bind_promise(&mut self) -> Result<(), SessionError> {
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
+        let identity = crate::resolve_project_forge_identity(&self.loaded.config);
         let ticket = match &self.scope {
             SessionScope::Promised { ticket, .. } => ticket.clone(),
             SessionScope::Bound(_) => return Ok(()),

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -4,7 +4,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::project::{
-    CONFIG_FILENAME, Config, DEFAULT_WORKSPACE_DIR, RUNA_DIR, STATE_FILENAME, STORE_DIRNAME, State,
+    CONFIG_FILENAME, Config, ConnectorsConfig, DEFAULT_WORKSPACE_DIR, McpConfig, RUNA_DIR,
+    STATE_FILENAME, STORE_DIRNAME, State,
 };
 
 #[derive(Debug)]
@@ -120,6 +121,8 @@ pub fn run(
         agent: crate::project::AgentConfig::default(),
         transcript: crate::project::TranscriptConfig::default(),
         forge: crate::project::ForgeConfig::default(),
+        connectors: ConnectorsConfig::default(),
+        mcp: McpConfig::default(),
     };
     let config_toml = toml::to_string(&config).expect("Config serialization should not fail");
 

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -1744,6 +1744,8 @@ cat >/dev/null
                 name: Some("runa".to_string()),
                 tracker_id: None,
             },
+            connectors: libagent::project::ConnectorsConfig::default(),
+            mcp: libagent::project::McpConfig::default(),
         };
 
         let env = resolved_runtime_env(temp.path(), &config);

--- a/runa-forge-connectors/Cargo.toml
+++ b/runa-forge-connectors/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "runa-forge-connectors"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+libagent.workspace = true
+runa-forge.workspace = true
+runa-forge-github.workspace = true
+runa-forge-sourcehut.workspace = true
+serde_json.workspace = true

--- a/runa-forge-connectors/src/lib.rs
+++ b/runa-forge-connectors/src/lib.rs
@@ -1,0 +1,119 @@
+//! Deployment connector registry for runa.
+
+use libagent::project::{
+    ConnectorCredentialConfig, ForgeConnectorsConfig, GithubForgeConnectorConfig,
+    SourcehutForgeConnectorConfig,
+};
+use runa_forge::{ConnectorConfig, CredentialSource, ForgeConnector, ForgeError};
+use runa_forge_github::GithubConnector;
+use runa_forge_sourcehut::SourcehutConnector;
+
+pub type DynForgeConnector = Box<dyn ForgeConnector>;
+
+pub fn configured_forge_connector(
+    config: &libagent::project::Config,
+) -> Result<Option<DynForgeConnector>, ForgeError> {
+    forge_connector_from_config(&config.connectors.forge)
+}
+
+pub fn forge_connector_from_config(
+    config: &ForgeConnectorsConfig,
+) -> Result<Option<DynForgeConnector>, ForgeError> {
+    let Some(provider) = config.provider.as_deref().filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    match provider {
+        "github" => {
+            let github = config.github.as_ref().ok_or_else(|| {
+                ForgeError::Config("connectors.forge.github is required".to_string())
+            })?;
+            Ok(Some(Box::new(GithubConnector::new(github_config(
+                github,
+            )?)?)))
+        }
+        "sourcehut" => {
+            let sourcehut = config.sourcehut.as_ref().ok_or_else(|| {
+                ForgeError::Config("connectors.forge.sourcehut is required".to_string())
+            })?;
+            Ok(Some(Box::new(SourcehutConnector::new(sourcehut_config(
+                sourcehut,
+            )?)?)))
+        }
+        other => Err(ForgeError::Config(format!(
+            "unsupported forge connector provider '{other}'"
+        ))),
+    }
+}
+
+fn github_config(config: &GithubForgeConnectorConfig) -> Result<ConnectorConfig, ForgeError> {
+    let owner = required(config.owner.as_deref(), "connectors.forge.github.owner")?;
+    let name = required(config.name.as_deref(), "connectors.forge.github.name")?;
+    let mut connector =
+        ConnectorConfig::github(owner, name, credential_source(config.credential.as_ref())?);
+    if let Some(value) = config.api_base_url.as_ref() {
+        connector
+            .extra
+            .insert("api_base_url".to_string(), value.clone());
+    }
+    if let Some(value) = config.web_base_url.as_ref() {
+        connector
+            .extra
+            .insert("web_base_url".to_string(), value.clone());
+    }
+    if let Some(value) = config.git_remote.as_ref() {
+        connector
+            .extra
+            .insert("git_remote".to_string(), value.clone());
+    }
+    Ok(connector)
+}
+
+fn sourcehut_config(config: &SourcehutForgeConnectorConfig) -> Result<ConnectorConfig, ForgeError> {
+    let owner = required(config.owner.as_deref(), "connectors.forge.sourcehut.owner")?;
+    let name = required(config.name.as_deref(), "connectors.forge.sourcehut.name")?;
+    let tracker_id = config.tracker_id.ok_or_else(|| {
+        ForgeError::Config("connectors.forge.sourcehut.tracker_id is required".to_string())
+    })?;
+    let endpoint = required(
+        config.endpoint.as_deref(),
+        "connectors.forge.sourcehut.endpoint",
+    )?;
+    let mut connector = ConnectorConfig::sourcehut(
+        owner,
+        name,
+        tracker_id,
+        endpoint,
+        credential_source(config.credential.as_ref())?,
+    );
+    if let Some(value) = config.assignee_user_id {
+        connector
+            .extra
+            .insert("assignee_user_id".to_string(), value.to_string());
+    }
+    Ok(connector)
+}
+
+fn credential_source(
+    config: Option<&ConnectorCredentialConfig>,
+) -> Result<CredentialSource, ForgeError> {
+    let Some(config) = config else {
+        return Ok(CredentialSource::None);
+    };
+    match (config.env.as_ref(), config.command.as_ref()) {
+        (Some(env), None) if !env.is_empty() => Ok(CredentialSource::Env(env.clone())),
+        (None, Some(command)) if !command.is_empty() => {
+            Ok(CredentialSource::Command(command.clone()))
+        }
+        (None, None) => Ok(CredentialSource::None),
+        _ => Err(ForgeError::Config(
+            "connector credential must specify exactly one non-empty env or command".to_string(),
+        )),
+    }
+}
+
+fn required<'a>(value: Option<&'a str>, name: &str) -> Result<&'a str, ForgeError> {
+    value
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::Config(format!("{name} is required")))
+}

--- a/runa-forge-github/Cargo.toml
+++ b/runa-forge-github/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-forge-github"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+runa-forge.workspace = true
+serde_json.workspace = true
+

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -1,0 +1,125 @@
+//! GitHub forge connector.
+
+use runa_forge::{
+    ConnectorConfig, ForgeConnector, ForgeError, Handle, Operation, handle_value, require_string,
+};
+use serde_json::{Value, json};
+
+pub struct GithubConnector {
+    config: ConnectorConfig,
+    owner: String,
+    name: String,
+}
+
+impl GithubConnector {
+    pub fn new(config: ConnectorConfig) -> Result<Self, ForgeError> {
+        if config.provider != "github" {
+            return Err(ForgeError::Config(format!(
+                "github connector cannot use provider '{}'",
+                config.provider
+            )));
+        }
+        let owner = config.required_owner()?.to_string();
+        let name = config.required_name()?.to_string();
+        Ok(Self {
+            config,
+            owner,
+            name,
+        })
+    }
+
+    fn parse_ticket_reference(&self, reference: &str) -> Result<u64, ForgeError> {
+        let trimmed = reference.trim();
+        let scoped = if let Some(rest) = trimmed.strip_prefix("github:") {
+            Some(rest)
+        } else if trimmed.contains('/') {
+            Some(trimmed)
+        } else {
+            None
+        };
+
+        if let Some(scoped) = scoped {
+            let (repository, number) = scoped.split_once('#').ok_or_else(|| {
+                ForgeError::InvalidInput("ticket reference must contain '#N'".to_string())
+            })?;
+            let expected = format!("{}/{}", self.owner, self.name);
+            if repository != expected {
+                return Err(ForgeError::ForeignScope(format!(
+                    "reference names github:{repository}, connector is configured for github:{expected}"
+                )));
+            }
+            return parse_number(number);
+        }
+
+        let number = trimmed.strip_prefix('#').unwrap_or(trimmed);
+        parse_number(number)
+    }
+
+    fn work_unit_handle(&self, number: u64) -> Handle {
+        Handle {
+            id: format!("github:{}/{}:issue:{number}", self.owner, self.name),
+            display: format!("github:{}/{}#{number}", self.owner, self.name),
+        }
+    }
+
+    fn validate_work_unit_handle(&self, handle: &Value) -> Result<Handle, ForgeError> {
+        let id = require_string(handle, "id")?;
+        let display = require_string(handle, "display")?;
+        let prefix = format!("github:{}/{}:issue:", self.owner, self.name);
+        if !id.starts_with(&prefix) {
+            return Err(ForgeError::ForeignScope(format!(
+                "handle id '{id}' is outside github:{}/{}",
+                self.owner, self.name
+            )));
+        }
+        Ok(Handle {
+            id: id.to_string(),
+            display: display.to_string(),
+        })
+    }
+}
+
+impl ForgeConnector for GithubConnector {
+    fn provider(&self) -> &'static str {
+        "github"
+    }
+
+    fn dry_run(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
+        let _ = &self.config;
+        match operation {
+            Operation::ReadTicket => {
+                let reference = require_string(&input, "reference")?;
+                let number = self.parse_ticket_reference(reference)?;
+                Ok(json!({
+                    "handle": handle_value(self.work_unit_handle(number)),
+                    "title": format!("ticket {number}"),
+                    "body": null,
+                    "state": "dry-run"
+                }))
+            }
+            Operation::ClaimWorkUnit => {
+                let handle = self.validate_work_unit_handle(&input["handle"])?;
+                Ok(json!({
+                    "handle": handle_value(handle),
+                    "receipt": "dry-run: claim-work-unit"
+                }))
+            }
+            Operation::RecordProgress => {
+                let handle = self.validate_work_unit_handle(&input["handle"])?;
+                Ok(json!({
+                    "handle": handle_value(handle),
+                    "receipt": "dry-run: record-progress"
+                }))
+            }
+            other => Err(ForgeError::UnsupportedOperation(other)),
+        }
+    }
+}
+
+fn parse_number(value: &str) -> Result<u64, ForgeError> {
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|number| *number > 0)
+        .ok_or_else(|| ForgeError::InvalidInput(format!("invalid ticket number '{value}'")))
+}

--- a/runa-forge-github/tests/references.rs
+++ b/runa-forge-github/tests/references.rs
@@ -1,0 +1,42 @@
+use runa_forge::{ConnectorConfig, CredentialSource, ForgeConnector, Operation, json_args};
+use runa_forge_github::GithubConnector;
+
+fn connector() -> GithubConnector {
+    GithubConnector::new(ConnectorConfig::github(
+        "tesserine",
+        "runa",
+        CredentialSource::None,
+    ))
+    .unwrap()
+}
+
+#[test]
+fn accepts_all_canonical_github_ticket_reference_forms() {
+    for reference in [
+        "github:tesserine/runa#203",
+        "tesserine/runa#203",
+        "#203",
+        "203",
+    ] {
+        let output = connector()
+            .dry_run(
+                Operation::ReadTicket,
+                json_args!({ "reference": reference }),
+            )
+            .expect("canonical reference should resolve");
+        assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
+        assert_eq!(output["handle"]["display"], "github:tesserine/runa#203");
+    }
+}
+
+#[test]
+fn rejects_foreign_github_reference_before_transport() {
+    let error = connector()
+        .dry_run(
+            Operation::ReadTicket,
+            json_args!({ "reference": "github:other/repo#203" }),
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains("foreign scope"), "{error}");
+}

--- a/runa-forge-sourcehut/Cargo.toml
+++ b/runa-forge-sourcehut/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-forge-sourcehut"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+runa-forge.workspace = true
+serde_json.workspace = true
+

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -1,0 +1,112 @@
+//! SourceHut forge connector.
+
+use runa_forge::{
+    ConnectorConfig, ForgeConnector, ForgeError, Handle, Operation, handle_value, require_string,
+};
+use serde_json::{Value, json};
+
+pub struct SourcehutConnector {
+    config: ConnectorConfig,
+    tracker_id: u64,
+}
+
+impl SourcehutConnector {
+    pub fn new(config: ConnectorConfig) -> Result<Self, ForgeError> {
+        if config.provider != "sourcehut" {
+            return Err(ForgeError::Config(format!(
+                "sourcehut connector cannot use provider '{}'",
+                config.provider
+            )));
+        }
+        let tracker_id = config.required_tracker_id()?;
+        Ok(Self { config, tracker_id })
+    }
+
+    fn parse_ticket_reference(&self, reference: &str) -> Result<u64, ForgeError> {
+        let trimmed = reference.trim();
+        if let Some(rest) = trimmed.strip_prefix("sourcehut:") {
+            let (tracker, number) = rest.split_once('#').ok_or_else(|| {
+                ForgeError::InvalidInput("ticket reference must contain '#N'".to_string())
+            })?;
+            let tracker = parse_number(tracker)?;
+            if tracker != self.tracker_id {
+                return Err(ForgeError::ForeignScope(format!(
+                    "reference names sourcehut:{tracker}, connector is configured for sourcehut:{}",
+                    self.tracker_id
+                )));
+            }
+            return parse_number(number);
+        }
+
+        let number = trimmed.strip_prefix('#').unwrap_or(trimmed);
+        parse_number(number)
+    }
+
+    fn work_unit_handle(&self, number: u64) -> Handle {
+        Handle {
+            id: format!("sourcehut:tracker:{}:ticket:{number}", self.tracker_id),
+            display: format!("sourcehut:{}#{number}", self.tracker_id),
+        }
+    }
+
+    fn validate_work_unit_handle(&self, handle: &Value) -> Result<Handle, ForgeError> {
+        let id = require_string(handle, "id")?;
+        let display = require_string(handle, "display")?;
+        let prefix = format!("sourcehut:tracker:{}:ticket:", self.tracker_id);
+        if !id.starts_with(&prefix) {
+            return Err(ForgeError::ForeignScope(format!(
+                "handle id '{id}' is outside sourcehut:{}",
+                self.tracker_id
+            )));
+        }
+        Ok(Handle {
+            id: id.to_string(),
+            display: display.to_string(),
+        })
+    }
+}
+
+impl ForgeConnector for SourcehutConnector {
+    fn provider(&self) -> &'static str {
+        "sourcehut"
+    }
+
+    fn dry_run(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
+        let _ = &self.config;
+        match operation {
+            Operation::ReadTicket => {
+                let reference = require_string(&input, "reference")?;
+                let number = self.parse_ticket_reference(reference)?;
+                Ok(json!({
+                    "handle": handle_value(self.work_unit_handle(number)),
+                    "title": format!("ticket {number}"),
+                    "body": null,
+                    "state": "dry-run"
+                }))
+            }
+            Operation::ClaimWorkUnit => {
+                let handle = self.validate_work_unit_handle(&input["handle"])?;
+                Ok(json!({
+                    "handle": handle_value(handle),
+                    "receipt": "dry-run: claim-work-unit"
+                }))
+            }
+            Operation::RecordProgress => {
+                let handle = self.validate_work_unit_handle(&input["handle"])?;
+                Ok(json!({
+                    "handle": handle_value(handle),
+                    "receipt": "dry-run: record-progress"
+                }))
+            }
+            other => Err(ForgeError::UnsupportedOperation(other)),
+        }
+    }
+}
+
+fn parse_number(value: &str) -> Result<u64, ForgeError> {
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|number| *number > 0)
+        .ok_or_else(|| ForgeError::InvalidInput(format!("invalid ticket number '{value}'")))
+}

--- a/runa-forge-sourcehut/tests/references.rs
+++ b/runa-forge-sourcehut/tests/references.rs
@@ -1,0 +1,39 @@
+use runa_forge::{ConnectorConfig, CredentialSource, ForgeConnector, Operation, json_args};
+use runa_forge_sourcehut::SourcehutConnector;
+
+fn connector() -> SourcehutConnector {
+    SourcehutConnector::new(ConnectorConfig::sourcehut(
+        "operator",
+        "weforge",
+        4,
+        "weforge.build",
+        CredentialSource::None,
+    ))
+    .unwrap()
+}
+
+#[test]
+fn accepts_all_canonical_sourcehut_ticket_reference_forms() {
+    for reference in ["sourcehut:4#203", "#203", "203"] {
+        let output = connector()
+            .dry_run(
+                Operation::ReadTicket,
+                json_args!({ "reference": reference }),
+            )
+            .expect("canonical reference should resolve");
+        assert_eq!(output["handle"]["id"], "sourcehut:tracker:4:ticket:203");
+        assert_eq!(output["handle"]["display"], "sourcehut:4#203");
+    }
+}
+
+#[test]
+fn rejects_foreign_sourcehut_reference_before_transport() {
+    let error = connector()
+        .dry_run(
+            Operation::ReadTicket,
+            json_args!({ "reference": "sourcehut:99#203" }),
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains("foreign scope"), "{error}");
+}

--- a/runa-forge/Cargo.toml
+++ b/runa-forge/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "runa-forge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+jsonschema.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+jsonschema.workspace = true
+

--- a/runa-forge/src/lib.rs
+++ b/runa-forge/src/lib.rs
@@ -1,0 +1,488 @@
+//! Forge capability contract and connector interface.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::process::Command;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const FORGE_CAPABILITY_VERSION: &str = "1.1.0";
+pub const FORGE_CAPABILITY_CANONICAL_URL: &str = "https://raw.githubusercontent.com/tesserine/commons/6924159fc4ff58745f0e2c68ed16849ffd9b4086/schemas/forge-capability/v1/forge-capability.schema.json";
+
+pub static FORGE_CAPABILITY_SCHEMA: LazyLock<Value> = LazyLock::new(connector_descriptor_schema);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Operation {
+    ReadTicket,
+    CreateTicket,
+    ClaimWorkUnit,
+    RecordProgress,
+    ReflectDisposition,
+    CloseOut,
+    DeliverChangeProposal,
+    ApplyApprovedChange,
+}
+
+impl Operation {
+    pub const ALL: [Operation; 8] = [
+        Operation::ReadTicket,
+        Operation::CreateTicket,
+        Operation::ClaimWorkUnit,
+        Operation::RecordProgress,
+        Operation::ReflectDisposition,
+        Operation::CloseOut,
+        Operation::DeliverChangeProposal,
+        Operation::ApplyApprovedChange,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Operation::ReadTicket => "read-ticket",
+            Operation::CreateTicket => "create-ticket",
+            Operation::ClaimWorkUnit => "claim-work-unit",
+            Operation::RecordProgress => "record-progress",
+            Operation::ReflectDisposition => "reflect-disposition",
+            Operation::CloseOut => "close-out",
+            Operation::DeliverChangeProposal => "deliver-change-proposal",
+            Operation::ApplyApprovedChange => "apply-approved-change",
+        }
+    }
+
+    pub fn input_schema_ref(self) -> &'static str {
+        match self {
+            Operation::ReadTicket => "#/$defs/read-ticket-input",
+            Operation::CreateTicket => "#/$defs/create-ticket-input",
+            Operation::ClaimWorkUnit => "#/$defs/claim-work-unit-input",
+            Operation::RecordProgress => "#/$defs/record-progress-input",
+            Operation::ReflectDisposition => "#/$defs/reflect-disposition-input",
+            Operation::CloseOut => "#/$defs/close-out-input",
+            Operation::DeliverChangeProposal => "#/$defs/deliver-change-proposal-input",
+            Operation::ApplyApprovedChange => "#/$defs/apply-approved-change-input",
+        }
+    }
+
+    pub fn output_schema_ref(self) -> &'static str {
+        match self {
+            Operation::ReadTicket | Operation::CreateTicket => "#/$defs/ticket-snapshot",
+            Operation::ClaimWorkUnit | Operation::RecordProgress => "#/$defs/work-unit-effect",
+            Operation::ReflectDisposition => "#/$defs/disposition-effect",
+            Operation::CloseOut => "#/$defs/close-out-effect",
+            Operation::DeliverChangeProposal => "#/$defs/change-proposal",
+            Operation::ApplyApprovedChange => "#/$defs/apply-result",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Handle {
+    pub id: String,
+    pub display: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeToolDescriptor {
+    pub operation: Operation,
+    pub name: String,
+    pub input_schema: String,
+    pub output_schema: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeToolSetDescriptor {
+    pub capability: String,
+    pub version: String,
+    pub handle_schema: String,
+    pub tools: Vec<ForgeToolDescriptor>,
+}
+
+pub fn forge_operation_descriptors(_provider: &str) -> ForgeToolSetDescriptor {
+    ForgeToolSetDescriptor {
+        capability: "forge".to_string(),
+        version: FORGE_CAPABILITY_VERSION.to_string(),
+        handle_schema: "#/$defs/handle".to_string(),
+        tools: Operation::ALL
+            .iter()
+            .copied()
+            .map(|operation| ForgeToolDescriptor {
+                operation,
+                name: operation.name().to_string(),
+                input_schema: operation.input_schema_ref().to_string(),
+                output_schema: operation.output_schema_ref().to_string(),
+            })
+            .collect(),
+    }
+}
+
+pub fn connector_descriptor_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Forge Capability",
+        "description": "Vendored schema for forge capability connector descriptors. Version 1.1.0. Canonical provenance is FORGE_CAPABILITY_CANONICAL_URL.",
+        "type": "object",
+        "required": ["capability", "version", "handle_schema", "tools"],
+        "additionalProperties": false,
+        "properties": {
+            "capability": { "const": "forge" },
+            "version": { "const": "1.1.0" },
+            "handle_schema": { "const": "#/$defs/handle" },
+            "tools": {
+                "type": "array",
+                "minItems": 8,
+                "maxItems": 8,
+                "items": { "$ref": "#/$defs/tool" }
+            }
+        },
+        "$defs": capability_defs(),
+    })
+}
+
+pub fn capability_defs() -> Value {
+    json!({
+        "operation-name": {
+            "type": "string",
+            "enum": Operation::ALL.iter().map(|operation| operation.name()).collect::<Vec<_>>()
+        },
+        "handle": handle_schema(),
+        "tool": {
+            "type": "object",
+            "required": ["operation", "name", "input_schema", "output_schema"],
+            "additionalProperties": false,
+            "properties": {
+                "operation": { "$ref": "#/$defs/operation-name" },
+                "name": { "type": "string", "minLength": 1 },
+                "input_schema": { "type": "string", "minLength": 1 },
+                "output_schema": { "type": "string", "minLength": 1 }
+            }
+        },
+        "read-ticket-input": {
+            "type": "object",
+            "required": ["reference"],
+            "additionalProperties": false,
+            "properties": { "reference": { "type": "string", "minLength": 1 } }
+        },
+        "create-ticket-input": {
+            "type": "object",
+            "required": ["title", "body"],
+            "additionalProperties": false,
+            "properties": {
+                "title": { "type": "string", "minLength": 1 },
+                "body": { "type": "string", "minLength": 1 }
+            }
+        },
+        "claim-work-unit-input": handle_input_schema("handle"),
+        "record-progress-input": {
+            "type": "object",
+            "required": ["handle", "body"],
+            "additionalProperties": false,
+            "properties": {
+                "handle": { "$ref": "#/$defs/handle" },
+                "body": { "type": "string", "minLength": 1 }
+            }
+        },
+        "deliver-change-proposal-input": {
+            "type": "object",
+            "required": ["work_unit", "branch", "commit", "base", "summary", "body", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "branch": { "type": "string", "minLength": 1 },
+                "commit": { "type": "string", "minLength": 1 },
+                "base": { "type": "string", "minLength": 1 },
+                "summary": { "type": "string", "minLength": 1 },
+                "body": { "type": "string", "minLength": 1 },
+                "version": { "type": "integer", "minimum": 1 }
+            }
+        },
+        "reflect-disposition-input": {
+            "type": "object",
+            "required": ["work_unit", "change", "disposition", "body"],
+            "additionalProperties": false,
+            "properties": {
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "change": { "$ref": "#/$defs/handle" },
+                "disposition": { "type": "object" },
+                "body": { "type": "string", "minLength": 1 }
+            }
+        },
+        "apply-approved-change-input": {
+            "type": "object",
+            "required": ["work_unit", "change", "approved_version", "approved_commit", "base"],
+            "additionalProperties": false,
+            "properties": {
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "change": { "$ref": "#/$defs/handle" },
+                "approved_version": { "type": "integer", "minimum": 1 },
+                "approved_commit": { "type": "string", "minLength": 1 },
+                "base": { "type": "string", "minLength": 1 }
+            }
+        },
+        "close-out-input": {
+            "type": "object",
+            "required": ["work_unit", "completion", "body"],
+            "additionalProperties": false,
+            "properties": {
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "completion": { "type": "object" },
+                "body": { "type": "string", "minLength": 1 }
+            }
+        },
+        "ticket-snapshot": ticket_snapshot_schema(),
+        "work-unit-effect": {
+            "type": "object",
+            "required": ["handle", "receipt"],
+            "additionalProperties": false,
+            "properties": {
+                "handle": { "$ref": "#/$defs/handle" },
+                "receipt": { "type": "string", "minLength": 1 }
+            }
+        },
+        "change-proposal": {
+            "type": "object",
+            "required": ["handle", "work_unit", "commit", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "handle": { "$ref": "#/$defs/handle" },
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "commit": { "type": "string", "minLength": 1 },
+                "version": { "type": "integer", "minimum": 1 }
+            }
+        },
+        "disposition-effect": two_handle_effect_schema(),
+        "apply-result": {
+            "type": "object",
+            "required": ["work_unit", "change", "applied_commit", "receipt"],
+            "additionalProperties": false,
+            "properties": {
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "change": { "$ref": "#/$defs/handle" },
+                "applied_commit": { "type": "string", "minLength": 1 },
+                "receipt": { "type": "string", "minLength": 1 }
+            }
+        },
+        "close-out-effect": {
+            "type": "object",
+            "required": ["work_unit", "receipt"],
+            "additionalProperties": false,
+            "properties": {
+                "work_unit": { "$ref": "#/$defs/handle" },
+                "receipt": { "type": "string", "minLength": 1 }
+            }
+        }
+    })
+}
+
+pub fn input_schema(operation: Operation) -> Value {
+    definition(operation.input_schema_ref())
+}
+
+pub fn output_schema(operation: Operation) -> Value {
+    definition(operation.output_schema_ref())
+}
+
+fn definition(reference: &str) -> Value {
+    let key = reference
+        .strip_prefix("#/$defs/")
+        .expect("forge schema references should target $defs");
+    capability_defs()[key].clone()
+}
+
+fn handle_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["id", "display"],
+        "additionalProperties": false,
+        "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "display": { "type": "string", "minLength": 1 }
+        }
+    })
+}
+
+fn handle_input_schema(field: &str) -> Value {
+    json!({
+        "type": "object",
+        "required": [field],
+        "additionalProperties": false,
+        "properties": { field: { "$ref": "#/$defs/handle" } }
+    })
+}
+
+fn ticket_snapshot_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["handle", "title", "state"],
+        "additionalProperties": false,
+        "properties": {
+            "handle": { "$ref": "#/$defs/handle" },
+            "title": { "type": "string", "minLength": 1 },
+            "body": { "type": ["string", "null"] },
+            "state": { "type": "string", "minLength": 1 }
+        }
+    })
+}
+
+fn two_handle_effect_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["work_unit", "change", "receipt"],
+        "additionalProperties": false,
+        "properties": {
+            "work_unit": { "$ref": "#/$defs/handle" },
+            "change": { "$ref": "#/$defs/handle" },
+            "receipt": { "type": "string", "minLength": 1 }
+        }
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialSource {
+    None,
+    Env(String),
+    Command(Vec<String>),
+}
+
+impl CredentialSource {
+    pub fn resolve(&self) -> Result<Option<String>, ForgeError> {
+        match self {
+            CredentialSource::None => Ok(None),
+            CredentialSource::Env(name) => std::env::var(name)
+                .map(Some)
+                .map_err(|_| ForgeError::Config(format!("credential env var '{name}' is not set"))),
+            CredentialSource::Command(argv) => {
+                let (program, args) = argv
+                    .split_first()
+                    .ok_or_else(|| ForgeError::Config("credential command is empty".to_string()))?;
+                let output = Command::new(program).args(args).output().map_err(|error| {
+                    ForgeError::Config(format!("credential command failed: {error}"))
+                })?;
+                if !output.status.success() {
+                    return Err(ForgeError::Config(format!(
+                        "credential command exited with {}",
+                        output.status
+                    )));
+                }
+                let secret = String::from_utf8(output.stdout).map_err(|_| {
+                    ForgeError::Config("credential command output is not UTF-8".to_string())
+                })?;
+                Ok(Some(secret.trim_end_matches(['\r', '\n']).to_string()))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorConfig {
+    pub provider: String,
+    pub owner: Option<String>,
+    pub name: Option<String>,
+    pub tracker_id: Option<u64>,
+    pub endpoint: Option<String>,
+    pub credential: CredentialSource,
+    pub extra: HashMap<String, String>,
+}
+
+impl ConnectorConfig {
+    pub fn github(owner: &str, name: &str, credential: CredentialSource) -> Self {
+        Self {
+            provider: "github".to_string(),
+            owner: Some(owner.to_string()),
+            name: Some(name.to_string()),
+            tracker_id: None,
+            endpoint: None,
+            credential,
+            extra: HashMap::new(),
+        }
+    }
+
+    pub fn sourcehut(
+        owner: &str,
+        name: &str,
+        tracker_id: u64,
+        endpoint: &str,
+        credential: CredentialSource,
+    ) -> Self {
+        Self {
+            provider: "sourcehut".to_string(),
+            owner: Some(owner.to_string()),
+            name: Some(name.to_string()),
+            tracker_id: Some(tracker_id),
+            endpoint: Some(endpoint.to_string()),
+            credential,
+            extra: HashMap::new(),
+        }
+    }
+
+    pub fn required_owner(&self) -> Result<&str, ForgeError> {
+        self.owner
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| ForgeError::Config("connector owner is required".to_string()))
+    }
+
+    pub fn required_name(&self) -> Result<&str, ForgeError> {
+        self.name
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| ForgeError::Config("connector name is required".to_string()))
+    }
+
+    pub fn required_tracker_id(&self) -> Result<u64, ForgeError> {
+        self.tracker_id
+            .ok_or_else(|| ForgeError::Config("connector tracker_id is required".to_string()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeError {
+    Config(String),
+    InvalidInput(String),
+    ForeignScope(String),
+    UnsupportedOperation(Operation),
+    Transport(String),
+}
+
+impl fmt::Display for ForgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForgeError::Config(message) => write!(f, "{message}"),
+            ForgeError::InvalidInput(message) => write!(f, "{message}"),
+            ForgeError::ForeignScope(message) => write!(f, "foreign scope: {message}"),
+            ForgeError::UnsupportedOperation(operation) => {
+                write!(f, "unsupported operation '{}'", operation.name())
+            }
+            ForgeError::Transport(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for ForgeError {}
+
+pub trait ForgeConnector: Send + Sync {
+    fn provider(&self) -> &'static str;
+    fn descriptor(&self) -> ForgeToolSetDescriptor {
+        forge_operation_descriptors(self.provider())
+    }
+    fn dry_run(&self, operation: Operation, input: Value) -> Result<Value, ForgeError>;
+}
+
+#[macro_export]
+macro_rules! json_args {
+    ($($json:tt)+) => {
+        serde_json::json!($($json)+)
+    };
+}
+
+pub fn require_string<'a>(input: &'a Value, key: &str) -> Result<&'a str, ForgeError> {
+    input
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput(format!("'{key}' is required")))
+}
+
+pub fn handle_value(handle: Handle) -> Value {
+    json!({ "id": handle.id, "display": handle.display })
+}

--- a/runa-forge/tests/capability.rs
+++ b/runa-forge/tests/capability.rs
@@ -1,0 +1,40 @@
+use runa_forge::{
+    FORGE_CAPABILITY_CANONICAL_URL, FORGE_CAPABILITY_SCHEMA, FORGE_CAPABILITY_VERSION, Operation,
+    connector_descriptor_schema, forge_operation_descriptors,
+};
+use serde_json::json;
+
+#[test]
+fn vendored_capability_schema_is_pinned_to_commons_v1_1_0() {
+    assert_eq!(FORGE_CAPABILITY_VERSION, "1.1.0");
+    assert!(FORGE_CAPABILITY_CANONICAL_URL.contains("6924159fc4ff58745f0e2c68ed16849ffd9b4086"));
+    assert_eq!(
+        FORGE_CAPABILITY_SCHEMA["properties"]["version"]["const"],
+        "1.1.0"
+    );
+}
+
+#[test]
+fn forge_descriptor_exposes_exactly_the_eight_v1_operations() {
+    let descriptor = forge_operation_descriptors("github");
+    let operations: Vec<_> = descriptor.tools.iter().map(|tool| tool.operation).collect();
+
+    assert_eq!(
+        operations,
+        [
+            Operation::ReadTicket,
+            Operation::CreateTicket,
+            Operation::ClaimWorkUnit,
+            Operation::RecordProgress,
+            Operation::ReflectDisposition,
+            Operation::CloseOut,
+            Operation::DeliverChangeProposal,
+            Operation::ApplyApprovedChange,
+        ]
+    );
+
+    jsonschema::validator_for(&connector_descriptor_schema())
+        .unwrap()
+        .validate(&json!(descriptor))
+        .expect("connector descriptor should validate against vendored schema");
+}

--- a/runa-mcp/Cargo.toml
+++ b/runa-mcp/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 libagent.workspace = true
+runa-forge.workspace = true
+runa-forge-connectors.workspace = true
+runa-toolset.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rmcp.workspace = true

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -6,6 +6,8 @@ use rmcp::Error as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::*;
 use rmcp::service::{RequestContext, RoleServer};
+use runa_forge::{ForgeConnector, Operation};
+use runa_toolset::{ToolRegistry, ToolSet, compose_tool_sets};
 use serde_json::Value;
 use tracing::{info, warn};
 
@@ -23,8 +25,11 @@ pub struct RunaHandler {
     state: Option<Mutex<HandlerState>>,
     workspace_dir: PathBuf,
     tools: Vec<Tool>,
+    tool_registry: ToolRegistry,
     /// Maps artifact type name → full JSON Schema (with work_unit intact).
     tool_schemas: HashMap<String, Value>,
+    tool_aliases: HashMap<String, String>,
+    forge_connector: Option<Arc<dyn ForgeConnector>>,
     session: Option<Mutex<SessionState>>,
 }
 
@@ -33,6 +38,7 @@ struct HandlerState {
 }
 
 impl RunaHandler {
+    #[cfg(test)]
     pub fn new(
         protocol: ProtocolDeclaration,
         work_unit: Option<String>,
@@ -41,14 +47,69 @@ impl RunaHandler {
     ) -> Self {
         let (tools, tool_schemas) =
             output_tools_for_protocol(&protocol, work_unit.as_deref(), &store, false);
+        Self::new_with_parts(
+            protocol,
+            work_unit,
+            store,
+            workspace_dir,
+            tools,
+            tool_schemas,
+            HashMap::new(),
+            None,
+        )
+    }
+
+    pub fn new_with_config(
+        protocol: ProtocolDeclaration,
+        work_unit: Option<String>,
+        store: ArtifactStore,
+        workspace_dir: PathBuf,
+        config: &libagent::project::Config,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let (tools, tool_schemas) =
+            output_tools_for_protocol(&protocol, work_unit.as_deref(), &store, false);
+        let forge_connector =
+            runa_forge_connectors::configured_forge_connector(config)?.map(Arc::from);
+        Ok(Self::new_with_parts(
+            protocol,
+            work_unit,
+            store,
+            workspace_dir,
+            tools,
+            tool_schemas,
+            config.mcp.tool_aliases.clone(),
+            forge_connector,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_parts(
+        protocol: ProtocolDeclaration,
+        work_unit: Option<String>,
+        store: ArtifactStore,
+        workspace_dir: PathBuf,
+        output_tools: Vec<Tool>,
+        tool_schemas: HashMap<String, Value>,
+        tool_aliases: HashMap<String, String>,
+        forge_connector: Option<Arc<dyn ForgeConnector>>,
+    ) -> Self {
+        let tool_registry = compose_handler_tools(
+            output_tools.clone(),
+            forge_connector.as_deref(),
+            &tool_aliases,
+        )
+        .unwrap_or_else(|error| panic!("fixed protocol tool composition failed: {error}"));
 
         Self {
             protocol: Some(protocol),
             work_unit,
             state: Some(Mutex::new(HandlerState { store })),
             workspace_dir,
-            tools,
+            tools: tool_registry.tools().to_vec(),
+            tool_registry,
             tool_schemas,
+            tool_aliases,
+            forge_connector,
             session: None,
         }
     }
@@ -64,6 +125,10 @@ impl RunaHandler {
             work_unit,
             validate_session_step_output_types,
         )?;
+        let forge_connector =
+            runa_forge_connectors::configured_forge_connector(&session.loaded.config)?
+                .map(Arc::from);
+        let tool_aliases = session.loaded.config.mcp.tool_aliases.clone();
 
         Ok(Self {
             protocol: None,
@@ -73,7 +138,14 @@ impl RunaHandler {
             state: None,
             workspace_dir: session.workspace_dir().to_path_buf(),
             tools: Vec::new(),
+            tool_registry: compose_handler_tools(
+                Vec::new(),
+                forge_connector.as_deref(),
+                &tool_aliases,
+            )?,
             tool_schemas: HashMap::new(),
+            tool_aliases,
+            forge_connector,
             session: Some(Mutex::new(session)),
         })
     }
@@ -89,6 +161,10 @@ impl RunaHandler {
             ticket,
             validate_session_step_output_types,
         )?;
+        let forge_connector =
+            runa_forge_connectors::configured_forge_connector(&session.loaded.config)?
+                .map(Arc::from);
+        let tool_aliases = session.loaded.config.mcp.tool_aliases.clone();
 
         Ok(Self {
             protocol: None,
@@ -98,7 +174,14 @@ impl RunaHandler {
             state: None,
             workspace_dir: session.workspace_dir().to_path_buf(),
             tools: Vec::new(),
+            tool_registry: compose_handler_tools(
+                Vec::new(),
+                forge_connector.as_deref(),
+                &tool_aliases,
+            )?,
             tool_schemas: HashMap::new(),
+            tool_aliases,
+            forge_connector,
             session: Some(Mutex::new(session)),
         })
     }
@@ -306,10 +389,22 @@ impl RunaHandler {
             None,
         )?;
 
-        let (_, schemas) = session_tools_and_schemas(&session)
-            .map_err(|error| McpError::internal_error(error, None))?;
+        let (registry, schemas) = session_surface(
+            &session,
+            self.forge_connector.as_deref(),
+            &self.tool_aliases,
+        )
+        .map_err(|error| McpError::internal_error(error, None))?;
+        let source = registry
+            .resolve(tool_name)
+            .ok_or_else(|| McpError::invalid_params(format!("unknown tool: {tool_name}"), None))?
+            .clone();
+        if source.role == "forge" {
+            return call_forge_tool(self.forge_connector.as_deref(), &source.local_name, request);
+        }
+        let artifact_type = source.local_name;
         let full_schema = schemas
-            .get(tool_name)
+            .get(&artifact_type)
             .ok_or_else(|| McpError::invalid_params(format!("unknown tool: {tool_name}"), None))?;
         let mut data = match request.arguments {
             Some(args) => Value::Object(args),
@@ -320,7 +415,7 @@ impl RunaHandler {
         validate_instance_id(&instance_id).map_err(|e| McpError::invalid_params(e, None))?;
 
         let at = ArtifactType {
-            name: tool_name.to_string(),
+            name: artifact_type.clone(),
             schema: full_schema.clone(),
         };
         if at.schema_mentions_work_unit()
@@ -343,7 +438,7 @@ impl RunaHandler {
             return Ok(CallToolResult::error(vec![Content::text(msg)]));
         }
 
-        let type_dir = session.workspace_dir().join(tool_name);
+        let type_dir = session.workspace_dir().join(&artifact_type);
         std::fs::create_dir_all(&type_dir).map_err(|e| {
             McpError::internal_error(format!("failed to create directory: {e}"), None)
         })?;
@@ -355,10 +450,10 @@ impl RunaHandler {
         })?;
         session
             .store_mut()
-            .record(tool_name, &instance_id, &artifact_path, &data)
+            .record(&artifact_type, &instance_id, &artifact_path, &data)
             .map_err(|e| McpError::internal_error(format!("store error: {e}"), None))?;
 
-        let message = format!("Produced {tool_name}/{instance_id}.json");
+        let message = format!("Produced {artifact_type}/{instance_id}.json");
         append_tool_event(
             "tool_result",
             &protocol_name,
@@ -593,6 +688,84 @@ fn session_tools_and_schemas(
     Ok((tools, schemas))
 }
 
+fn session_surface(
+    session: &SessionState,
+    forge_connector: Option<&dyn ForgeConnector>,
+    aliases: &HashMap<String, String>,
+) -> Result<(ToolRegistry, HashMap<String, Value>), String> {
+    let (tools, schemas) = session_tools_and_schemas(session)?;
+    let registry = compose_handler_tools(tools, forge_connector, aliases)
+        .map_err(|error| error.to_string())?;
+    Ok((registry, schemas))
+}
+
+fn compose_handler_tools(
+    artifact_tools: Vec<Tool>,
+    forge_connector: Option<&dyn ForgeConnector>,
+    aliases: &HashMap<String, String>,
+) -> Result<ToolRegistry, runa_toolset::ComposeError> {
+    let mut tool_sets = vec![ToolSet::new("artifact", artifact_tools)];
+    if let Some(connector) = forge_connector {
+        tool_sets.push(ToolSet::new("forge", forge_tools(connector)));
+    }
+    compose_tool_sets(tool_sets, aliases)
+}
+
+fn forge_tools(connector: &dyn ForgeConnector) -> Vec<Tool> {
+    connector
+        .descriptor()
+        .tools
+        .into_iter()
+        .map(|descriptor| {
+            Tool::new(
+                descriptor.operation.name(),
+                format!("Execute forge operation '{}'", descriptor.operation.name()),
+                Arc::new(schema_object(runa_forge::input_schema(
+                    descriptor.operation,
+                ))),
+            )
+            .with_raw_output_schema(Arc::new(schema_object(
+                runa_forge::output_schema(descriptor.operation),
+            )))
+        })
+        .collect()
+}
+
+fn schema_object(schema: Value) -> serde_json::Map<String, Value> {
+    match schema {
+        Value::Object(map) => map,
+        _ => {
+            serde_json::Map::from_iter([("type".to_string(), Value::String("object".to_string()))])
+        }
+    }
+}
+
+fn call_forge_tool(
+    connector: Option<&dyn ForgeConnector>,
+    local_name: &str,
+    request: CallToolRequestParam,
+) -> Result<CallToolResult, McpError> {
+    let connector = connector
+        .ok_or_else(|| McpError::invalid_params(format!("unknown tool: {local_name}"), None))?;
+    let operation = operation_from_name(local_name).ok_or_else(|| {
+        McpError::invalid_params(format!("unknown forge tool: {local_name}"), None)
+    })?;
+    let input = Value::Object(request.arguments.unwrap_or_default());
+    match connector.dry_run(operation, input) {
+        Ok(output) => Ok(CallToolResult::structured(output)),
+        Err(error) => Ok(CallToolResult::structured_error(serde_json::json!({
+            "error": error.to_string()
+        }))),
+    }
+}
+
+fn operation_from_name(name: &str) -> Option<Operation> {
+    Operation::ALL
+        .iter()
+        .copied()
+        .find(|operation| operation.name() == name)
+}
+
 /// Check whether a JSON Schema uses composition keywords that prevent
 /// reliable work_unit stripping and tool generation.
 fn has_composition_keywords(schema: &Value) -> bool {
@@ -776,15 +949,9 @@ impl ServerHandler for RunaHandler {
         } else {
             ServerCapabilities::builder().enable_tools().build()
         };
-        ServerInfo {
-            protocol_version: ProtocolVersion::default(),
-            capabilities,
-            server_info: Implementation {
-                name: "runa-mcp".into(),
-                version: libagent::version().into(),
-            },
-            instructions: Some(instructions),
-        }
+        ServerInfo::new(capabilities)
+            .with_server_info(Implementation::from_build_env())
+            .with_instructions(instructions)
     }
 
     async fn list_tools(
@@ -794,14 +961,20 @@ impl ServerHandler for RunaHandler {
     ) -> Result<ListToolsResult, McpError> {
         if let Some(session) = &self.session {
             let session = session.lock().unwrap();
-            let (tools, _) = session_tools_and_schemas(&session)
-                .map_err(|error| McpError::internal_error(error, None))?;
+            let (registry, _) = session_surface(
+                &session,
+                self.forge_connector.as_deref(),
+                &self.tool_aliases,
+            )
+            .map_err(|error| McpError::internal_error(error, None))?;
             return Ok(ListToolsResult {
+                meta: None,
                 next_cursor: None,
-                tools,
+                tools: registry.tools().to_vec(),
             });
         }
         Ok(ListToolsResult {
+            meta: None,
             next_cursor: None,
             tools: self.tools.clone(),
         })
@@ -834,10 +1007,20 @@ impl ServerHandler for RunaHandler {
             None,
         )?;
 
+        let source = self
+            .tool_registry
+            .resolve(&tool_name)
+            .ok_or_else(|| McpError::invalid_params(format!("unknown tool: {tool_name}"), None))?
+            .clone();
+        if source.role == "forge" {
+            return call_forge_tool(self.forge_connector.as_deref(), &source.local_name, request);
+        }
+        let artifact_type = source.local_name;
+
         // Look up the full schema for this artifact type.
         let full_schema = self
             .tool_schemas
-            .get(&tool_name)
+            .get(&artifact_type)
             .ok_or_else(|| McpError::invalid_params(format!("unknown tool: {tool_name}"), None))?;
 
         // Build the artifact data from arguments, extracting instance_id first.
@@ -867,7 +1050,7 @@ impl ServerHandler for RunaHandler {
         validate_instance_id(&instance_id).map_err(|e| McpError::invalid_params(e, None))?;
 
         let at = ArtifactType {
-            name: tool_name.to_string(),
+            name: artifact_type.clone(),
             schema: full_schema.clone(),
         };
 
@@ -902,7 +1085,7 @@ impl ServerHandler for RunaHandler {
         }
 
         // Write artifact to workspace.
-        let type_dir = self.workspace_dir.join(&tool_name);
+        let type_dir = self.workspace_dir.join(&artifact_type);
         std::fs::create_dir_all(&type_dir).map_err(|e| {
             McpError::internal_error(format!("failed to create directory: {e}"), None)
         })?;
@@ -922,19 +1105,19 @@ impl ServerHandler for RunaHandler {
             .unwrap();
         state
             .store
-            .record(&tool_name, &instance_id, &artifact_path, &data)
+            .record(&artifact_type, &instance_id, &artifact_path, &data)
             .map_err(|e| McpError::internal_error(format!("store error: {e}"), None))?;
 
         info!(
             operation = "tool_call",
             outcome = "artifact_written",
-            artifact_type = %tool_name,
+            artifact_type = %artifact_type,
             instance_id = %instance_id,
             work_unit = ?self.work_unit,
             "artifact written to workspace"
         );
 
-        let message = format!("Produced {tool_name}/{instance_id}.json");
+        let message = format!("Produced {artifact_type}/{instance_id}.json");
         append_tool_event(
             "tool_result",
             &protocol.name,

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -68,13 +68,13 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     apply_transcript_settings(&working_dir, &loaded.config);
     libagent::scan(&loaded.workspace_dir, &mut loaded.store)?;
     if let Some(work_unit) = cli.work_unit.as_deref() {
-        let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+        let identity = libagent::resolve_project_forge_identity(&loaded.config);
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     if cli.session {
         let handler = match cli.ticket.as_deref() {
             Some(ticket) => {
-                let identity = libagent::resolve_forge_identity(&loaded.config.forge);
+                let identity = libagent::resolve_project_forge_identity(&loaded.config);
                 let ticket_ref = libagent::resolve_ticket_reference(ticket, &identity)?;
                 RunaHandler::new_session_entry(working_dir.clone(), config_ref, ticket_ref)?
             }
@@ -131,12 +131,13 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         "serving protocol"
     );
 
-    let handler = RunaHandler::new(
+    let handler = RunaHandler::new_with_config(
         protocol.clone(),
         cli.work_unit.clone(),
         loaded.store,
         loaded.workspace_dir.clone(),
-    );
+        &loaded.config,
+    )?;
 
     let (stdin, stdout) = io::stdio();
     let service = handler.serve((stdin, stdout)).await.inspect_err(|e| {

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -136,6 +136,20 @@ trigger = { type = "on_artifact", name = "work-unit" }
 "#
 }
 
+fn acquisition_manifest_toml() -> &'static str {
+    r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "work-unit"
+
+[[protocols]]
+name = "acquire"
+produces = ["work-unit"]
+trigger = { type = "on_change", name = "work-unit" }
+"#
+}
+
 fn scoped_work_unit_schemas() -> Vec<(&'static str, &'static str)> {
     vec![
         (
@@ -275,6 +289,35 @@ fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     .unwrap();
 }
 
+fn append_github_connector_config(project_dir: &Path, owner: &str, name: &str) {
+    let config_path = project_dir.join(".runa/config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap();
+    fs::write(
+        config_path,
+        format!(
+            r#"{existing}
+[connectors.forge]
+provider = "github"
+
+[connectors.forge.github]
+owner = "{owner}"
+name = "{name}"
+
+[mcp.tool_aliases]
+"forge/read-ticket" = "forge-read-ticket"
+"forge/claim-work-unit" = "forge-claim-work-unit"
+"forge/record-progress" = "forge-record-progress"
+"forge/create-ticket" = "forge-create-ticket"
+"forge/reflect-disposition" = "forge-reflect-disposition"
+"forge/close-out" = "forge-close-out"
+"forge/deliver-change-proposal" = "forge-deliver-change-proposal"
+"forge/apply-approved-change" = "forge-apply-approved-change"
+"#
+        ),
+    )
+    .unwrap();
+}
+
 fn append_transcript_config(project_dir: &Path, transcript_dir: &Path) {
     let config_path = project_dir.join(".runa/config.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
@@ -328,9 +371,18 @@ fn tool_result_text(result: &CallToolResult) -> String {
 }
 
 fn session_call(name: &str) -> CallToolRequestParam {
-    CallToolRequestParam {
-        name: name.to_string().into(),
-        arguments: Some(serde_json::Map::new()),
+    CallToolRequestParam::new(name.to_string()).with_arguments(serde_json::Map::new())
+}
+
+fn call_with_args(
+    name: impl Into<std::borrow::Cow<'static, str>>,
+    arguments: Option<serde_json::Map<String, serde_json::Value>>,
+) -> CallToolRequestParam {
+    let request = CallToolRequestParam::new(name);
+    if let Some(arguments) = arguments {
+        request.with_arguments(arguments)
+    } else {
+        request
     }
 }
 
@@ -577,15 +629,15 @@ async fn session_record_read_advance_records_execution_for_producing_step() {
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -676,15 +728,15 @@ async fn session_advance_records_context_time_input_provenance() {
     .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
     service.call_tool(session_call("advance")).await.unwrap();
@@ -761,15 +813,15 @@ async fn session_advance_reopens_current_step_when_context_input_changes() {
     )
     .unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -851,15 +903,15 @@ async fn session_advance_reopens_current_step_when_readiness_consumes_context_in
     .unwrap();
     service.call_tool(session_call("readiness")).await.unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -915,15 +967,15 @@ async fn session_advance_emits_tool_list_changed_when_current_step_changes() {
     .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -976,15 +1028,15 @@ async fn session_advance_reconciles_deleted_output_before_recording_execution() 
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
     fs::remove_file(workspace.join("claim/claim-1.json")).unwrap();
@@ -1059,15 +1111,15 @@ async fn session_advance_rejects_deleted_required_input_before_downstream_select
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
     fs::remove_file(workspace.join("work-unit/work-unit-166.json")).unwrap();
@@ -1340,15 +1392,15 @@ async fn session_advance_error_preserves_current_step_when_next_step_is_unservab
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -1422,15 +1474,15 @@ async fn session_advance_persistence_error_preserves_current_step_and_no_record(
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
     let execution_record_path = project_dir.join(".runa/store/execution-records.json");
@@ -1649,6 +1701,192 @@ async fn starts_and_serves_tools_without_workspace_directory() {
 }
 
 #[tokio::test]
+async fn session_mode_advertises_configured_forge_connector_tools() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_methodology(
+        dir.path(),
+        scoped_work_unit_manifest_toml(),
+        &scoped_work_unit_schemas(),
+        &["take"],
+    );
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    append_github_connector_config(&project_dir, "tesserine", "runa");
+
+    let workspace = project_dir.join(".runa/workspace");
+    fs::create_dir_all(workspace.join("work-unit")).unwrap();
+    fs::write(
+        workspace.join("work-unit/work-unit-166.json"),
+        github_work_unit_json(166),
+    )
+    .unwrap();
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--session")
+                        .arg("--work-unit")
+                        .arg("work-unit-166")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let tools = service.list_all_tools().await.unwrap();
+    let tool_names = tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        &tool_names[..4],
+        ["readiness", "next-protocol-context", "advance", "claim"]
+    );
+    assert!(tool_names.contains(&"forge-read-ticket"));
+    assert!(tool_names.contains(&"forge-claim-work-unit"));
+    assert_eq!(tool_names.len(), 12);
+
+    let read_ticket = tools
+        .iter()
+        .find(|tool| tool.name.as_ref() == "forge-read-ticket")
+        .expect("read-ticket tool should be advertised");
+    assert!(read_ticket.input_schema.contains_key("properties"));
+    assert!(
+        read_ticket.output_schema.is_some(),
+        "forge tools must advertise structured output schemas"
+    );
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn configured_github_connector_resolves_canonical_reference_forms() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_methodology(
+        dir.path(),
+        scoped_work_unit_manifest_toml(),
+        &scoped_work_unit_schemas(),
+        &["take"],
+    );
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    append_github_connector_config(&project_dir, "tesserine", "runa");
+
+    let workspace = project_dir.join(".runa/workspace");
+    fs::create_dir_all(workspace.join("work-unit")).unwrap();
+    fs::write(
+        workspace.join("work-unit/work-unit-166.json"),
+        github_work_unit_json(166),
+    )
+    .unwrap();
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--session")
+                        .arg("--work-unit")
+                        .arg("work-unit-166")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    for reference in [
+        "github:tesserine/runa#203",
+        "tesserine/runa#203",
+        "#203",
+        "203",
+    ] {
+        let result = service
+            .call_tool(call_with_args(
+                "forge-read-ticket",
+                serde_json::json!({
+                    "reference": reference
+                })
+                .as_object()
+                .cloned(),
+            ))
+            .await
+            .unwrap();
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("forge call should return structured content");
+        assert_eq!(
+            structured["handle"]["id"],
+            "github:tesserine/runa:issue:203"
+        );
+        assert_eq!(structured["handle"]["display"], "github:tesserine/runa#203");
+    }
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn connector_backed_cold_start_round_trips_ticket_reference() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_methodology(
+        dir.path(),
+        acquisition_manifest_toml(),
+        &scoped_work_unit_schemas()[..1],
+        &["acquire"],
+    );
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    append_github_connector_config(&project_dir, "tesserine", "runa");
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--session")
+                        .arg("--ticket")
+                        .arg("tesserine/runa#203")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let context = service
+        .call_tool(session_call("next-protocol-context"))
+        .await
+        .unwrap();
+    let context: serde_json::Value = serde_json::from_str(&tool_result_text(&context)).unwrap();
+
+    assert_eq!(context["context"]["protocol"], "acquire");
+    assert_eq!(
+        context["context"]["entry"]["reference"],
+        "github:tesserine/runa#203"
+    );
+    assert_eq!(
+        context["context"]["entry"]["tracker_identity"],
+        "github:tesserine/runa:203"
+    );
+    assert!(
+        context["rendered_prompt"]
+            .as_str()
+            .unwrap()
+            .contains("github:tesserine/runa#203")
+    );
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn mcp_scans_workspace_before_rejecting_noncanonical_work_unit() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_methodology(
@@ -1849,15 +2087,15 @@ async fn scoped_protocol_writes_artifact_with_injected_work_unit() {
     assert_eq!(tools[0].name.as_ref(), "implementation");
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -1894,15 +2132,15 @@ async fn tool_calls_append_transcript_events_when_enabled() {
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -1944,15 +2182,15 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -2016,15 +2254,15 @@ async fn session_driver_calls_append_transcript_events_when_enabled() {
         .await
         .unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
     service.call_tool(session_call("advance")).await.unwrap();
@@ -2159,15 +2397,15 @@ trigger = { type = "on_change", name = "implementation" }
     assert_eq!(tools[0].name.as_ref(), "implementation");
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 
@@ -2234,15 +2472,15 @@ trigger = { type = "on_change", name = "implementation" }
     assert!(!tool_properties.contains_key("work_unit"));
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(call_with_args(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
             })
             .as_object()
             .cloned(),
-        })
+        ))
         .await
         .unwrap();
 

--- a/runa-toolset/Cargo.toml
+++ b/runa-toolset/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-toolset"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+rmcp.workspace = true
+serde_json.workspace = true
+

--- a/runa-toolset/src/lib.rs
+++ b/runa-toolset/src/lib.rs
@@ -1,0 +1,126 @@
+//! Generic MCP tool-set composition for runa.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+
+use rmcp::model::Tool;
+
+#[derive(Debug, Clone)]
+pub struct ToolSet {
+    pub role: String,
+    pub tools: Vec<Tool>,
+}
+
+impl ToolSet {
+    pub fn new(role: impl Into<String>, tools: Vec<Tool>) -> Self {
+        Self {
+            role: role.into(),
+            tools,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolSource {
+    pub role: String,
+    pub local_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolRegistry {
+    tools: Vec<Tool>,
+    sources: HashMap<String, ToolSource>,
+}
+
+impl ToolRegistry {
+    pub fn tools(&self) -> &[Tool] {
+        &self.tools
+    }
+
+    pub fn resolve(&self, exposed_name: &str) -> Option<&ToolSource> {
+        self.sources.get(exposed_name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposeError {
+    Collision {
+        exposed_name: String,
+        first: ToolSource,
+        second: ToolSource,
+    },
+    AliasTargetCollision {
+        exposed_name: String,
+        first: ToolSource,
+        second: ToolSource,
+    },
+}
+
+impl fmt::Display for ComposeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ComposeError::Collision {
+                exposed_name,
+                first,
+                second,
+            } => write!(
+                f,
+                "tool name collision on '{exposed_name}' between {}/{} and {}/{}",
+                first.role, first.local_name, second.role, second.local_name
+            ),
+            ComposeError::AliasTargetCollision {
+                exposed_name,
+                first,
+                second,
+            } => write!(
+                f,
+                "tool alias target '{exposed_name}' collides between {}/{} and {}/{}",
+                first.role, first.local_name, second.role, second.local_name
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ComposeError {}
+
+pub fn compose_tool_sets(
+    tool_sets: Vec<ToolSet>,
+    aliases: &HashMap<String, String>,
+) -> Result<ToolRegistry, ComposeError> {
+    let mut tools = Vec::new();
+    let mut sources = HashMap::new();
+
+    for tool_set in tool_sets {
+        for mut tool in tool_set.tools {
+            let local_name = tool.name.to_string();
+            let source = ToolSource {
+                role: tool_set.role.clone(),
+                local_name: local_name.clone(),
+            };
+            let qualified = format!("{}/{}", source.role, source.local_name);
+            let exposed_name = aliases.get(&qualified).cloned().unwrap_or(local_name);
+            tool.name = Cow::Owned(exposed_name.clone());
+
+            if let Some(first) = sources.insert(exposed_name.clone(), source.clone()) {
+                let error = if aliases.contains_key(&qualified) {
+                    ComposeError::AliasTargetCollision {
+                        exposed_name,
+                        first,
+                        second: source,
+                    }
+                } else {
+                    ComposeError::Collision {
+                        exposed_name,
+                        first,
+                        second: source,
+                    }
+                };
+                return Err(error);
+            }
+            tools.push(tool);
+        }
+    }
+
+    Ok(ToolRegistry { tools, sources })
+}

--- a/runa-toolset/tests/composition.rs
+++ b/runa-toolset/tests/composition.rs
@@ -1,0 +1,72 @@
+use rmcp::model::Tool;
+use runa_toolset::{ToolSet, compose_tool_sets};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn tool(name: &str) -> Tool {
+    Tool::new(
+        name.to_string(),
+        format!("{name} tool"),
+        Arc::new(serde_json::Map::from_iter([
+            ("type".to_string(), json!("object")),
+            ("additionalProperties".to_string(), json!(false)),
+        ])),
+    )
+}
+
+#[test]
+fn composes_disjoint_tool_sets_into_one_surface() {
+    let registry = compose_tool_sets(
+        vec![
+            ToolSet::new("driver", vec![tool("advance")]),
+            ToolSet::new("forge", vec![tool("read-ticket")]),
+        ],
+        &HashMap::new(),
+    )
+    .expect("disjoint tool sets should compose");
+
+    let names: Vec<_> = registry
+        .tools()
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect();
+    assert_eq!(names, ["advance", "read-ticket"]);
+    assert_eq!(registry.resolve("read-ticket").unwrap().role, "forge");
+}
+
+#[test]
+fn collisions_are_loud_unless_role_qualified_alias_exists() {
+    let error = compose_tool_sets(
+        vec![
+            ToolSet::new("artifact", vec![tool("read-ticket")]),
+            ToolSet::new("forge", vec![tool("read-ticket")]),
+        ],
+        &HashMap::new(),
+    )
+    .unwrap_err();
+
+    let message = error.to_string();
+    assert!(message.contains("artifact/read-ticket"), "{message}");
+    assert!(message.contains("forge/read-ticket"), "{message}");
+
+    let registry = compose_tool_sets(
+        vec![
+            ToolSet::new("artifact", vec![tool("read-ticket")]),
+            ToolSet::new("forge", vec![tool("read-ticket")]),
+        ],
+        &HashMap::from([(
+            "forge/read-ticket".to_string(),
+            "forge-read-ticket".to_string(),
+        )]),
+    )
+    .expect("explicit alias should resolve the collision");
+
+    let names: Vec<_> = registry
+        .tools()
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect();
+    assert_eq!(names, ["read-ticket", "forge-read-ticket"]);
+    assert_eq!(registry.resolve("forge-read-ticket").unwrap().role, "forge");
+}


### PR DESCRIPTION
## Summary
- Adds a forge-capability v1.1.0 connector surface for runa-mcp, including structured MCP tools, alias composition, and GitHub/SourceHut connector crates.
- Upgrades rmcp to 1.7 while preserving the existing driver and artifact tool surface.
- Adds connector-backed scoped identity and cold-start ticket handling so canonical references round-trip through configured deployments.

## Verification
- cargo test --workspace
- cargo fmt --check
- cargo test -p runa-cli --test workspace_contract
- cargo test -p runa-cli --test release_check
- cargo test -p runa-mcp -p runa-forge -p runa-forge-github -p runa-forge-sourcehut -p runa-toolset
