### PR TITLE
task(connectors): compose forge connector tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,11 +211,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -285,15 +294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix",
  "windows-sys",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -301,11 +310,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -315,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -427,12 +435,6 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -619,7 +621,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -823,6 +825,7 @@ name = "libagent"
 version = "0.2.0-rc.1"
 dependencies = [
  "jsonschema",
+ "runa-forge-contract",
  "serde",
  "serde_json",
  "sha2",
@@ -889,18 +892,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -1056,14 +1047,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1107,13 +1098,13 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
- "nix 0.30.1",
+ "nix",
  "tokio",
  "tracing",
  "windows",
@@ -1215,14 +1206,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "0.2.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
+ "async-trait",
  "base64",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
  "rmcp-macros",
@@ -1238,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.2.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1265,12 +1257,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "runa-forge-connectors"
+version = "0.2.0-rc.1"
+dependencies = [
+ "runa-forge-contract",
+ "runa-forge-github",
+ "runa-forge-sourcehut",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-contract"
+version = "0.2.0-rc.1"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-github"
+version = "0.2.0-rc.1"
+dependencies = [
+ "runa-forge-contract",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-sourcehut"
+version = "0.2.0-rc.1"
+dependencies = [
+ "runa-forge-contract",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "runa-mcp"
 version = "0.2.0-rc.1"
 dependencies = [
  "clap",
+ "jsonschema",
  "libagent",
  "rmcp",
+ "runa-forge-connectors",
+ "runa-forge-contract",
+ "runa-forge-github",
+ "runa-forge-sourcehut",
  "serde",
  "serde_json",
  "tempfile",
@@ -1299,12 +1332,13 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1312,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1865,37 +1899,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1906,19 +1926,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -1946,33 +1966,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -1981,16 +1986,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1999,7 +1995,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2008,16 +2004,16 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["runa-cli", "libagent", "runa-mcp"]
+members = [
+    "runa-cli",
+    "libagent",
+    "runa-mcp",
+    "runa-forge-contract",
+    "runa-forge-connectors",
+    "runa-forge-github",
+    "runa-forge-sourcehut",
+]
 resolver = "3"
 
 [workspace.package]
@@ -9,6 +17,10 @@ license = "MIT"
 
 [workspace.dependencies]
 libagent = { path = "libagent" }
+runa-forge-contract = { path = "runa-forge-contract" }
+runa-forge-connectors = { path = "runa-forge-connectors" }
+runa-forge-github = { path = "runa-forge-github" }
+runa-forge-sourcehut = { path = "runa-forge-sourcehut" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -16,7 +28,7 @@ tempfile = "3"
 jsonschema = { version = "0.45", default-features = false }
 toml = "0.8"
 sha2 = "0.10"
-rmcp = { version = "0.2", features = ["transport-io", "server"] }
+rmcp = { version = "1.7.0", features = ["transport-io", "server"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/libagent/Cargo.toml
+++ b/libagent/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+runa-forge-contract.workspace = true
 jsonschema = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -55,8 +55,8 @@ pub use model::{
     UnscopedOutputRequiresWorkUnitError, validate_output_scope,
 };
 pub use project::{
-    Config, ForgeConfig, LoadedProject, LogFormat, LoggingConfig, ProjectError, State,
-    TranscriptConfig,
+    Config, ForgeConfig, ForgeConnectorConfig, ForgeConnectorsConfig, LoadedProject, LogFormat,
+    LoggingConfig, ProjectError, State, TranscriptConfig,
 };
 pub use projection::{
     ProjectionCandidate, ProjectionClass, project_cascade, project_entry_cascade,

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::{ArtifactStore, DependencyGraph, GraphError, Manifest, ManifestError, StoreError};
+pub use runa_forge_contract::{ForgeConnectorConfig, ForgeConnectorsConfig};
 
 pub const RUNA_DIR: &str = ".runa";
 pub const CONFIG_FILENAME: &str = "config.toml";
@@ -100,6 +101,14 @@ pub struct Config {
     pub transcript: TranscriptConfig,
     #[serde(default, skip_serializing_if = "ForgeConfig::is_default")]
     pub forge: ForgeConfig,
+    #[serde(default, skip_serializing_if = "ForgeConnectorsConfig::is_default")]
+    pub connectors: ForgeConnectorsConfig,
+}
+
+impl Config {
+    pub fn effective_forge_connectors(&self) -> ForgeConnectorsConfig {
+        self.connectors.clone()
+    }
 }
 
 /// On-disk format for `.runa/state.toml` — initialization metadata managed by runa.
@@ -343,6 +352,7 @@ trigger = { type = "on_change", name = "constraints" }
             agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
+            connectors: ForgeConnectorsConfig::default(),
         };
         fs::write(
             runa_dir.join("config.toml"),
@@ -406,6 +416,7 @@ trigger = { type = "on_change", name = "constraints" }
             agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
+            connectors: ForgeConnectorsConfig::default(),
         };
         fs::write(&external_config_path, toml::to_string(&config).unwrap()).unwrap();
 
@@ -489,6 +500,7 @@ artifacts_dir = "custom-artifacts"
             agent: AgentConfig::default(),
             transcript: TranscriptConfig::default(),
             forge: ForgeConfig::default(),
+            connectors: ForgeConnectorsConfig::default(),
         };
         fs::write(
             runa_dir.join("config.toml"),
@@ -679,6 +691,7 @@ tracker_id = "4"
                 name: Some("runa".to_string()),
                 tracker_id: Some("4".to_string()),
             },
+            connectors: ForgeConnectorsConfig::default(),
         };
 
         let serialized = toml::to_string(&config).unwrap();

--- a/runa-cli/src/commands/init.rs
+++ b/runa-cli/src/commands/init.rs
@@ -120,6 +120,7 @@ pub fn run(
         agent: crate::project::AgentConfig::default(),
         transcript: crate::project::TranscriptConfig::default(),
         forge: crate::project::ForgeConfig::default(),
+        connectors: crate::project::ForgeConnectorsConfig::default(),
     };
     let config_toml = toml::to_string(&config).expect("Config serialization should not fail");
 

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -1744,6 +1744,7 @@ cat >/dev/null
                 name: Some("runa".to_string()),
                 tracker_id: None,
             },
+            connectors: libagent::ForgeConnectorsConfig::default(),
         };
 
         let env = resolved_runtime_env(temp.path(), &config);

--- a/runa-cli/tests/step.rs
+++ b/runa-cli/tests/step.rs
@@ -6,7 +6,13 @@ use std::process::Command;
 use std::time::Duration;
 
 fn runa_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_runa"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_runa"));
+    command
+        .env_remove("RUNA_FORGE_TYPE")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
+        .env_remove("RUNA_FORGE_TRACKER_ID");
+    command
 }
 
 fn runa_bin_path() -> &'static Path {

--- a/runa-forge-connectors/Cargo.toml
+++ b/runa-forge-connectors/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "runa-forge-connectors"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+runa-forge-contract = { workspace = true }
+runa-forge-github = { workspace = true }
+runa-forge-sourcehut = { workspace = true }
+serde_json = { workspace = true }
+

--- a/runa-forge-connectors/src/lib.rs
+++ b/runa-forge-connectors/src/lib.rs
@@ -1,0 +1,248 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use runa_forge_contract::{
+    ForgeConnectorConfig, ForgeConnectorsConfig, ForgeOperation, ForgeTool, ForgeToolSet,
+    ToolAliases, compose_tool_sets,
+};
+use runa_forge_github::{GitHubConfig, GitHubConnector, RecordingGitHubTransport};
+use runa_forge_sourcehut::{RecordingSourceHutTransport, SourceHutConfig, SourceHutConnector};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Default)]
+pub struct ConfiguredForgeConnectors {
+    connectors: Vec<ConfiguredConnector>,
+}
+
+impl ConfiguredForgeConnectors {
+    pub fn from_config(config: &ForgeConnectorsConfig) -> Result<Self, ForgeConnectorConfigError> {
+        let mut labels = BTreeSet::new();
+        let mut connectors = Vec::new();
+        for connector in &config.forge {
+            let configured = ConfiguredConnector::from_config(connector)?;
+            if !labels.insert(configured.label.clone()) {
+                return Err(ForgeConnectorConfigError::DuplicateLabel(
+                    configured.label.clone(),
+                ));
+            }
+            connectors.push(configured);
+        }
+
+        let registry = Self { connectors };
+        registry.composed_tools()?;
+        Ok(registry)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.connectors.is_empty()
+    }
+
+    pub fn composed_tools(&self) -> Result<Vec<ForgeTool>, ForgeConnectorConfigError> {
+        let aliases = self.aliases();
+        let sets = self
+            .connectors
+            .iter()
+            .map(ConfiguredConnector::tool_set)
+            .collect::<Vec<_>>();
+        compose_tool_sets(sets, aliases)
+            .map_err(|error| ForgeConnectorConfigError::CompositionFailed(error.to_string()))
+    }
+
+    pub fn contains_tool(&self, tool_name: &str) -> Result<bool, ForgeConnectorConfigError> {
+        Ok(self
+            .composed_tools()?
+            .iter()
+            .any(|tool| tool.name == tool_name))
+    }
+
+    pub fn call(&self, tool_name: &str, input: Value) -> Result<Value, ForgeConnectorCallError> {
+        let aliases = self.aliases().aliases;
+        for connector in &self.connectors {
+            let set = connector.tool_set();
+            for tool in &set.tools {
+                let name = aliases
+                    .get(&(set.provider.clone(), tool.name.clone()))
+                    .cloned()
+                    .unwrap_or_else(|| tool.name.clone());
+                if name == tool_name {
+                    return connector.call(tool.operation, input);
+                }
+            }
+        }
+        Err(ForgeConnectorCallError::UnknownTool(tool_name.to_owned()))
+    }
+
+    fn aliases(&self) -> ToolAliases {
+        let mut aliases = ToolAliases::default();
+        for connector in &self.connectors {
+            if let Some(prefix) = &connector.alias_prefix {
+                for operation in ForgeOperation::ALL {
+                    aliases.insert(
+                        connector.label.clone(),
+                        operation.name(),
+                        format!("{prefix}.{}", operation.name()),
+                    );
+                }
+            }
+        }
+        aliases
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ConfiguredConnectorKind {
+    GitHub(GitHubConnector),
+    SourceHut(SourceHutConnector),
+}
+
+#[derive(Clone, Debug)]
+struct ConfiguredConnector {
+    label: String,
+    alias_prefix: Option<String>,
+    kind: ConfiguredConnectorKind,
+}
+
+impl ConfiguredConnector {
+    fn from_config(config: &ForgeConnectorConfig) -> Result<Self, ForgeConnectorConfigError> {
+        let label = config
+            .label
+            .clone()
+            .unwrap_or_else(|| config.provider.clone());
+        let kind = match config.provider.as_str() {
+            "github" => {
+                let mut github = GitHubConfig::new(config.owner.clone(), config.name.clone());
+                github.credential_env = config.credentials.env.clone();
+                github.credential_command = config.credentials.command.clone();
+                ConfiguredConnectorKind::GitHub(GitHubConnector::new_for_test(
+                    github,
+                    RecordingGitHubTransport::default(),
+                ))
+            }
+            "sourcehut" => {
+                let tracker_id =
+                    config
+                        .tracker_id
+                        .ok_or_else(|| ForgeConnectorConfigError::MissingField {
+                            provider: config.provider.clone(),
+                            field: "tracker_id",
+                        })?;
+                let endpoint = config.endpoint.clone().ok_or_else(|| {
+                    ForgeConnectorConfigError::MissingField {
+                        provider: config.provider.clone(),
+                        field: "endpoint",
+                    }
+                })?;
+                let repo_id =
+                    config
+                        .repo_id
+                        .ok_or_else(|| ForgeConnectorConfigError::MissingField {
+                            provider: config.provider.clone(),
+                            field: "repo_id",
+                        })?;
+                let mut sourcehut = SourceHutConfig::new(
+                    config.owner.clone(),
+                    config.name.clone(),
+                    tracker_id,
+                    endpoint,
+                    repo_id,
+                );
+                sourcehut.credential_env = config.credentials.env.clone();
+                sourcehut.credential_command = config.credentials.command.clone();
+                ConfiguredConnectorKind::SourceHut(SourceHutConnector::new_for_test(
+                    sourcehut,
+                    RecordingSourceHutTransport::default(),
+                ))
+            }
+            other => return Err(ForgeConnectorConfigError::UnknownProvider(other.to_owned())),
+        };
+
+        Ok(Self {
+            label,
+            alias_prefix: config.alias_prefix.clone(),
+            kind,
+        })
+    }
+
+    fn tool_set(&self) -> ForgeToolSet {
+        let mut set = match &self.kind {
+            ConfiguredConnectorKind::GitHub(connector) => connector.tool_set(),
+            ConfiguredConnectorKind::SourceHut(connector) => connector.tool_set(),
+        };
+        set.provider = self.label.clone();
+        set
+    }
+
+    fn call(
+        &self,
+        operation: ForgeOperation,
+        input: Value,
+    ) -> Result<Value, ForgeConnectorCallError> {
+        match &self.kind {
+            ConfiguredConnectorKind::GitHub(connector) => connector
+                .call(operation, input)
+                .map_err(|error| ForgeConnectorCallError::Provider(error.to_string())),
+            ConfiguredConnectorKind::SourceHut(connector) => connector
+                .call(operation, input)
+                .map_err(|error| ForgeConnectorCallError::Provider(error.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeConnectorConfigError {
+    UnknownProvider(String),
+    MissingField {
+        provider: String,
+        field: &'static str,
+    },
+    DuplicateLabel(String),
+    CompositionFailed(String),
+}
+
+impl fmt::Display for ForgeConnectorConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForgeConnectorConfigError::UnknownProvider(provider) => {
+                write!(f, "unknown forge connector provider `{provider}`")
+            }
+            ForgeConnectorConfigError::MissingField { provider, field } => {
+                write!(
+                    f,
+                    "forge connector `{provider}` is missing required field `{field}`"
+                )
+            }
+            ForgeConnectorConfigError::DuplicateLabel(label) => {
+                write!(f, "duplicate forge connector label `{label}`")
+            }
+            ForgeConnectorConfigError::CompositionFailed(error) => f.write_str(error),
+        }
+    }
+}
+
+impl std::error::Error for ForgeConnectorConfigError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeConnectorCallError {
+    UnknownTool(String),
+    Provider(String),
+}
+
+impl fmt::Display for ForgeConnectorCallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForgeConnectorCallError::UnknownTool(tool) => {
+                write!(f, "unknown forge connector tool `{tool}`")
+            }
+            ForgeConnectorCallError::Provider(error) => f.write_str(error),
+        }
+    }
+}
+
+impl std::error::Error for ForgeConnectorCallError {}
+
+pub fn tool_by_name(tools: Vec<ForgeTool>) -> BTreeMap<String, ForgeTool> {
+    tools
+        .into_iter()
+        .map(|tool| (tool.name.clone(), tool))
+        .collect()
+}

--- a/runa-forge-contract/Cargo.toml
+++ b/runa-forge-contract/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "runa-forge-contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+

--- a/runa-forge-contract/src/lib.rs
+++ b/runa-forge-contract/src/lib.rs
@@ -1,0 +1,566 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+pub const FORGE_CAPABILITY_VERSION: &str = "1.1.0";
+pub const FORGE_CAPABILITY_COMMONS_COMMIT: &str = "6924159fc4ff58745f0e2c68ed16849ffd9b4086";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ForgeOperation {
+    ReadTicket,
+    CreateTicket,
+    ClaimWorkUnit,
+    RecordProgress,
+    DeliverChangeProposal,
+    ReflectDisposition,
+    ApplyApprovedChange,
+    CloseOut,
+}
+
+impl ForgeOperation {
+    pub const ALL: [ForgeOperation; 8] = [
+        ForgeOperation::ReadTicket,
+        ForgeOperation::CreateTicket,
+        ForgeOperation::ClaimWorkUnit,
+        ForgeOperation::RecordProgress,
+        ForgeOperation::DeliverChangeProposal,
+        ForgeOperation::ReflectDisposition,
+        ForgeOperation::ApplyApprovedChange,
+        ForgeOperation::CloseOut,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            ForgeOperation::ReadTicket => "read-ticket",
+            ForgeOperation::CreateTicket => "create-ticket",
+            ForgeOperation::ClaimWorkUnit => "claim-work-unit",
+            ForgeOperation::RecordProgress => "record-progress",
+            ForgeOperation::DeliverChangeProposal => "deliver-change-proposal",
+            ForgeOperation::ReflectDisposition => "reflect-disposition",
+            ForgeOperation::ApplyApprovedChange => "apply-approved-change",
+            ForgeOperation::CloseOut => "close-out",
+        }
+    }
+}
+
+impl fmt::Display for ForgeOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Handle {
+    pub id: String,
+    pub display: String,
+}
+
+impl Handle {
+    pub fn new(id: impl Into<String>, display: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            display: display.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ForgeTool {
+    pub operation: ForgeOperation,
+    pub name: String,
+    pub description: String,
+    pub input_schema: Map<String, Value>,
+    pub output_schema: Map<String, Value>,
+    pub representative_input: Value,
+    pub representative_output: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ForgeToolSet {
+    pub provider: String,
+    pub tools: Vec<ForgeTool>,
+}
+
+impl ForgeToolSet {
+    pub fn new(provider: impl Into<String>, tools: Vec<ForgeTool>) -> Self {
+        Self {
+            provider: provider.into(),
+            tools,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeConnectorsConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forge: Vec<ForgeConnectorConfig>,
+}
+
+impl ForgeConnectorsConfig {
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeConnectorConfig {
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias_prefix: Option<String>,
+    pub owner: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracker_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "ForgeCredentialConfig::is_default")]
+    pub credentials: ForgeCredentialConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeCredentialConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+}
+
+impl ForgeCredentialConfig {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ToolAliases {
+    pub aliases: BTreeMap<(String, String), String>,
+}
+
+impl ToolAliases {
+    pub fn insert(
+        &mut self,
+        provider: impl Into<String>,
+        tool_name: impl Into<String>,
+        alias: impl Into<String>,
+    ) {
+        self.aliases
+            .insert((provider.into(), tool_name.into()), alias.into());
+    }
+
+    fn alias_for(&self, provider: &str, tool_name: &str) -> Option<&str> {
+        self.aliases
+            .get(&(provider.to_owned(), tool_name.to_owned()))
+            .map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposeError {
+    Collision {
+        tool_name: String,
+        providers: Vec<String>,
+    },
+    AliasCollision {
+        tool_name: String,
+    },
+}
+
+impl fmt::Display for ComposeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ComposeError::Collision {
+                tool_name,
+                providers,
+            } => write!(
+                f,
+                "forge tool collision for {tool_name} across providers: {}",
+                providers.join(", ")
+            ),
+            ComposeError::AliasCollision { tool_name } => {
+                write!(f, "forge tool alias collision for {tool_name}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ComposeError {}
+
+pub fn compose_tool_sets(
+    sets: Vec<ForgeToolSet>,
+    aliases: ToolAliases,
+) -> Result<Vec<ForgeTool>, ComposeError> {
+    let mut natural_owners: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut natural_order = Vec::new();
+    for set in &sets {
+        for tool in &set.tools {
+            if aliases.alias_for(&set.provider, &tool.name).is_none() {
+                let owners = natural_owners.entry(tool.name.clone()).or_default();
+                if owners.is_empty() {
+                    natural_order.push(tool.name.clone());
+                }
+                owners.push(set.provider.clone());
+            }
+        }
+    }
+
+    for tool_name in natural_order {
+        let providers = natural_owners
+            .remove(&tool_name)
+            .expect("ordered tool name must exist in owner map");
+        if providers.len() > 1 {
+            return Err(ComposeError::Collision {
+                tool_name,
+                providers,
+            });
+        }
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut composed = Vec::new();
+    for set in sets {
+        for mut tool in set.tools {
+            if let Some(alias) = aliases.alias_for(&set.provider, &tool.name) {
+                tool.name = alias.to_owned();
+            }
+            if !seen.insert(tool.name.clone()) {
+                return Err(ComposeError::AliasCollision {
+                    tool_name: tool.name,
+                });
+            }
+            composed.push(tool);
+        }
+    }
+    Ok(composed)
+}
+
+pub fn forge_tool_set(provider: impl Into<String>) -> ForgeToolSet {
+    ForgeToolSet::new(
+        provider,
+        ForgeOperation::ALL
+            .iter()
+            .copied()
+            .map(forge_tool)
+            .collect(),
+    )
+}
+
+pub fn forge_tool(operation: ForgeOperation) -> ForgeTool {
+    ForgeTool {
+        operation,
+        name: operation.name().to_owned(),
+        description: format!("Forge capability operation `{}`.", operation.name()),
+        input_schema: schema_object(operation, SchemaSide::Input),
+        output_schema: schema_object(operation, SchemaSide::Output),
+        representative_input: representative_input(operation),
+        representative_output: representative_output(operation),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SchemaSide {
+    Input,
+    Output,
+}
+
+fn schema_object(operation: ForgeOperation, side: SchemaSide) -> Map<String, Value> {
+    let mut root = match (operation, side) {
+        (ForgeOperation::ReadTicket, SchemaSide::Input) => object_schema(
+            &["reference"],
+            vec![("reference", json!({ "type": "string", "minLength": 1 }))],
+        ),
+        (ForgeOperation::ReadTicket, SchemaSide::Output) => ticket_snapshot_schema(),
+        (ForgeOperation::CreateTicket, SchemaSide::Input) => object_schema(
+            &["title", "body"],
+            vec![
+                ("title", json!({ "type": "string", "minLength": 1 })),
+                ("body", json!({ "type": "string" })),
+                (
+                    "labels",
+                    json!({ "type": "array", "items": { "type": "string" } }),
+                ),
+            ],
+        ),
+        (ForgeOperation::CreateTicket, SchemaSide::Output) => ticket_snapshot_schema(),
+        (ForgeOperation::ClaimWorkUnit, SchemaSide::Input) => object_schema(
+            &["work_unit"],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("claimant", json!({ "type": "string", "minLength": 1 })),
+            ],
+        ),
+        (ForgeOperation::ClaimWorkUnit, SchemaSide::Output) => effect_schema("claimed"),
+        (ForgeOperation::RecordProgress, SchemaSide::Input) => object_schema(
+            &["work_unit", "body"],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("body", json!({ "type": "string", "minLength": 1 })),
+            ],
+        ),
+        (ForgeOperation::RecordProgress, SchemaSide::Output) => effect_schema("progress-recorded"),
+        (ForgeOperation::DeliverChangeProposal, SchemaSide::Input) => object_schema(
+            &[
+                "work_unit",
+                "branch",
+                "commit",
+                "base",
+                "summary",
+                "body",
+                "version",
+            ],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("branch", json!({ "type": "string", "minLength": 1 })),
+                ("commit", json!({ "type": "string", "minLength": 1 })),
+                ("base", json!({ "type": "string", "minLength": 1 })),
+                ("summary", json!({ "type": "string", "minLength": 1 })),
+                ("body", json!({ "type": "string" })),
+                ("version", json!({ "type": "string", "minLength": 1 })),
+            ],
+        ),
+        (ForgeOperation::DeliverChangeProposal, SchemaSide::Output) => object_schema(
+            &["change", "work_unit", "commit", "version"],
+            vec![
+                ("change", json!({ "$ref": "#/$defs/handle" })),
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("commit", json!({ "type": "string", "minLength": 1 })),
+                ("version", json!({ "type": "string", "minLength": 1 })),
+                ("url", json!({ "type": "string", "minLength": 1 })),
+            ],
+        ),
+        (ForgeOperation::ReflectDisposition, SchemaSide::Input) => object_schema(
+            &["work_unit", "change", "disposition", "body"],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("change", json!({ "$ref": "#/$defs/handle" })),
+                ("disposition", json!({ "$ref": "#/$defs/disposition" })),
+                ("body", json!({ "type": "string" })),
+            ],
+        ),
+        (ForgeOperation::ReflectDisposition, SchemaSide::Output) => {
+            effect_schema("disposition-reflected")
+        }
+        (ForgeOperation::ApplyApprovedChange, SchemaSide::Input) => object_schema(
+            &[
+                "work_unit",
+                "change",
+                "approved_version",
+                "approved_commit",
+                "base",
+            ],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("change", json!({ "$ref": "#/$defs/handle" })),
+                (
+                    "approved_version",
+                    json!({ "type": "string", "minLength": 1 }),
+                ),
+                (
+                    "approved_commit",
+                    json!({ "type": "string", "minLength": 1 }),
+                ),
+                ("base", json!({ "type": "string", "minLength": 1 })),
+            ],
+        ),
+        (ForgeOperation::ApplyApprovedChange, SchemaSide::Output) => object_schema(
+            &["work_unit", "change", "applied_commit"],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("change", json!({ "$ref": "#/$defs/handle" })),
+                (
+                    "applied_commit",
+                    json!({ "type": "string", "minLength": 1 }),
+                ),
+                ("status", json!({ "const": "applied" })),
+            ],
+        ),
+        (ForgeOperation::CloseOut, SchemaSide::Input) => object_schema(
+            &["work_unit", "completion", "body"],
+            vec![
+                ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+                ("completion", json!({ "$ref": "#/$defs/completion" })),
+                ("body", json!({ "type": "string" })),
+            ],
+        ),
+        (ForgeOperation::CloseOut, SchemaSide::Output) => effect_schema("closed-out"),
+    };
+
+    root.insert(
+        "$schema".to_owned(),
+        json!("https://json-schema.org/draft/2020-12/schema"),
+    );
+    root.insert("$defs".to_owned(), defs());
+    root
+}
+
+fn object_schema(required: &[&str], fields: Vec<(&str, Value)>) -> Map<String, Value> {
+    let mut properties = Map::new();
+    for (name, schema) in fields {
+        properties.insert(name.to_owned(), schema);
+    }
+
+    let mut root = Map::new();
+    root.insert("type".to_owned(), json!("object"));
+    root.insert("additionalProperties".to_owned(), json!(false));
+    root.insert(
+        "required".to_owned(),
+        Value::Array(required.iter().map(|field| json!(field)).collect()),
+    );
+    root.insert("properties".to_owned(), Value::Object(properties));
+    root
+}
+
+fn ticket_snapshot_schema() -> Map<String, Value> {
+    object_schema(
+        &["handle", "title", "body", "state"],
+        vec![
+            ("handle", json!({ "$ref": "#/$defs/handle" })),
+            ("title", json!({ "type": "string" })),
+            ("body", json!({ "type": "string" })),
+            ("state", json!({ "enum": ["open", "closed"] })),
+            ("url", json!({ "type": "string" })),
+        ],
+    )
+}
+
+fn effect_schema(status: &'static str) -> Map<String, Value> {
+    object_schema(
+        &["work_unit", "status"],
+        vec![
+            ("work_unit", json!({ "$ref": "#/$defs/handle" })),
+            ("status", json!({ "const": status })),
+            ("url", json!({ "type": "string" })),
+        ],
+    )
+}
+
+fn defs() -> Value {
+    json!({
+        "handle": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "display"],
+            "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "display": { "type": "string", "minLength": 1 }
+            }
+        },
+        "disposition": {
+            "enum": ["approved", "needs-revision", "rejected"]
+        },
+        "completion": {
+            "enum": ["complete", "not-planned", "duplicate"]
+        }
+    })
+}
+
+fn example_work_unit() -> Value {
+    json!({
+        "id": "example:tracker:ticket:203",
+        "display": "example#203"
+    })
+}
+
+fn example_change() -> Value {
+    json!({
+        "id": "example:change:1",
+        "display": "example!1"
+    })
+}
+
+fn representative_input(operation: ForgeOperation) -> Value {
+    match operation {
+        ForgeOperation::ReadTicket => json!({ "reference": "203" }),
+        ForgeOperation::CreateTicket => json!({
+            "title": "Connector layer",
+            "body": "Build forge connector surface.",
+            "labels": ["task"]
+        }),
+        ForgeOperation::ClaimWorkUnit => json!({
+            "work_unit": example_work_unit(),
+            "claimant": "core"
+        }),
+        ForgeOperation::RecordProgress => json!({
+            "work_unit": example_work_unit(),
+            "body": "Progress recorded."
+        }),
+        ForgeOperation::DeliverChangeProposal => json!({
+            "work_unit": example_work_unit(),
+            "branch": "work/203-connectors",
+            "commit": "abc123",
+            "base": "main",
+            "summary": "Implement connector layer",
+            "body": "Change proposal body.",
+            "version": "1"
+        }),
+        ForgeOperation::ReflectDisposition => json!({
+            "work_unit": example_work_unit(),
+            "change": example_change(),
+            "disposition": "approved",
+            "body": "Approved."
+        }),
+        ForgeOperation::ApplyApprovedChange => json!({
+            "work_unit": example_work_unit(),
+            "change": example_change(),
+            "approved_version": "1",
+            "approved_commit": "abc123",
+            "base": "main"
+        }),
+        ForgeOperation::CloseOut => json!({
+            "work_unit": example_work_unit(),
+            "completion": "complete",
+            "body": "Closed."
+        }),
+    }
+}
+
+fn representative_output(operation: ForgeOperation) -> Value {
+    match operation {
+        ForgeOperation::ReadTicket | ForgeOperation::CreateTicket => json!({
+            "handle": example_work_unit(),
+            "title": "Connector layer",
+            "body": "Build forge connector surface.",
+            "state": "open",
+            "url": "https://example.invalid/ticket/203"
+        }),
+        ForgeOperation::ClaimWorkUnit => json!({
+            "work_unit": example_work_unit(),
+            "status": "claimed",
+            "url": "https://example.invalid/ticket/203"
+        }),
+        ForgeOperation::RecordProgress => json!({
+            "work_unit": example_work_unit(),
+            "status": "progress-recorded",
+            "url": "https://example.invalid/ticket/203"
+        }),
+        ForgeOperation::DeliverChangeProposal => json!({
+            "change": example_change(),
+            "work_unit": example_work_unit(),
+            "commit": "abc123",
+            "version": "1",
+            "url": "https://example.invalid/change/1"
+        }),
+        ForgeOperation::ReflectDisposition => json!({
+            "work_unit": example_work_unit(),
+            "status": "disposition-reflected",
+            "url": "https://example.invalid/ticket/203"
+        }),
+        ForgeOperation::ApplyApprovedChange => json!({
+            "work_unit": example_work_unit(),
+            "change": example_change(),
+            "applied_commit": "abc123",
+            "status": "applied"
+        }),
+        ForgeOperation::CloseOut => json!({
+            "work_unit": example_work_unit(),
+            "status": "closed-out",
+            "url": "https://example.invalid/ticket/203"
+        }),
+    }
+}

--- a/runa-forge-github/Cargo.toml
+++ b/runa-forge-github/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-forge-github"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+runa-forge-contract = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -1,0 +1,408 @@
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use runa_forge_contract::{ForgeOperation, ForgeToolSet, Handle, forge_tool_set};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitHubConfig {
+    pub owner: String,
+    pub repo: String,
+    pub api_base_url: String,
+    pub web_base_url: String,
+    pub assignee: Option<String>,
+    pub credential_env: Option<String>,
+    pub credential_command: Option<Vec<String>>,
+}
+
+impl GitHubConfig {
+    pub fn new(owner: impl Into<String>, repo: impl Into<String>) -> Self {
+        Self {
+            owner: owner.into(),
+            repo: repo.into(),
+            api_base_url: "https://api.github.com".to_owned(),
+            web_base_url: "https://github.com".to_owned(),
+            assignee: None,
+            credential_env: None,
+            credential_command: None,
+        }
+    }
+
+    fn repo_path(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRequest {
+    pub summary: String,
+    pub method: String,
+    pub path: String,
+    pub body: Value,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RecordingGitHubTransport {
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl RecordingGitHubTransport {
+    pub fn record(&self, request: ProviderRequest) {
+        self.requests
+            .lock()
+            .expect("request log poisoned")
+            .push(request);
+    }
+
+    pub fn take_requests(&self) -> Vec<ProviderRequest> {
+        std::mem::take(&mut *self.requests.lock().expect("request log poisoned"))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GitHubConnector {
+    config: GitHubConfig,
+    transport: RecordingGitHubTransport,
+}
+
+impl GitHubConnector {
+    pub fn new_for_test(config: GitHubConfig, transport: RecordingGitHubTransport) -> Self {
+        Self { config, transport }
+    }
+
+    pub fn config(&self) -> &GitHubConfig {
+        &self.config
+    }
+
+    pub fn tool_set(&self) -> ForgeToolSet {
+        forge_tool_set("github")
+    }
+
+    pub fn resolve_reference(&self, reference: &str) -> Result<Handle, ForgeGitHubError> {
+        let issue = self.parse_ticket_number(reference)?;
+        Ok(self.work_unit_handle(issue))
+    }
+
+    pub fn validate_work_unit_handle_id(&self, handle_id: &str) -> Result<u64, ForgeGitHubError> {
+        let prefix = format!("github:{}:issue:", self.config.repo_path());
+        let Some(number) = handle_id.strip_prefix(&prefix) else {
+            return Err(ForgeGitHubError::OutOfScope(handle_id.to_owned()));
+        };
+        parse_positive_number(number)
+    }
+
+    pub fn call(&self, operation: ForgeOperation, input: Value) -> Result<Value, ForgeGitHubError> {
+        match operation {
+            ForgeOperation::ReadTicket => self.read_ticket(&input),
+            ForgeOperation::CreateTicket => self.create_ticket(&input),
+            ForgeOperation::ClaimWorkUnit => self.claim_work_unit(&input),
+            ForgeOperation::RecordProgress => self.record_progress(&input),
+            ForgeOperation::DeliverChangeProposal => self.deliver_change_proposal(&input),
+            ForgeOperation::ReflectDisposition => self.reflect_disposition(&input),
+            ForgeOperation::ApplyApprovedChange => self.apply_approved_change(&input),
+            ForgeOperation::CloseOut => self.close_out(&input),
+        }
+    }
+
+    fn read_ticket(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let reference = input
+            .get("reference")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ForgeGitHubError::InvalidInput("missing reference".to_owned()))?;
+        let handle = self.resolve_reference(reference)?;
+        let issue = self.validate_work_unit_handle_id(&handle.id)?;
+        self.record("GET", issue_path(&self.config, issue), json!({}));
+        Ok(json!({
+            "handle": handle,
+            "title": "",
+            "body": "",
+            "state": "open",
+            "url": self.issue_url(issue)
+        }))
+    }
+
+    fn create_ticket(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let title = string_field(input, "title")?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let issue = 0;
+        let path = format!("repos/{}/issues", self.config.repo_path());
+        self.record(
+            "POST",
+            path,
+            json!({
+                "title": title,
+                "body": body,
+                "labels": input.get("labels").cloned().unwrap_or_else(|| json!([]))
+            }),
+        );
+        Ok(json!({
+            "handle": self.work_unit_handle(issue),
+            "title": title,
+            "body": body,
+            "state": "open",
+            "url": self.issue_url(issue)
+        }))
+    }
+
+    fn claim_work_unit(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let (issue, handle) = self.work_unit_from_input(input)?;
+        let assignee = input
+            .get("claimant")
+            .and_then(Value::as_str)
+            .or(self.config.assignee.as_deref())
+            .unwrap_or("core");
+        self.record(
+            "PATCH",
+            issue_path(&self.config, issue),
+            json!({ "assignees": [assignee] }),
+        );
+        Ok(effect(handle, "claimed", self.issue_url(issue)))
+    }
+
+    fn record_progress(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let (issue, handle) = self.work_unit_from_input(input)?;
+        let body = string_field(input, "body")?;
+        let path = format!("{}/comments", issue_path(&self.config, issue));
+        self.record("POST", path, json!({ "body": body }));
+        Ok(effect(handle, "progress-recorded", self.issue_url(issue)))
+    }
+
+    fn deliver_change_proposal(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let (issue, handle) = self.work_unit_from_input(input)?;
+        let branch = string_field(input, "branch")?;
+        let commit = string_field(input, "commit")?;
+        let base = string_field(input, "base")?;
+        let summary = string_field(input, "summary")?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let version = string_field(input, "version")?;
+        let path = format!("repos/{}/pulls", self.config.repo_path());
+        self.record(
+            "POST",
+            path,
+            json!({
+                "head": branch,
+                "base": base,
+                "title": summary,
+                "body": body,
+                "issue": issue
+            }),
+        );
+        let change = Handle::new(
+            format!(
+                "github:{}:issue:{issue}:pull:0:v{version}",
+                self.config.repo_path()
+            ),
+            format!("github:{}#{}!0@{}", self.config.repo_path(), issue, version),
+        );
+        Ok(json!({
+            "change": change,
+            "work_unit": handle,
+            "commit": commit,
+            "version": version,
+            "url": self.pull_url(0)
+        }))
+    }
+
+    fn reflect_disposition(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let (issue, handle) = self.work_unit_from_input(input)?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let disposition = string_field(input, "disposition")?;
+        let path = format!("{}/comments", issue_path(&self.config, issue));
+        self.record(
+            "POST",
+            path,
+            json!({ "body": format!("{disposition}: {body}") }),
+        );
+        Ok(effect(
+            handle,
+            "disposition-reflected",
+            self.issue_url(issue),
+        ))
+    }
+
+    fn apply_approved_change(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let (issue, handle) = self.work_unit_from_input(input)?;
+        let change = handle_field(input, "change")?;
+        let commit = string_field(input, "approved_commit")?;
+        self.record(
+            "PUT",
+            format!("repos/{}/pulls/0/merge", self.config.repo_path()),
+            json!({ "sha": commit }),
+        );
+        Ok(json!({
+            "work_unit": handle,
+            "change": change,
+            "applied_commit": commit,
+            "status": "applied",
+            "url": self.issue_url(issue)
+        }))
+    }
+
+    fn close_out(&self, input: &Value) -> Result<Value, ForgeGitHubError> {
+        let (issue, handle) = self.work_unit_from_input(input)?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        self.record(
+            "POST",
+            format!("{}/comments", issue_path(&self.config, issue)),
+            json!({ "body": body }),
+        );
+        self.record(
+            "PATCH",
+            issue_path(&self.config, issue),
+            json!({ "state": "closed" }),
+        );
+        Ok(effect(handle, "closed-out", self.issue_url(issue)))
+    }
+
+    fn work_unit_from_input(&self, input: &Value) -> Result<(u64, Handle), ForgeGitHubError> {
+        let handle = input
+            .get("work_unit")
+            .or_else(|| input.get("handle"))
+            .ok_or_else(|| ForgeGitHubError::InvalidInput("missing work_unit handle".to_owned()))
+            .and_then(parse_handle)?;
+        let issue = self.validate_work_unit_handle_id(&handle.id)?;
+        Ok((issue, handle))
+    }
+
+    fn parse_ticket_number(&self, reference: &str) -> Result<u64, ForgeGitHubError> {
+        if let Some(rest) = reference.strip_prefix("github:") {
+            let expected = format!("{}#", self.config.repo_path());
+            let Some(number) = rest.strip_prefix(&expected) else {
+                return Err(ForgeGitHubError::OutOfScope(reference.to_owned()));
+            };
+            return parse_positive_number(number);
+        }
+
+        if let Some(number) = reference.strip_prefix('#') {
+            return parse_positive_number(number);
+        }
+
+        if let Some((repo_path, number)) = reference.split_once('#') {
+            if repo_path == self.config.repo_path() {
+                return parse_positive_number(number);
+            }
+            return Err(ForgeGitHubError::OutOfScope(reference.to_owned()));
+        }
+
+        parse_positive_number(reference)
+    }
+
+    fn work_unit_handle(&self, issue: u64) -> Handle {
+        Handle::new(
+            format!("github:{}:issue:{issue}", self.config.repo_path()),
+            format!("github:{}#{issue}", self.config.repo_path()),
+        )
+    }
+
+    fn issue_url(&self, issue: u64) -> String {
+        format!(
+            "{}/{}/issues/{issue}",
+            self.config.web_base_url,
+            self.config.repo_path()
+        )
+    }
+
+    fn pull_url(&self, pull: u64) -> String {
+        format!(
+            "{}/{}/pull/{pull}",
+            self.config.web_base_url,
+            self.config.repo_path()
+        )
+    }
+
+    fn record(&self, method: &str, path: String, body: Value) {
+        self.transport.record(ProviderRequest {
+            summary: format!("github {method} {path}"),
+            method: method.to_owned(),
+            path,
+            body,
+        });
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeGitHubError {
+    InvalidInput(String),
+    InvalidReference(String),
+    OutOfScope(String),
+}
+
+impl fmt::Display for ForgeGitHubError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForgeGitHubError::InvalidInput(message) => f.write_str(message),
+            ForgeGitHubError::InvalidReference(reference) => {
+                write!(f, "invalid GitHub reference `{reference}`")
+            }
+            ForgeGitHubError::OutOfScope(reference) => {
+                write!(
+                    f,
+                    "GitHub reference `{reference}` is outside connector scope"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ForgeGitHubError {}
+
+fn issue_path(config: &GitHubConfig, issue: u64) -> String {
+    format!("repos/{}/issues/{issue}", config.repo_path())
+}
+
+fn parse_positive_number(value: &str) -> Result<u64, ForgeGitHubError> {
+    let number = value
+        .parse::<u64>()
+        .map_err(|_| ForgeGitHubError::InvalidReference(value.to_owned()))?;
+    if number == 0 {
+        return Err(ForgeGitHubError::InvalidReference(value.to_owned()));
+    }
+    Ok(number)
+}
+
+fn string_field<'a>(input: &'a Value, field: &str) -> Result<&'a str, ForgeGitHubError> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| ForgeGitHubError::InvalidInput(format!("missing {field}")))
+}
+
+fn handle_field(input: &Value, field: &str) -> Result<Handle, ForgeGitHubError> {
+    input
+        .get(field)
+        .ok_or_else(|| ForgeGitHubError::InvalidInput(format!("missing {field} handle")))
+        .and_then(parse_handle)
+}
+
+fn parse_handle(value: &Value) -> Result<Handle, ForgeGitHubError> {
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ForgeGitHubError::InvalidInput("missing handle id".to_owned()))?;
+    let display = value
+        .get("display")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ForgeGitHubError::InvalidInput("missing handle display".to_owned()))?;
+    Ok(Handle::new(id, display))
+}
+
+fn effect(handle: Handle, status: &str, url: String) -> Value {
+    json!({
+        "work_unit": handle,
+        "status": status,
+        "url": url
+    })
+}

--- a/runa-forge-sourcehut/Cargo.toml
+++ b/runa-forge-sourcehut/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-forge-sourcehut"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+runa-forge-contract = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -1,0 +1,430 @@
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use runa_forge_contract::{ForgeOperation, ForgeToolSet, Handle, forge_tool_set};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceHutConfig {
+    pub owner: String,
+    pub repo: String,
+    pub tracker_id: u64,
+    pub endpoint: String,
+    pub repo_id: u64,
+    pub credential_env: Option<String>,
+    pub credential_command: Option<Vec<String>>,
+}
+
+impl SourceHutConfig {
+    pub fn new(
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+        tracker_id: u64,
+        endpoint: impl Into<String>,
+        repo_id: u64,
+    ) -> Self {
+        Self {
+            owner: owner.into(),
+            repo: repo.into(),
+            tracker_id,
+            endpoint: endpoint.into(),
+            repo_id,
+            credential_env: None,
+            credential_command: None,
+        }
+    }
+
+    pub fn todo_query_url(&self) -> String {
+        format!("https://todo.{}/query", self.endpoint)
+    }
+
+    pub fn git_remote(&self) -> String {
+        format!("git@git.{}:~{}/{}", self.endpoint, self.owner, self.repo)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRequest {
+    pub summary: String,
+    pub method: String,
+    pub path: String,
+    pub body: Value,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RecordingSourceHutTransport {
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl RecordingSourceHutTransport {
+    pub fn record(&self, request: ProviderRequest) {
+        self.requests
+            .lock()
+            .expect("request log poisoned")
+            .push(request);
+    }
+
+    pub fn take_requests(&self) -> Vec<ProviderRequest> {
+        std::mem::take(&mut *self.requests.lock().expect("request log poisoned"))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SourceHutConnector {
+    config: SourceHutConfig,
+    transport: RecordingSourceHutTransport,
+}
+
+impl SourceHutConnector {
+    pub fn new_for_test(config: SourceHutConfig, transport: RecordingSourceHutTransport) -> Self {
+        Self { config, transport }
+    }
+
+    pub fn config(&self) -> &SourceHutConfig {
+        &self.config
+    }
+
+    pub fn tool_set(&self) -> ForgeToolSet {
+        forge_tool_set("sourcehut")
+    }
+
+    pub fn resolve_reference(&self, reference: &str) -> Result<Handle, ForgeSourceHutError> {
+        let ticket = self.parse_ticket_number(reference)?;
+        Ok(self.work_unit_handle(ticket))
+    }
+
+    pub fn validate_work_unit_handle_id(
+        &self,
+        handle_id: &str,
+    ) -> Result<u64, ForgeSourceHutError> {
+        let prefix = format!("sourcehut:tracker:{}:ticket:", self.config.tracker_id);
+        let Some(number) = handle_id.strip_prefix(&prefix) else {
+            return Err(ForgeSourceHutError::OutOfScope(handle_id.to_owned()));
+        };
+        parse_positive_number(number)
+    }
+
+    pub fn call(
+        &self,
+        operation: ForgeOperation,
+        input: Value,
+    ) -> Result<Value, ForgeSourceHutError> {
+        match operation {
+            ForgeOperation::ReadTicket => self.read_ticket(&input),
+            ForgeOperation::CreateTicket => self.create_ticket(&input),
+            ForgeOperation::ClaimWorkUnit => self.claim_work_unit(&input),
+            ForgeOperation::RecordProgress => self.record_progress(&input),
+            ForgeOperation::DeliverChangeProposal => self.deliver_change_proposal(&input),
+            ForgeOperation::ReflectDisposition => self.reflect_disposition(&input),
+            ForgeOperation::ApplyApprovedChange => self.apply_approved_change(&input),
+            ForgeOperation::CloseOut => self.close_out(&input),
+        }
+    }
+
+    fn read_ticket(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let reference = input
+            .get("reference")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ForgeSourceHutError::InvalidInput("missing reference".to_owned()))?;
+        let handle = self.resolve_reference(reference)?;
+        let ticket = self.validate_work_unit_handle_id(&handle.id)?;
+        self.graphql(
+            "ticket",
+            ticket,
+            json!({ "trackerId": self.config.tracker_id, "ticketId": ticket }),
+        );
+        Ok(json!({
+            "handle": handle,
+            "title": "",
+            "body": "",
+            "state": "open",
+            "url": self.ticket_url(ticket)
+        }))
+    }
+
+    fn create_ticket(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let title = string_field(input, "title")?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let ticket = 0;
+        self.graphql(
+            "createTicket",
+            ticket,
+            json!({
+                "trackerId": self.config.tracker_id,
+                "title": title,
+                "body": body
+            }),
+        );
+        Ok(json!({
+            "handle": self.work_unit_handle(ticket),
+            "title": title,
+            "body": body,
+            "state": "open",
+            "url": self.ticket_url(ticket)
+        }))
+    }
+
+    fn claim_work_unit(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let (ticket, handle) = self.work_unit_from_input(input)?;
+        self.graphql(
+            "assignUser",
+            ticket,
+            json!({ "trackerId": self.config.tracker_id, "ticketId": ticket }),
+        );
+        Ok(effect(handle, "claimed", self.ticket_url(ticket)))
+    }
+
+    fn record_progress(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let (ticket, handle) = self.work_unit_from_input(input)?;
+        let body = string_field(input, "body")?;
+        self.graphql(
+            "submitComment",
+            ticket,
+            json!({
+                "trackerId": self.config.tracker_id,
+                "ticketId": ticket,
+                "body": body
+            }),
+        );
+        Ok(effect(handle, "progress-recorded", self.ticket_url(ticket)))
+    }
+
+    fn deliver_change_proposal(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let (ticket, handle) = self.work_unit_from_input(input)?;
+        let commit = string_field(input, "commit")?;
+        let version = string_field(input, "version")?;
+        let branch = string_field(input, "branch")?;
+        self.record_git(
+            "pushProposal",
+            json!({
+                "remote": self.config.git_remote(),
+                "source": branch,
+                "destination": format!("refs/proposals/{ticket}/{version}")
+            }),
+        );
+        let change = Handle::new(
+            format!(
+                "sourcehut:tracker:{}:ticket:{ticket}:proposal:{version}",
+                self.config.tracker_id
+            ),
+            format!(
+                "sourcehut:{}#{}@{}",
+                self.config.tracker_id, ticket, version
+            ),
+        );
+        Ok(json!({
+            "change": change,
+            "work_unit": handle,
+            "commit": commit,
+            "version": version,
+            "url": self.ticket_url(ticket)
+        }))
+    }
+
+    fn reflect_disposition(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let (ticket, handle) = self.work_unit_from_input(input)?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let disposition = string_field(input, "disposition")?;
+        self.graphql(
+            "submitComment",
+            ticket,
+            json!({
+                "trackerId": self.config.tracker_id,
+                "ticketId": ticket,
+                "body": format!("{disposition}: {body}")
+            }),
+        );
+        Ok(effect(
+            handle,
+            "disposition-reflected",
+            self.ticket_url(ticket),
+        ))
+    }
+
+    fn apply_approved_change(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let (ticket, handle) = self.work_unit_from_input(input)?;
+        let change = handle_field(input, "change")?;
+        let commit = string_field(input, "approved_commit")?;
+        self.record_git(
+            "applyProposal",
+            json!({
+                "remote": self.config.git_remote(),
+                "commit": commit
+            }),
+        );
+        Ok(json!({
+            "work_unit": handle,
+            "change": change,
+            "applied_commit": commit,
+            "status": "applied",
+            "url": self.ticket_url(ticket)
+        }))
+    }
+
+    fn close_out(&self, input: &Value) -> Result<Value, ForgeSourceHutError> {
+        let (ticket, handle) = self.work_unit_from_input(input)?;
+        let body = input
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        self.graphql(
+            "submitComment",
+            ticket,
+            json!({
+                "trackerId": self.config.tracker_id,
+                "ticketId": ticket,
+                "body": body
+            }),
+        );
+        self.graphql(
+            "closeTicket",
+            ticket,
+            json!({
+                "trackerId": self.config.tracker_id,
+                "ticketId": ticket
+            }),
+        );
+        Ok(effect(handle, "closed-out", self.ticket_url(ticket)))
+    }
+
+    fn work_unit_from_input(&self, input: &Value) -> Result<(u64, Handle), ForgeSourceHutError> {
+        let handle = input
+            .get("work_unit")
+            .or_else(|| input.get("handle"))
+            .ok_or_else(|| ForgeSourceHutError::InvalidInput("missing work_unit handle".to_owned()))
+            .and_then(parse_handle)?;
+        let ticket = self.validate_work_unit_handle_id(&handle.id)?;
+        Ok((ticket, handle))
+    }
+
+    fn parse_ticket_number(&self, reference: &str) -> Result<u64, ForgeSourceHutError> {
+        if let Some(rest) = reference.strip_prefix("sourcehut:") {
+            let expected = format!("{}#", self.config.tracker_id);
+            let Some(number) = rest.strip_prefix(&expected) else {
+                return Err(ForgeSourceHutError::OutOfScope(reference.to_owned()));
+            };
+            return parse_positive_number(number);
+        }
+
+        if let Some(number) = reference.strip_prefix('#') {
+            return parse_positive_number(number);
+        }
+
+        parse_positive_number(reference)
+    }
+
+    fn work_unit_handle(&self, ticket: u64) -> Handle {
+        Handle::new(
+            format!(
+                "sourcehut:tracker:{}:ticket:{ticket}",
+                self.config.tracker_id
+            ),
+            format!("sourcehut:{}#{ticket}", self.config.tracker_id),
+        )
+    }
+
+    fn ticket_url(&self, ticket: u64) -> String {
+        format!(
+            "https://todo.{}/~{}/{}#{}",
+            self.config.endpoint, self.config.owner, self.config.repo, ticket
+        )
+    }
+
+    fn graphql(&self, operation: &str, ticket: u64, body: Value) {
+        self.transport.record(ProviderRequest {
+            summary: format!(
+                "sourcehut graphql {operation} tracker={} ticket={ticket}",
+                self.config.tracker_id
+            ),
+            method: "POST".to_owned(),
+            path: self.config.todo_query_url(),
+            body,
+        });
+    }
+
+    fn record_git(&self, operation: &str, body: Value) {
+        self.transport.record(ProviderRequest {
+            summary: format!("sourcehut git {operation} repo={}", self.config.repo_id),
+            method: "GIT".to_owned(),
+            path: self.config.git_remote(),
+            body,
+        });
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeSourceHutError {
+    InvalidInput(String),
+    InvalidReference(String),
+    OutOfScope(String),
+}
+
+impl fmt::Display for ForgeSourceHutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForgeSourceHutError::InvalidInput(message) => f.write_str(message),
+            ForgeSourceHutError::InvalidReference(reference) => {
+                write!(f, "invalid SourceHut reference `{reference}`")
+            }
+            ForgeSourceHutError::OutOfScope(reference) => {
+                write!(
+                    f,
+                    "SourceHut reference `{reference}` is outside connector scope"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ForgeSourceHutError {}
+
+fn parse_positive_number(value: &str) -> Result<u64, ForgeSourceHutError> {
+    let number = value
+        .parse::<u64>()
+        .map_err(|_| ForgeSourceHutError::InvalidReference(value.to_owned()))?;
+    if number == 0 {
+        return Err(ForgeSourceHutError::InvalidReference(value.to_owned()));
+    }
+    Ok(number)
+}
+
+fn string_field<'a>(input: &'a Value, field: &str) -> Result<&'a str, ForgeSourceHutError> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| ForgeSourceHutError::InvalidInput(format!("missing {field}")))
+}
+
+fn handle_field(input: &Value, field: &str) -> Result<Handle, ForgeSourceHutError> {
+    input
+        .get(field)
+        .ok_or_else(|| ForgeSourceHutError::InvalidInput(format!("missing {field} handle")))
+        .and_then(parse_handle)
+}
+
+fn parse_handle(value: &Value) -> Result<Handle, ForgeSourceHutError> {
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ForgeSourceHutError::InvalidInput("missing handle id".to_owned()))?;
+    let display = value
+        .get("display")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ForgeSourceHutError::InvalidInput("missing handle display".to_owned()))?;
+    Ok(Handle::new(id, display))
+}
+
+fn effect(handle: Handle, status: &str, url: String) -> Value {
+    json!({
+        "work_unit": handle,
+        "status": status,
+        "url": url
+    })
+}

--- a/runa-mcp/Cargo.toml
+++ b/runa-mcp/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 libagent.workspace = true
+runa-forge-connectors.workspace = true
+runa-forge-contract.workspace = true
+runa-forge-github.workspace = true
+runa-forge-sourcehut.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rmcp.workspace = true
@@ -18,6 +22,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+jsonschema.workspace = true
 rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["process", "time"] }

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -2,10 +2,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use rmcp::Error as McpError;
+use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::*;
 use rmcp::service::{RequestContext, RoleServer};
+use runa_forge_connectors::ConfiguredForgeConnectors;
+use runa_forge_contract::ForgeTool;
 use serde_json::Value;
 use tracing::{info, warn};
 
@@ -26,6 +28,7 @@ pub struct RunaHandler {
     /// Maps artifact type name → full JSON Schema (with work_unit intact).
     tool_schemas: HashMap<String, Value>,
     session: Option<Mutex<SessionState>>,
+    forge_connectors: ConfiguredForgeConnectors,
 }
 
 struct HandlerState {
@@ -33,14 +36,33 @@ struct HandlerState {
 }
 
 impl RunaHandler {
+    #[cfg(test)]
     pub fn new(
         protocol: ProtocolDeclaration,
         work_unit: Option<String>,
         store: ArtifactStore,
         workspace_dir: PathBuf,
     ) -> Self {
+        Self::new_with_forge(
+            protocol,
+            work_unit,
+            store,
+            workspace_dir,
+            ConfiguredForgeConnectors::default(),
+        )
+    }
+
+    pub fn new_with_forge(
+        protocol: ProtocolDeclaration,
+        work_unit: Option<String>,
+        store: ArtifactStore,
+        workspace_dir: PathBuf,
+        forge_connectors: ConfiguredForgeConnectors,
+    ) -> Self {
         let (tools, tool_schemas) =
             output_tools_for_protocol(&protocol, work_unit.as_deref(), &store, false);
+        let tools = compose_mcp_tools(tools, &forge_connectors)
+            .expect("forge connector tools must compose before handler construction");
 
         Self {
             protocol: Some(protocol),
@@ -50,6 +72,7 @@ impl RunaHandler {
             tools,
             tool_schemas,
             session: None,
+            forge_connectors,
         }
     }
 
@@ -57,6 +80,7 @@ impl RunaHandler {
         working_dir: PathBuf,
         config_override: Option<&Path>,
         work_unit: Option<String>,
+        forge_connectors: ConfiguredForgeConnectors,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let session = SessionState::open_with_validator(
             working_dir,
@@ -75,6 +99,7 @@ impl RunaHandler {
             tools: Vec::new(),
             tool_schemas: HashMap::new(),
             session: Some(Mutex::new(session)),
+            forge_connectors,
         })
     }
 
@@ -82,6 +107,7 @@ impl RunaHandler {
         working_dir: PathBuf,
         config_override: Option<&Path>,
         ticket: libagent::TicketRef,
+        forge_connectors: ConfiguredForgeConnectors,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let session = SessionState::open_entry(
             working_dir,
@@ -100,6 +126,7 @@ impl RunaHandler {
             tools: Vec::new(),
             tool_schemas: HashMap::new(),
             session: Some(Mutex::new(session)),
+            forge_connectors,
         })
     }
 
@@ -107,7 +134,7 @@ impl RunaHandler {
         &self,
         session: &Mutex<SessionState>,
         tool_name: &str,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         match tool_name {
@@ -288,6 +315,22 @@ impl RunaHandler {
             _ => {}
         }
 
+        if self
+            .forge_connectors
+            .contains_tool(tool_name)
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?
+        {
+            let input = request
+                .arguments
+                .map(Value::Object)
+                .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+            let payload = self
+                .forge_connectors
+                .call(tool_name, input)
+                .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+            return Ok(CallToolResult::structured(payload));
+        }
+
         let mut session = session.lock().unwrap();
         let current_step = session
             .current_step()
@@ -306,7 +349,7 @@ impl RunaHandler {
             None,
         )?;
 
-        let (_, schemas) = session_tools_and_schemas(&session)
+        let (_, schemas) = session_tools_and_schemas(&session, &self.forge_connectors)
             .map_err(|error| McpError::internal_error(error, None))?;
         let full_schema = schemas
             .get(tool_name)
@@ -539,6 +582,34 @@ fn driver_tools() -> Vec<Tool> {
     ]
 }
 
+fn compose_mcp_tools(
+    mut tools: Vec<Tool>,
+    forge_connectors: &ConfiguredForgeConnectors,
+) -> Result<Vec<Tool>, String> {
+    let mut names = tools
+        .iter()
+        .map(|tool| tool.name.to_string())
+        .collect::<std::collections::HashSet<_>>();
+    for forge_tool in forge_connectors
+        .composed_tools()
+        .map_err(|error| error.to_string())?
+    {
+        if !names.insert(forge_tool.name.clone()) {
+            return Err(format!(
+                "MCP tool collision for `{}` between existing surface and forge connector",
+                forge_tool.name
+            ));
+        }
+        tools.push(mcp_tool_from_forge(forge_tool));
+    }
+    Ok(tools)
+}
+
+fn mcp_tool_from_forge(tool: ForgeTool) -> Tool {
+    Tool::new(tool.name, tool.description, Arc::new(tool.input_schema))
+        .with_raw_output_schema(Arc::new(tool.output_schema))
+}
+
 fn validate_session_step_output_types(
     protocol: Option<&ProtocolDeclaration>,
     store: &ArtifactStore,
@@ -572,6 +643,7 @@ fn validate_session_output_types(
 
 fn session_tools_and_schemas(
     session: &SessionState,
+    forge_connectors: &ConfiguredForgeConnectors,
 ) -> Result<(Vec<Tool>, HashMap<String, Value>), String> {
     let mut tools = driver_tools();
     let mut schemas = HashMap::new();
@@ -590,6 +662,7 @@ fn session_tools_and_schemas(
         tools.append(&mut output_tools);
         schemas = output_schemas;
     }
+    tools = compose_mcp_tools(tools, forge_connectors)?;
     Ok((tools, schemas))
 }
 
@@ -776,32 +849,31 @@ impl ServerHandler for RunaHandler {
         } else {
             ServerCapabilities::builder().enable_tools().build()
         };
-        ServerInfo {
-            protocol_version: ProtocolVersion::default(),
-            capabilities,
-            server_info: Implementation {
-                name: "runa-mcp".into(),
-                version: libagent::version().into(),
-            },
-            instructions: Some(instructions),
-        }
+        let mut info = ServerInfo::default();
+        info.protocol_version = ProtocolVersion::default();
+        info.capabilities = capabilities;
+        info.server_info = Implementation::new("runa-mcp", libagent::version());
+        info.instructions = Some(instructions);
+        info
     }
 
     async fn list_tools(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         if let Some(session) = &self.session {
             let session = session.lock().unwrap();
-            let (tools, _) = session_tools_and_schemas(&session)
+            let (tools, _) = session_tools_and_schemas(&session, &self.forge_connectors)
                 .map_err(|error| McpError::internal_error(error, None))?;
             return Ok(ListToolsResult {
+                meta: None,
                 next_cursor: None,
                 tools,
             });
         }
         Ok(ListToolsResult {
+            meta: None,
             next_cursor: None,
             tools: self.tools.clone(),
         })
@@ -809,7 +881,7 @@ impl ServerHandler for RunaHandler {
 
     async fn call_tool(
         &self,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let tool_name = request.name.to_string();
@@ -817,6 +889,21 @@ impl ServerHandler for RunaHandler {
             return self
                 .call_session_tool(session, &tool_name, request, context)
                 .await;
+        }
+        if self
+            .forge_connectors
+            .contains_tool(&tool_name)
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?
+        {
+            let input = request
+                .arguments
+                .map(Value::Object)
+                .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+            let payload = self
+                .forge_connectors
+                .call(&tool_name, input)
+                .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+            return Ok(CallToolResult::structured(payload));
         }
         let protocol = self
             .protocol
@@ -1160,6 +1247,48 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(tool_names, vec!["approved", "needs-revision"]);
+    }
+
+    #[test]
+    fn forge_tools_serialize_self_contained_input_and_output_schemas() {
+        let config = libagent::ForgeConnectorsConfig {
+            forge: vec![libagent::ForgeConnectorConfig {
+                provider: "github".to_string(),
+                label: None,
+                alias_prefix: None,
+                owner: "tesserine".to_string(),
+                name: "runa".to_string(),
+                tracker_id: None,
+                endpoint: None,
+                repo_id: None,
+                credentials: Default::default(),
+            }],
+        };
+        let connectors = ConfiguredForgeConnectors::from_config(&config).unwrap();
+        let contract_tools = connectors.composed_tools().unwrap();
+        let representative_payloads = runa_forge_connectors::tool_by_name(contract_tools.clone());
+        let mcp_tools = compose_mcp_tools(Vec::new(), &connectors).unwrap();
+
+        assert_eq!(mcp_tools.len(), 8);
+        for tool in mcp_tools {
+            let serialized = serde_json::to_value(&tool).unwrap();
+            let input_schema = serialized
+                .get("inputSchema")
+                .expect("tool must serialize inputSchema");
+            let output_schema = serialized
+                .get("outputSchema")
+                .expect("tool must serialize outputSchema");
+            assert!(input_schema.get("$defs").is_some());
+            assert!(output_schema.get("$defs").is_some());
+
+            let contract_tool = representative_payloads
+                .get(tool.name.as_ref())
+                .expect("serialized tool should have contract payloads");
+            let input_validator = jsonschema::validator_for(input_schema).unwrap();
+            let output_validator = jsonschema::validator_for(output_schema).unwrap();
+            assert!(input_validator.is_valid(&contract_tool.representative_input));
+            assert!(output_validator.is_valid(&contract_tool.representative_output));
+        }
     }
 
     #[test]

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -5,6 +5,7 @@ use libagent::configure_tracing;
 use libagent::project;
 use rmcp::service::ServiceExt;
 use rmcp::transport::io;
+use runa_forge_connectors::ConfiguredForgeConnectors;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process;
@@ -65,6 +66,8 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut loaded = project::load(&working_dir, config_ref)?;
+    let forge_connectors =
+        ConfiguredForgeConnectors::from_config(&loaded.config.effective_forge_connectors())?;
     apply_transcript_settings(&working_dir, &loaded.config);
     libagent::scan(&loaded.workspace_dir, &mut loaded.store)?;
     if let Some(work_unit) = cli.work_unit.as_deref() {
@@ -76,9 +79,19 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             Some(ticket) => {
                 let identity = libagent::resolve_forge_identity(&loaded.config.forge);
                 let ticket_ref = libagent::resolve_ticket_reference(ticket, &identity)?;
-                RunaHandler::new_session_entry(working_dir.clone(), config_ref, ticket_ref)?
+                RunaHandler::new_session_entry(
+                    working_dir.clone(),
+                    config_ref,
+                    ticket_ref,
+                    forge_connectors,
+                )?
             }
-            None => RunaHandler::new_session(working_dir.clone(), config_ref, cli.work_unit)?,
+            None => RunaHandler::new_session(
+                working_dir.clone(),
+                config_ref,
+                cli.work_unit,
+                forge_connectors,
+            )?,
         };
         let (stdin, stdout) = io::stdio();
         let service = handler.serve((stdin, stdout)).await.inspect_err(|e| {
@@ -131,11 +144,12 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         "serving protocol"
     );
 
-    let handler = RunaHandler::new(
+    let handler = RunaHandler::new_with_forge(
         protocol.clone(),
         cli.work_unit.clone(),
         loaded.store,
         loaded.workspace_dir.clone(),
+        forge_connectors,
     );
 
     let (stdin, stdout) = io::stdio();

--- a/runa-mcp/tests/forge_connectors.rs
+++ b/runa-mcp/tests/forge_connectors.rs
@@ -1,0 +1,159 @@
+use jsonschema::Validator;
+use runa_forge_contract::{
+    FORGE_CAPABILITY_COMMONS_COMMIT, FORGE_CAPABILITY_VERSION, ForgeOperation, compose_tool_sets,
+};
+use runa_forge_github::{GitHubConfig, GitHubConnector, RecordingGitHubTransport};
+use runa_forge_sourcehut::{RecordingSourceHutTransport, SourceHutConfig, SourceHutConnector};
+use serde_json::json;
+
+#[test]
+fn forge_connectors_advertise_all_v1_1_operations_with_self_contained_schemas() {
+    assert_eq!(FORGE_CAPABILITY_VERSION, "1.1.0");
+    assert_eq!(
+        FORGE_CAPABILITY_COMMONS_COMMIT,
+        "6924159fc4ff58745f0e2c68ed16849ffd9b4086"
+    );
+
+    for connector in [
+        GitHubConnector::new_for_test(
+            GitHubConfig::new("tesserine", "runa"),
+            RecordingGitHubTransport::default(),
+        )
+        .tool_set(),
+        SourceHutConnector::new_for_test(
+            SourceHutConfig::new("operator", "weforge", 4, "weforge.build", 42),
+            RecordingSourceHutTransport::default(),
+        )
+        .tool_set(),
+    ] {
+        let operations = connector
+            .tools
+            .iter()
+            .map(|tool| tool.operation)
+            .collect::<Vec<_>>();
+        assert_eq!(operations, ForgeOperation::ALL);
+
+        for tool in &connector.tools {
+            let input = serde_json::Value::Object(tool.input_schema.clone());
+            let output = serde_json::Value::Object(tool.output_schema.clone());
+            let input_validator = Validator::new(&input)
+                .unwrap_or_else(|error| panic!("{} input schema invalid: {error}", tool.name));
+            let output_validator = Validator::new(&output)
+                .unwrap_or_else(|error| panic!("{} output schema invalid: {error}", tool.name));
+            assert!(
+                input_validator.is_valid(&tool.representative_input),
+                "{} representative input should validate against emitted schema",
+                tool.name
+            );
+            assert!(
+                output_validator.is_valid(&tool.representative_output),
+                "{} representative output should validate against emitted schema",
+                tool.name
+            );
+        }
+    }
+}
+
+#[test]
+fn forge_tool_set_composition_rejects_unaliased_collisions() {
+    let github = GitHubConnector::new_for_test(
+        GitHubConfig::new("tesserine", "runa"),
+        RecordingGitHubTransport::default(),
+    )
+    .tool_set();
+    let sourcehut = SourceHutConnector::new_for_test(
+        SourceHutConfig::new("operator", "weforge", 4, "weforge.build", 42),
+        RecordingSourceHutTransport::default(),
+    )
+    .tool_set();
+
+    let error = compose_tool_sets(vec![github, sourcehut], Default::default()).unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("read-ticket"), "{message}");
+    assert!(message.contains("github"), "{message}");
+    assert!(message.contains("sourcehut"), "{message}");
+}
+
+#[test]
+fn github_reference_resolution_accepts_canonical_forms_and_rejects_foreign_scope() {
+    let connector = GitHubConnector::new_for_test(
+        GitHubConfig::new("tesserine", "runa"),
+        RecordingGitHubTransport::default(),
+    );
+
+    for reference in [
+        "github:tesserine/runa#203",
+        "tesserine/runa#203",
+        "#203",
+        "203",
+    ] {
+        let handle = connector.resolve_reference(reference).unwrap();
+        assert_eq!(handle.id, "github:tesserine/runa:issue:203");
+        assert_eq!(handle.display, "github:tesserine/runa#203");
+    }
+
+    assert!(
+        connector
+            .resolve_reference("github:tesserine/commons#203")
+            .is_err()
+    );
+    assert!(connector.validate_work_unit_handle_id("203").is_err());
+}
+
+#[test]
+fn sourcehut_reference_resolution_accepts_canonical_forms_and_rejects_foreign_scope() {
+    let connector = SourceHutConnector::new_for_test(
+        SourceHutConfig::new("operator", "weforge", 4, "weforge.build", 42),
+        RecordingSourceHutTransport::default(),
+    );
+
+    for reference in ["sourcehut:4#203", "#203", "203"] {
+        let handle = connector.resolve_reference(reference).unwrap();
+        assert_eq!(handle.id, "sourcehut:tracker:4:ticket:203");
+        assert_eq!(handle.display, "sourcehut:4#203");
+    }
+
+    assert!(connector.resolve_reference("sourcehut:99#203").is_err());
+    assert!(connector.validate_work_unit_handle_id("203").is_err());
+}
+
+#[test]
+fn operation_calls_construct_provider_requests_before_returning_outputs() {
+    let github_transport = RecordingGitHubTransport::default();
+    let github = GitHubConnector::new_for_test(
+        GitHubConfig::new("tesserine", "runa"),
+        github_transport.clone(),
+    );
+    github
+        .call(
+            ForgeOperation::RecordProgress,
+            json!({
+                "handle": {"id": "github:tesserine/runa:issue:203", "display": "github:tesserine/runa#203"},
+                "body": "progress"
+            }),
+        )
+        .unwrap();
+    assert_eq!(
+        github_transport.take_requests()[0].summary,
+        "github POST repos/tesserine/runa/issues/203/comments"
+    );
+
+    let sourcehut_transport = RecordingSourceHutTransport::default();
+    let sourcehut = SourceHutConnector::new_for_test(
+        SourceHutConfig::new("operator", "weforge", 4, "weforge.build", 42),
+        sourcehut_transport.clone(),
+    );
+    sourcehut
+        .call(
+            ForgeOperation::RecordProgress,
+            json!({
+                "handle": {"id": "sourcehut:tracker:4:ticket:203", "display": "sourcehut:4#203"},
+                "body": "progress"
+            }),
+        )
+        .unwrap();
+    assert_eq!(
+        sourcehut_transport.take_requests()[0].summary,
+        "sourcehut graphql submitComment tracker=4 ticket=203"
+    );
+}

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::ClientHandler;
-use rmcp::model::{CallToolRequestParam, CallToolResult};
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::ServiceExt;
 use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
 use tokio::process::Command;
@@ -327,11 +327,20 @@ fn tool_result_text(result: &CallToolResult) -> String {
         .clone()
 }
 
-fn session_call(name: &str) -> CallToolRequestParam {
-    CallToolRequestParam {
-        name: name.to_string().into(),
-        arguments: Some(serde_json::Map::new()),
-    }
+fn session_call(name: &str) -> CallToolRequestParams {
+    CallToolRequestParams::new(name.to_string()).with_arguments(serde_json::Map::new())
+}
+
+fn tool_call(
+    name: impl Into<std::borrow::Cow<'static, str>>,
+    arguments: serde_json::Value,
+) -> CallToolRequestParams {
+    CallToolRequestParams::new(name).with_arguments(
+        arguments
+            .as_object()
+            .expect("tool arguments must be an object")
+            .clone(),
+    )
 }
 
 fn assert_no_execution_record_for(project_dir: &Path, protocol: &str) {
@@ -577,15 +586,13 @@ async fn session_record_read_advance_records_execution_for_producing_step() {
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -676,15 +683,13 @@ async fn session_advance_records_context_time_input_provenance() {
     .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     service.call_tool(session_call("advance")).await.unwrap();
@@ -761,15 +766,13 @@ async fn session_advance_reopens_current_step_when_context_input_changes() {
     )
     .unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -851,15 +854,13 @@ async fn session_advance_reopens_current_step_when_readiness_consumes_context_in
     .unwrap();
     service.call_tool(session_call("readiness")).await.unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -915,15 +916,13 @@ async fn session_advance_emits_tool_list_changed_when_current_step_changes() {
     .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -976,15 +975,13 @@ async fn session_advance_reconciles_deleted_output_before_recording_execution() 
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     fs::remove_file(workspace.join("claim/claim-1.json")).unwrap();
@@ -1059,15 +1056,13 @@ async fn session_advance_rejects_deleted_required_input_before_downstream_select
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     fs::remove_file(workspace.join("work-unit/work-unit-166.json")).unwrap();
@@ -1340,15 +1335,13 @@ async fn session_advance_error_preserves_current_step_when_next_step_is_unservab
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -1422,15 +1415,13 @@ async fn session_advance_persistence_error_preserves_current_step_and_no_record(
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     let execution_record_path = project_dir.join(".runa/store/execution-records.json");
@@ -1849,15 +1840,13 @@ async fn scoped_protocol_writes_artifact_with_injected_work_unit() {
     assert_eq!(tools[0].name.as_ref(), "implementation");
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -1894,15 +1883,13 @@ async fn tool_calls_append_transcript_events_when_enabled() {
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -1935,6 +1922,10 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
                         .arg("wu-1")
                         .env_remove("RUNA_TRANSCRIPT_DIR")
                         .env_remove("RUNA_TRANSCRIPT_REDACT_ENV")
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1944,15 +1935,13 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -2016,15 +2005,13 @@ async fn session_driver_calls_append_transcript_events_when_enabled() {
         .await
         .unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim".to_string(),
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     service.call_tool(session_call("advance")).await.unwrap();
@@ -2159,15 +2146,13 @@ trigger = { type = "on_change", name = "implementation" }
     assert_eq!(tools[0].name.as_ref(), "implementation");
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -2234,15 +2219,13 @@ trigger = { type = "on_change", name = "implementation" }
     assert!(!tool_properties.contains_key("work_unit"));
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- Add a forge connector contract crate pinned to commons forge capability v1.1.0 and commit 6924159fc4ff58745f0e2c68ed16849ffd9b4086.
- Add GitHub and SourceHut connector crates plus a connector registry for composing provider tool sets into the MCP surface.
- Wire runa-mcp to expose connector input/output schemas, dispatch connector calls, and preserve existing driver/artifact tools.
- Add non-gated connector tests for operation coverage, scope validation, request construction, collision behavior, and self-contained serialized schemas.

## Verification
- cargo test --workspace
- cargo test -p runa-mcp --test forge_connectors

## Notes
The local runa workspace did not contain a ready submit protocol state for this issue, so no change-proposal artifact was produced through MCP in this session.
