### PR TITLE
feat: compose forge connector tools in runa mcp

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,11 +11,15 @@ runa's actual architecture.
 
 ## Workspace Structure
 
-Three crates, Rust 2024 edition, resolver v3:
+Seven crates, Rust 2024 edition, resolver v3:
 
 - **`libagent`** — All domain logic: data model, TOML manifest parsing, JSON Schema validation, dependency graph, artifact state tracking, trigger condition evaluation, context injection construction, graph-based dry-run projection, pre/post-execution enforcement, project loading, protocol selection, status evaluation, and session state.
 - **`runa-cli`** — Thin CLI binary. Clap-based argument parsing, delegates to libagent and the session MCP surface. No domain logic.
 - **`runa-mcp`** — MCP server binary. In fixed-protocol mode, serves one named protocol invocation per process. In session mode, serves one scoped work-unit session with driver verbs and current-step output tools in one MCP connection. Writes produced artifacts into the workspace through the same validation path in both modes.
+- **`runa-forge-contract`** — Provider-neutral forge capability contract: the canonical operation set, tool schemas, scoped handles, and tool-set composition rules.
+- **`runa-forge-github`** — GitHub forge connector implementation and request construction.
+- **`runa-forge-sourcehut`** — SourceHut forge connector implementation and request construction.
+- **`runa-forge-compose`** — Runtime composition from `[forge]` config into a connector-backed MCP tool surface.
 
 Supported runtime adapters live in top-level **`adapters/`**. They translate
 the runtime-agnostic `RUNA_MCP_CONFIG` payload into each runtime's MCP
@@ -48,7 +52,17 @@ These are library capabilities exposed by libagent and consumed by both the CLI 
 
 10. **CLI execution commands.** `runa state`, `runa step`, `runa run`, and `runa go` share the same scope-resolved topology, readiness evaluation, and scope handling. Without `--work-unit`, commands evaluate only unscoped protocols; with `--work-unit <ID>`, they evaluate only scoped protocols for that delegated work unit after canonical identity validation. `step --dry-run` previews only the next concrete execution, while `run --dry-run` projects the full optimistic cascade to quiescence from declared `produces` outputs plus already-known required output choice branches within that same scope and scope-filtered execution order; optional `may_produce` outputs do not advance the projection unless they already exist, and required output choice branches are not synthesized unless exactly one member already exists. Live execution targets Linux. Live `step` executes exactly one ready candidate through fixed-protocol MCP, then re-scans and prints the refreshed state. Live `run` repeats the execute → scan → enforce → re-evaluate cycle until quiescence, resolves its agent command from `--agent-command -- <argv...>` or `[agent].command` in config, reopens exhausted work when a later reconciliation changes relevant inputs, and exits with outcome-specific status codes. Live `go` launches the configured agent with `runa-mcp --session --work-unit <ID>`, sends a generic one-tick prompt, and verifies that the selected session step recorded execution through the session surface. Before launching an agent, live execution builds a `runa-mcp` config, exports it through `RUNA_MCP_CONFIG`, injects config-resolved transcript and forge identity environment into both the agent process and MCP config, and launches the configured argv unmodified; runtime-specific MCP adaptation belongs to the runtime or adapter. When transcript capture is enabled by config or `RUNA_TRANSCRIPT_DIR`, live execution appends structured transcript events for the rendered prompt, agent stdout/stderr, and exit status beneath the configured root, separated by deployment, work unit, and per-invocation run id.
 
-11. **MCP runtime loop.** In fixed-protocol mode, `runa-mcp` parses `--protocol` and optional `--work-unit`, loads the project, scans the workspace, resolves the named protocol from the manifest, validates declared scope and canonical work-unit identity against the provided arguments, validates that its outputs can be served as MCP tools, and serves output tools via stdio. In session mode, `runa-mcp --session --work-unit <ID>` opens a scoped `SessionState`, advertises driver tools plus current-step output tools, and emits `notifications/tools/list_changed` whenever a session verb changes the current step and therefore the advertised output tools. When transcript capture is enabled, tool calls and tool results are appended under the same deployment/work-unit/run transcript path as CLI execution events.
+11. **Forge connector composition.** `runa-forge-contract` defines the
+canonical forge operations (`read-ticket`, `create-ticket`, `claim-work-unit`,
+`record-progress`, `deliver-change-proposal`, `reflect-disposition`,
+`apply-approved-change`, and `close-out`) plus self-contained input/output
+schemas. GitHub and SourceHut connectors implement those operations behind a
+provider-neutral trait and reject references outside their configured scope
+before issuing provider requests. `runa-forge-compose` resolves `[forge]`
+config into at most one connector runtime, applies role-qualified aliases, and
+fails loudly on exposed tool-name collisions.
+
+12. **MCP runtime loop.** In fixed-protocol mode, `runa-mcp` parses `--protocol` and optional `--work-unit`, loads the project, scans the workspace, resolves the named protocol from the manifest, validates declared scope and canonical work-unit identity against the provided arguments, validates that its outputs can be served as MCP tools, and serves output tools via stdio. In session mode, `runa-mcp --session --work-unit <ID>` opens a scoped `SessionState`, advertises driver tools plus current-step output tools, and emits `notifications/tools/list_changed` whenever a session verb changes the current step and therefore the advertised output tools. In both modes, a configured forge connector appends its forge tools to the advertised MCP surface, and connector/artifact/driver name collisions are rejected during tool-list composition. When transcript capture is enabled, tool calls and tool results are appended under the same deployment/work-unit/run transcript path as CLI execution events.
 
 ## Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Semantic Versioning.
 
 ### Added
 
+- MCP forge connector surface: `[forge]` can now compose provider-backed tools
+  into `runa-mcp` for the canonical work-unit lifecycle. New connector crates
+  define the forge contract, compose configured tool sets, and implement GitHub
+  and SourceHut request construction with scoped-handle validation and
+  self-contained MCP input/output schemas.
 - README ecosystem links corrected: commons described as the
   convention/ADR authority with principles at their canonical home
   `pentaxis93/principles` (#181), and the agentd/groundwork links moved to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,7 @@ dependencies = [
  "runa-forge-sourcehut",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "runa-forge-contract",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,6 +95,23 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -200,11 +217,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -285,15 +300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
- "windows-sys",
+ "nix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -301,11 +316,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -315,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -391,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -429,12 +443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +453,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fraction"
@@ -556,6 +573,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -608,6 +638,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,7 +747,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -758,6 +886,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,19 +1028,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -921,7 +1049,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1056,14 +1184,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1087,6 +1215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,16 +1244,71 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
- "nix 0.30.1",
+ "nix",
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1139,6 +1331,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1214,15 +1435,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rmcp"
-version = "0.2.1"
+name = "reqwest"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
  "base64",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
  "rmcp-macros",
@@ -1238,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.2.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1265,18 +1541,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "runa-forge-compose"
+version = "0.2.0-rc.1"
+dependencies = [
+ "libagent",
+ "runa-forge-contract",
+ "runa-forge-github",
+ "runa-forge-sourcehut",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-contract"
+version = "0.2.0-rc.1"
+dependencies = [
+ "jsonschema",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-github"
+version = "0.2.0-rc.1"
+dependencies = [
+ "reqwest",
+ "runa-forge-contract",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "runa-forge-sourcehut"
+version = "0.2.0-rc.1"
+dependencies = [
+ "reqwest",
+ "runa-forge-contract",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "runa-mcp"
 version = "0.2.0-rc.1"
 dependencies = [
  "clap",
  "libagent",
  "rmcp",
+ "runa-forge-compose",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1288,7 +1612,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1298,13 +1657,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
+name = "ryu"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1312,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1398,6 +1764,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1860,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1489,7 +1892,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1532,6 +1935,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,8 +1960,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1555,6 +1974,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1621,6 +2050,51 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1697,6 +2171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +2199,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -1761,6 +2259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +2302,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1864,38 +2385,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.61.3"
+name = "web-sys"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1906,19 +2442,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -1946,33 +2482,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -1981,16 +2502,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1999,7 +2511,25 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2008,17 +2538,146 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2186,6 +2845,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,7 @@ dependencies = [
 name = "runa-forge-compose"
 version = "0.2.0-rc.1"
 dependencies = [
+ "jsonschema",
  "libagent",
  "runa-forge-contract",
  "runa-forge-github",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apollo-compiler"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b877306ffde4d3cc428bbc8f506fdd67b99255298ae92b919954c0c52f530504"
+dependencies = [
+ "ahash",
+ "apollo-parser",
+ "ariadne",
+ "futures",
+ "indexmap",
+ "rowan",
+ "serde",
+ "serde_json_bytes",
+ "thiserror 2.0.18",
+ "triomphe",
+ "typed-arena",
+]
+
+[[package]]
+name = "apollo-parser"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f6e2be4b3474e5890d34d3e483d49ec9b5cbf9e358bc62c9cc5423376df54b"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "concolor",
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +180,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -269,10 +316,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -360,7 +433,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -613,6 +686,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -636,6 +715,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -892,6 +977,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1007,19 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cc127b7c3d270be504572364f9569761a180b981919dd0d87693a7f5fb7829"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1037,7 +1146,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1200,6 +1309,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,10 +1419,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1287,11 +1439,11 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1367,7 +1519,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1505,7 +1657,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1523,6 +1675,18 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
 ]
 
 [[package]]
@@ -1576,6 +1740,7 @@ dependencies = [
 name = "runa-forge-sourcehut"
 version = "0.2.0-rc.1"
 dependencies = [
+ "apollo-compiler",
  "reqwest",
  "runa-forge-contract",
  "serde",
@@ -1600,6 +1765,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -1610,7 +1781,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1757,6 +1928,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_bytes"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a27c10711f94d1042b4c96d483556ec84371864e25d0e1cf3dc1024b0880b1"
+dependencies = [
+ "ahash",
+ "bytes",
+ "indexmap",
+ "jsonpath-rust",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,12 +2084,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2074,7 +2286,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2173,16 +2385,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-general-category"
@@ -2195,6 +2429,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -2380,7 +2620,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2518,6 +2758,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2541,6 +2790,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2587,6 +2851,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2599,6 +2869,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2608,6 +2884,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2635,6 +2917,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2644,6 +2932,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2659,6 +2953,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2668,6 +2968,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2748,7 +3054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -2783,6 +3089,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 jsonschema = { version = "0.45", default-features = false }
+apollo-compiler = "1.32.0"
 toml = "0.8"
 sha2 = "0.10"
 rmcp = { version = "1.7.0", features = ["transport-io", "server"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["runa-cli", "libagent", "runa-mcp"]
+members = [
+    "runa-cli",
+    "libagent",
+    "runa-mcp",
+    "runa-forge-contract",
+    "runa-forge-github",
+    "runa-forge-sourcehut",
+    "runa-forge-compose",
+]
 resolver = "3"
 
 [workspace.package]
@@ -16,9 +24,14 @@ tempfile = "3"
 jsonschema = { version = "0.45", default-features = false }
 toml = "0.8"
 sha2 = "0.10"
-rmcp = { version = "0.2", features = ["transport-io", "server"] }
+rmcp = { version = "1.7.0", features = ["transport-io", "server"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 ctrlc = "3.4"
 libc = "0.2"
+runa-forge-contract = { path = "runa-forge-contract" }
+runa-forge-github = { path = "runa-forge-github" }
+runa-forge-sourcehut = { path = "runa-forge-sourcehut" }
+runa-forge-compose = { path = "runa-forge-compose" }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -208,9 +208,16 @@ See [CLI Reference](docs/cli-reference.md) for flags, exit codes, configuration,
 
 `runa init` creates `.runa/config.toml` with the methodology path. Operators
 may also set durable project defaults there for live agent command,
-transcript capture, and scoped forge identity. Environment variables such as
+transcript capture, scoped forge identity, and MCP forge connector settings.
+Environment variables such as
 `RUNA_TRANSCRIPT_DIR` and `RUNA_FORGE_*` remain per-invocation overrides;
 config is the project-local default.
+
+When `[forge]` identifies a supported connector, `runa-mcp` composes the
+methodology artifact tools with forge tools for the canonical work-unit
+lifecycle: read/create ticket, claim work, record progress, deliver a change
+proposal, reflect review disposition, apply an approved change, and close out.
+GitHub and SourceHut connector implementations are provided.
 
 Runa ships supported agent adapters for Codex and Claude Code in `adapters/`.
 Set `[agent].command` to `./adapters/agent-codex.sh` or

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Set `[agent].command` to `./adapters/agent-codex.sh` or
 `./adapters/agent-claude-code.sh`; the adapter translates `RUNA_MCP_CONFIG` for
 the selected runtime.
 
+GitHub forge claiming requires `[forge].assignee` so `claim-work-unit` can set
+a real issue assignee instead of reporting a synthetic claim.
+
 ## Build
 
 Rust 2024 edition. Runa targets Linux.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,6 +28,12 @@ type = "github"
 owner = "tesserine"
 name = "runa"
 tracker_id = "4"
+api_base = "https://api.github.com"
+credential_env = "WEFORGE_OPERATOR_PAT"
+credential_command = ["bws", "secret", "get", "..."]
+
+[forge.tool_aliases]
+"github:read-ticket" = "github-read-ticket"
 ```
 
 `[transcript].dir` enables transcript capture and is resolved relative to the
@@ -44,6 +50,20 @@ it when validating tracker-backed `work-unit` roots and injects the resolved
 Any non-empty matching `RUNA_FORGE_*` environment variable overrides the
 configured field for that invocation. The forge type still defaults to `github`
 when neither config nor env specifies one.
+
+When `[forge]` is sufficiently configured for a supported connector, `runa-mcp`
+also exposes the forge capability tool-set alongside artifact and session
+driver tools. The canonical operations are `read-ticket`, `create-ticket`,
+`claim-work-unit`, `record-progress`, `deliver-change-proposal`,
+`reflect-disposition`, `apply-approved-change`, and `close-out`. GitHub uses
+`owner` and `name`; SourceHut uses `tracker_id` and may also use `git_remote`.
+`api_base` overrides the provider API endpoint for harnesses or enterprise
+deployments. `credential_env` and `credential_command` describe where the
+connector should obtain credentials; secret values are process-local inputs and
+are not serialized into MCP tool schemas, launch config, transcripts, or logs.
+`[forge.tool_aliases]` maps role-qualified connector tool names such as
+`"github:read-ticket"` to explicit exposed MCP names; otherwise name collisions
+across composed tool sets fail loudly.
 
 ### Logging
 
@@ -363,9 +383,9 @@ runa-mcp --protocol <name> [--work-unit <name>]
 runa-mcp --session (--work-unit <name> | --ticket <ref>)
 ```
 
-In fixed-protocol mode, the server loads the project, scans the workspace, resolves the named protocol from the manifest, validates that its declared scope matches the presence or absence of `--work-unit`, validates canonical `work-unit` identity for scoped sessions, validates that its required output types can be served as MCP tools, and serves that protocol's output tools over stdio. Each output artifact type (`produces`, required output choice members, and viable `may_produce`) becomes one MCP tool. The tool input schema is the artifact type's JSON Schema with the `work_unit` field removed — the server injects `work_unit` automatically from the `--work-unit` argument.
+In fixed-protocol mode, the server loads the project, scans the workspace, resolves the named protocol from the manifest, validates that its declared scope matches the presence or absence of `--work-unit`, validates canonical `work-unit` identity for scoped sessions, validates that its required output types can be served as MCP tools, and serves that protocol's output tools over stdio. Each output artifact type (`produces`, required output choice members, and viable `may_produce`) becomes one MCP tool. The tool input schema is the artifact type's JSON Schema with the `work_unit` field removed — the server injects `work_unit` automatically from the `--work-unit` argument. If a configured forge connector is available, the server also appends its canonical forge tools with self-contained input and output schemas.
 
-In session mode, the server serves one scoped work-unit session in a single MCP connection, opened either with `--work-unit <name>` (a recorded work-unit) or `--ticket <ref>` (a forge ticket reference for cold-start entry). With `--ticket`, the session begins in a promised scope serving the methodology's acquisition surface; once the agent materializes the `work-unit`, `advance` binds the session to it and the tool list flips to the bound step's tools. The runtime resolves the reference to an identity only and performs no forge read. The tool list always includes the driver tools `readiness`, `next-protocol-context`, and `advance`, plus the output tools for the current ready step. A current step is refused if any declared output type for that step would collide with one of those reserved driver tool names. Every driver verb rescans and revalidates the scoped work-unit identity before reporting, serving, or advancing. `readiness` reports the same status classification as `runa state` for the session scope, and selects the first non-exhausted ready step when the session has no current step. `next-protocol-context` verifies that the current step still satisfies readiness authority for its trigger and preconditions, and returns both the structured context and rendered prompt for the current step without advancing it. `advance` verifies that the current step still satisfies readiness authority for its trigger and preconditions, enforces postconditions for the current step, uses staged execution metadata to select and validate the next ready step, and only then persists that metadata and advances the session. Any driver verb that changes the current step emits `notifications/tools/list_changed` so caching MCP clients can rediscover the current step's output tools. Output tools validate and write artifacts exactly as in fixed-protocol mode; recording an output does not advance the session.
+In session mode, the server serves one scoped work-unit session in a single MCP connection, opened either with `--work-unit <name>` (a recorded work-unit) or `--ticket <ref>` (a forge ticket reference for cold-start entry). With `--ticket`, the session begins in a promised scope serving the methodology's acquisition surface; once the agent materializes the `work-unit`, `advance` binds the session to it and the tool list flips to the bound step's tools. The runtime resolves the reference to an identity only and performs no forge read; provider reads and writes happen only through explicitly invoked connector tools. The tool list always includes the driver tools `readiness`, `next-protocol-context`, and `advance`, plus the output tools for the current ready step, plus any configured forge connector tools. A current step is refused if any declared output type for that step would collide with one of those reserved driver tool names; connector/artifact collisions are also rejected during tool-list composition. Every driver verb rescans and revalidates the scoped work-unit identity before reporting, serving, or advancing. `readiness` reports the same status classification as `runa state` for the session scope, and selects the first non-exhausted ready step when the session has no current step. `next-protocol-context` verifies that the current step still satisfies readiness authority for its trigger and preconditions, and returns both the structured context and rendered prompt for the current step without advancing it. `advance` verifies that the current step still satisfies readiness authority for its trigger and preconditions, enforces postconditions for the current step, uses staged execution metadata to select and validate the next ready step, and only then persists that metadata and advances the session. Any driver verb that changes the current step emits `notifications/tools/list_changed` so caching MCP clients can rediscover the current step's output tools. Output tools validate and write artifacts exactly as in fixed-protocol mode; recording an output does not advance the session.
 
 `runa step` currently continues to use fixed-protocol mode. `runa go` uses
 session mode. Neither command spawns `runa-mcp` directly. Before launching the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -57,12 +57,16 @@ also exposes the forge capability tool-set alongside artifact and session
 driver tools. The canonical operations are `read-ticket`, `create-ticket`,
 `claim-work-unit`, `record-progress`, `deliver-change-proposal`,
 `reflect-disposition`, `apply-approved-change`, and `close-out`. GitHub uses
-`owner` and `name`; SourceHut uses `tracker_id` and may also use `git_remote`.
-`api_base` overrides the provider API endpoint for harnesses or enterprise
-deployments. GitHub `claim-work-unit` uses `assignee` as the account to assign
-to the issue. `credential_env` and `credential_command` describe where the
-connector should obtain credentials; secret values are process-local inputs and
-are not serialized into MCP tool schemas, launch config, transcripts, or logs.
+`owner` and `name`; SourceHut uses `tracker_id` for ticket identity and uses
+resolved `owner`/`name` for git repo coordinates. SourceHut `git_remote`
+supplies the host/protocol path shape for git operations, but its repo
+coordinate follows the resolved forge identity after any `RUNA_FORGE_*`
+overrides. `api_base` overrides the provider API endpoint for harnesses or
+enterprise deployments. GitHub `claim-work-unit` uses `assignee` as the account
+to assign to the issue. `credential_env` and `credential_command` describe where
+the connector should obtain credentials; secret values are process-local inputs
+and are not serialized into MCP tool schemas, launch config, transcripts, or
+logs.
 `[forge.tool_aliases]` maps role-qualified connector tool names such as
 `"github:read-ticket"` to explicit exposed MCP names; otherwise name collisions
 across composed tool sets fail loudly.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,6 +29,7 @@ owner = "tesserine"
 name = "runa"
 tracker_id = "4"
 api_base = "https://api.github.com"
+assignee = "pentaxis93"
 credential_env = "WEFORGE_OPERATOR_PAT"
 credential_command = ["bws", "secret", "get", "..."]
 
@@ -58,7 +59,8 @@ driver tools. The canonical operations are `read-ticket`, `create-ticket`,
 `reflect-disposition`, `apply-approved-change`, and `close-out`. GitHub uses
 `owner` and `name`; SourceHut uses `tracker_id` and may also use `git_remote`.
 `api_base` overrides the provider API endpoint for harnesses or enterprise
-deployments. `credential_env` and `credential_command` describe where the
+deployments. GitHub `claim-work-unit` uses `assignee` as the account to assign
+to the issue. `credential_env` and `credential_command` describe where the
 connector should obtain credentials; secret values are process-local inputs and
 are not serialized into MCP tool schemas, launch config, transcripts, or logs.
 `[forge.tool_aliases]` maps role-qualified connector tool names such as

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -4,6 +4,7 @@
 //! manifest, builds the dependency graph, and initializes the artifact store.
 //! See [`load`] for the main entry point.
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -80,6 +81,16 @@ pub struct ForgeConfig {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tracker_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_base: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_remote: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_env: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credential_command: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tool_aliases: BTreeMap<String, String>,
 }
 
 impl ForgeConfig {
@@ -651,6 +662,10 @@ type = "sourcehut"
 owner = "operator"
 name = "weforge"
 tracker_id = "4"
+api_base = "https://todo.example/query"
+git_remote = "ssh://git@git.example/runa"
+credential_env = "WEFORGE_OPERATOR_PAT"
+credential_command = ["secret-tool", "lookup", "token"]
 "#,
         )
         .unwrap();
@@ -661,6 +676,22 @@ tracker_id = "4"
         assert_eq!(config.forge.owner.as_deref(), Some("operator"));
         assert_eq!(config.forge.name.as_deref(), Some("weforge"));
         assert_eq!(config.forge.tracker_id.as_deref(), Some("4"));
+        assert_eq!(
+            config.forge.api_base.as_deref(),
+            Some("https://todo.example/query")
+        );
+        assert_eq!(
+            config.forge.git_remote.as_deref(),
+            Some("ssh://git@git.example/runa")
+        );
+        assert_eq!(
+            config.forge.credential_env.as_deref(),
+            Some("WEFORGE_OPERATOR_PAT")
+        );
+        assert_eq!(
+            config.forge.credential_command,
+            ["secret-tool", "lookup", "token"]
+        );
     }
 
     #[test]
@@ -678,6 +709,11 @@ tracker_id = "4"
                 owner: Some("tesserine".to_string()),
                 name: Some("runa".to_string()),
                 tracker_id: Some("4".to_string()),
+                api_base: None,
+                git_remote: None,
+                credential_env: None,
+                credential_command: Vec::new(),
+                tool_aliases: BTreeMap::new(),
             },
         };
 

--- a/libagent/src/project.rs
+++ b/libagent/src/project.rs
@@ -86,6 +86,8 @@ pub struct ForgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_remote: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub credential_env: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credential_command: Vec<String>,
@@ -664,6 +666,7 @@ name = "weforge"
 tracker_id = "4"
 api_base = "https://todo.example/query"
 git_remote = "ssh://git@git.example/runa"
+assignee = "pentaxis93"
 credential_env = "WEFORGE_OPERATOR_PAT"
 credential_command = ["secret-tool", "lookup", "token"]
 "#,
@@ -684,6 +687,7 @@ credential_command = ["secret-tool", "lookup", "token"]
             config.forge.git_remote.as_deref(),
             Some("ssh://git@git.example/runa")
         );
+        assert_eq!(config.forge.assignee.as_deref(), Some("pentaxis93"));
         assert_eq!(
             config.forge.credential_env.as_deref(),
             Some("WEFORGE_OPERATOR_PAT")
@@ -711,6 +715,7 @@ credential_command = ["secret-tool", "lookup", "token"]
                 tracker_id: Some("4".to_string()),
                 api_base: None,
                 git_remote: None,
+                assignee: Some("pentaxis93".to_string()),
                 credential_env: None,
                 credential_command: Vec::new(),
                 tool_aliases: BTreeMap::new(),

--- a/libagent/src/scoped_identity.rs
+++ b/libagent/src/scoped_identity.rs
@@ -498,6 +498,7 @@ mod tests {
             owner: Some("operator".to_string()),
             name: Some("weforge".to_string()),
             tracker_id: Some("4".to_string()),
+            ..ForgeConfig::default()
         };
 
         let environment = resolve_forge_environment(&config);
@@ -533,6 +534,7 @@ mod tests {
             owner: Some("config-owner".to_string()),
             name: Some("config-name".to_string()),
             tracker_id: Some("4".to_string()),
+            ..ForgeConfig::default()
         };
 
         let environment = resolve_forge_environment(&config);
@@ -568,6 +570,7 @@ mod tests {
             owner: Some("tesserine".to_string()),
             name: Some("runa".to_string()),
             tracker_id: None,
+            ..ForgeConfig::default()
         };
 
         let environment = resolve_forge_environment(&config);
@@ -797,6 +800,7 @@ mod tests {
             owner: Some("operator".to_string()),
             name: Some("weforge".to_string()),
             tracker_id: Some("4".to_string()),
+            ..ForgeConfig::default()
         });
 
         let result =

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -217,6 +217,7 @@ enum SessionScope {
 pub struct SessionState {
     working_dir: PathBuf,
     pub loaded: crate::LoadedProject,
+    identity: crate::ResolvedForgeIdentity,
     scope: SessionScope,
     current_step: Option<CurrentStep>,
     exhausted: HashSet<crate::CandidateKey>,
@@ -279,9 +280,39 @@ impl SessionState {
     {
         let work_unit = work_unit.ok_or(SessionError::MissingWorkUnit)?;
         let loaded = crate::project::load(&working_dir, config_override)?;
+        let identity = crate::resolve_forge_identity(&loaded.config.forge);
+        Self::open_loaded_with_validator(working_dir, loaded, work_unit, identity, validate_step)
+    }
+
+    pub fn open_with_validator_and_identity<F>(
+        working_dir: PathBuf,
+        config_override: Option<&Path>,
+        work_unit: Option<String>,
+        identity: crate::ResolvedForgeIdentity,
+        validate_step: F,
+    ) -> Result<Self, SessionError>
+    where
+        F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
+    {
+        let work_unit = work_unit.ok_or(SessionError::MissingWorkUnit)?;
+        let loaded = crate::project::load(&working_dir, config_override)?;
+        Self::open_loaded_with_validator(working_dir, loaded, work_unit, identity, validate_step)
+    }
+
+    fn open_loaded_with_validator<F>(
+        working_dir: PathBuf,
+        loaded: crate::LoadedProject,
+        work_unit: String,
+        identity: crate::ResolvedForgeIdentity,
+        validate_step: F,
+    ) -> Result<Self, SessionError>
+    where
+        F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
+    {
         let mut session = Self {
             working_dir,
             loaded,
+            identity,
             scope: SessionScope::Bound(work_unit),
             current_step: None,
             exhausted: HashSet::new(),
@@ -312,10 +343,37 @@ impl SessionState {
     where
         F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
     {
-        let mut loaded = crate::project::load(&working_dir, config_override)?;
+        let loaded = crate::project::load(&working_dir, config_override)?;
+        let identity = crate::resolve_forge_identity(&loaded.config.forge);
+        Self::open_entry_loaded(working_dir, loaded, ticket, identity, validate_step)
+    }
+
+    pub fn open_entry_with_identity<F>(
+        working_dir: PathBuf,
+        config_override: Option<&Path>,
+        ticket: crate::TicketRef,
+        identity: crate::ResolvedForgeIdentity,
+        validate_step: F,
+    ) -> Result<Self, SessionError>
+    where
+        F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
+    {
+        let loaded = crate::project::load(&working_dir, config_override)?;
+        Self::open_entry_loaded(working_dir, loaded, ticket, identity, validate_step)
+    }
+
+    fn open_entry_loaded<F>(
+        working_dir: PathBuf,
+        mut loaded: crate::LoadedProject,
+        ticket: crate::TicketRef,
+        identity: crate::ResolvedForgeIdentity,
+        validate_step: F,
+    ) -> Result<Self, SessionError>
+    where
+        F: FnOnce(Option<&crate::ProtocolDeclaration>, &crate::ArtifactStore) -> Result<(), String>,
+    {
         let scan_result = crate::scan(&loaded.workspace_dir, &mut loaded.store)?;
         let scan_findings = crate::collect_scan_findings(&scan_result, &loaded.workspace_dir);
-        let identity = crate::resolve_forge_identity(&loaded.config.forge);
 
         // Resolve the promise first. Re-entry (the work-unit already exists)
         // degrades to an ordinary bound session and needs no acquisition surface;
@@ -325,6 +383,7 @@ impl SessionState {
             let mut session = Self {
                 working_dir,
                 loaded,
+                identity,
                 scope: SessionScope::Bound(work_unit),
                 current_step: None,
                 exhausted: HashSet::new(),
@@ -344,6 +403,7 @@ impl SessionState {
         let mut session = Self {
             working_dir,
             loaded,
+            identity,
             scope: SessionScope::Promised { ticket },
             current_step: None,
             exhausted: HashSet::new(),
@@ -604,17 +664,16 @@ impl SessionState {
         require_current_ready: bool,
     ) -> Result<ReconciledScan, SessionError> {
         let scan_result = self.scan_workspace()?;
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
         match &self.scope {
             SessionScope::Bound(work_unit) => {
                 crate::validate_scoped_work_unit_with_identity(
                     &self.loaded.store,
                     work_unit,
-                    &identity,
+                    &self.identity,
                 )?;
             }
             SessionScope::Promised { .. } => {
-                crate::validate_tracker_consistency(&self.loaded.store, &identity)?;
+                crate::validate_tracker_consistency(&self.loaded.store, &self.identity)?;
             }
         }
         self.refresh_exhaustion_after_scan(&scan_result);
@@ -688,17 +747,16 @@ impl SessionState {
     /// work-unit ([`EntryError::Unresolved`]) or the recorded work-unit fails
     /// scoped-identity validation.
     fn bind_promise(&mut self) -> Result<(), SessionError> {
-        let identity = crate::resolve_forge_identity(&self.loaded.config.forge);
         let ticket = match &self.scope {
             SessionScope::Promised { ticket, .. } => ticket.clone(),
             SessionScope::Bound(_) => return Ok(()),
         };
-        match crate::resolve_promise(&self.loaded.store, &identity, &ticket)? {
+        match crate::resolve_promise(&self.loaded.store, &self.identity, &ticket)? {
             Some(work_unit) => {
                 crate::validate_scoped_work_unit_with_identity(
                     &self.loaded.store,
                     &work_unit,
-                    &identity,
+                    &self.identity,
                 )?;
                 self.scope = SessionScope::Bound(work_unit);
                 Ok(())

--- a/libagent/src/transcript.rs
+++ b/libagent/src/transcript.rs
@@ -686,6 +686,7 @@ mod tests {
                 owner: Some("tesserine".to_string()),
                 name: Some("runa".to_string()),
                 tracker_id: None,
+                ..ForgeConfig::default()
             },
         );
 

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -1743,6 +1743,7 @@ cat >/dev/null
                 owner: Some("tesserine".to_string()),
                 name: Some("runa".to_string()),
                 tracker_id: None,
+                ..libagent::ForgeConfig::default()
             },
         };
 

--- a/runa-cli/tests/step.rs
+++ b/runa-cli/tests/step.rs
@@ -6,7 +6,13 @@ use std::process::Command;
 use std::time::Duration;
 
 fn runa_bin() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_runa"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_runa"));
+    command
+        .env_remove("RUNA_FORGE_TYPE")
+        .env_remove("RUNA_FORGE_OWNER")
+        .env_remove("RUNA_FORGE_NAME")
+        .env_remove("RUNA_FORGE_TRACKER_ID");
+    command
 }
 
 fn runa_bin_path() -> &'static Path {

--- a/runa-forge-compose/Cargo.toml
+++ b/runa-forge-compose/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "runa-forge-compose"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+libagent.workspace = true
+runa-forge-contract.workspace = true
+runa-forge-github.workspace = true
+runa-forge-sourcehut.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/runa-forge-compose/Cargo.toml
+++ b/runa-forge-compose/Cargo.toml
@@ -11,3 +11,6 @@ runa-forge-github.workspace = true
 runa-forge-sourcehut.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/runa-forge-compose/Cargo.toml
+++ b/runa-forge-compose/Cargo.toml
@@ -9,6 +9,7 @@ libagent.workspace = true
 runa-forge-contract.workspace = true
 runa-forge-github.workspace = true
 runa-forge-sourcehut.workspace = true
+jsonschema.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/runa-forge-compose/src/lib.rs
+++ b/runa-forge-compose/src/lib.rs
@@ -1,0 +1,115 @@
+use libagent::ForgeConfig;
+use runa_forge_contract::{ComposedTool, ForgeConnector, ForgeError, Operation, compose_tool_sets};
+use runa_forge_github::{GithubConfig, GithubConnector, GithubHttpTransport};
+use runa_forge_sourcehut::{SourcehutConfig, SourcehutConnector, SourcehutHttpTransport};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+pub struct ForgeRuntime {
+    pub tools: BTreeMap<String, ComposedTool>,
+    connector: Box<dyn ForgeConnector>,
+}
+
+impl ForgeRuntime {
+    pub fn call_tool(&self, exposed_name: &str, input: Value) -> Result<Value, RuntimeError> {
+        let tool = self
+            .tools
+            .get(exposed_name)
+            .ok_or_else(|| RuntimeError::UnknownTool(exposed_name.to_string()))?;
+        self.connector
+            .call(tool.operation, input)
+            .map_err(RuntimeError::Forge)
+    }
+}
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    UnknownTool(String),
+    Composition(String),
+    Forge(ForgeError),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RuntimeError::UnknownTool(tool) => write!(f, "unknown forge tool '{tool}'"),
+            RuntimeError::Composition(message) => write!(f, "{message}"),
+            RuntimeError::Forge(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeError {}
+
+pub fn runtime_from_config(config: &ForgeConfig) -> Result<Option<ForgeRuntime>, RuntimeError> {
+    let forge_type = config.forge_type.as_deref().unwrap_or("github");
+    let aliases: HashMap<String, String> = config
+        .tool_aliases
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+
+    match forge_type {
+        "github" => {
+            let Some(owner) = config.owner.as_ref().filter(|value| !value.is_empty()) else {
+                return Ok(None);
+            };
+            let Some(repo) = config.name.as_ref().filter(|value| !value.is_empty()) else {
+                return Ok(None);
+            };
+            let connector = GithubConnector::new(
+                GithubConfig {
+                    owner: owner.clone(),
+                    repo: repo.clone(),
+                    api_base: config
+                        .api_base
+                        .clone()
+                        .unwrap_or_else(|| "https://api.github.com".to_string()),
+                    credential_env: config.credential_env.clone(),
+                    credential_command: non_empty_command(config),
+                },
+                GithubHttpTransport,
+            );
+            runtime_for_connector(Box::new(connector), aliases)
+        }
+        "sourcehut" => {
+            let Some(tracker_id) = config.tracker_id.as_ref().filter(|value| !value.is_empty())
+            else {
+                return Ok(None);
+            };
+            let connector = SourcehutConnector::new(
+                SourcehutConfig {
+                    tracker_id: tracker_id.clone(),
+                    api_base: config
+                        .api_base
+                        .clone()
+                        .unwrap_or_else(|| "https://todo.sr.ht/query".to_string()),
+                    git_remote: config.git_remote.clone().unwrap_or_default(),
+                    credential_env: config.credential_env.clone(),
+                    credential_command: non_empty_command(config),
+                },
+                SourcehutHttpTransport,
+            );
+            runtime_for_connector(Box::new(connector), aliases)
+        }
+        _ => Ok(None),
+    }
+}
+
+fn runtime_for_connector(
+    connector: Box<dyn ForgeConnector>,
+    aliases: HashMap<String, String>,
+) -> Result<Option<ForgeRuntime>, RuntimeError> {
+    let tools = compose_tool_sets(&[connector.tool_set()], &aliases)
+        .map_err(|error| RuntimeError::Composition(error.to_string()))?;
+    Ok(Some(ForgeRuntime { tools, connector }))
+}
+
+fn non_empty_command(config: &ForgeConfig) -> Option<Vec<String>> {
+    (!config.credential_command.is_empty()).then(|| config.credential_command.clone())
+}
+
+pub fn operation_for_tool(runtime: &ForgeRuntime, exposed_name: &str) -> Option<Operation> {
+    runtime.tools.get(exposed_name).map(|tool| tool.operation)
+}

--- a/runa-forge-compose/src/lib.rs
+++ b/runa-forge-compose/src/lib.rs
@@ -17,9 +17,32 @@ impl ForgeRuntime {
             .tools
             .get(exposed_name)
             .ok_or_else(|| RuntimeError::UnknownTool(exposed_name.to_string()))?;
+        validate_tool_input(tool, &input)?;
         self.connector
             .call(tool.operation, input)
             .map_err(RuntimeError::Forge)
+    }
+}
+
+fn validate_tool_input(tool: &ComposedTool, input: &Value) -> Result<(), RuntimeError> {
+    let validator = jsonschema::validator_for(&tool.input_schema).map_err(|error| {
+        RuntimeError::InvalidInput(format!(
+            "{} input schema is invalid: {error}",
+            tool.exposed_name
+        ))
+    })?;
+    let violations = validator
+        .iter_errors(input)
+        .map(|error| format!("{}: {}", error.instance_path(), error))
+        .collect::<Vec<_>>();
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(RuntimeError::InvalidInput(format!(
+            "{} input does not match advertised schema:\n{}",
+            tool.exposed_name,
+            violations.join("\n")
+        )))
     }
 }
 
@@ -27,6 +50,7 @@ impl ForgeRuntime {
 pub enum RuntimeError {
     UnknownTool(String),
     Composition(String),
+    InvalidInput(String),
     Forge(ForgeError),
 }
 
@@ -35,6 +59,7 @@ impl fmt::Display for RuntimeError {
         match self {
             RuntimeError::UnknownTool(tool) => write!(f, "unknown forge tool '{tool}'"),
             RuntimeError::Composition(message) => write!(f, "{message}"),
+            RuntimeError::InvalidInput(message) => write!(f, "invalid input: {message}"),
             RuntimeError::Forge(error) => write!(f, "{error}"),
         }
     }
@@ -203,4 +228,138 @@ fn replace_repo_path(path: &str, owner: &str, name: &str) -> String {
 
 pub fn operation_for_tool(runtime: &ForgeRuntime, exposed_name: &str) -> Option<Operation> {
     runtime.tools.get(exposed_name).map(|tool| tool.operation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runa_forge_contract::ForgeConnector;
+    use serde_json::{Value, json};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct RecordingConnector {
+        calls: Arc<Mutex<Vec<Operation>>>,
+    }
+
+    impl ForgeConnector for RecordingConnector {
+        fn set_name(&self) -> &str {
+            "test"
+        }
+
+        fn call(&self, operation: Operation, _input: Value) -> Result<Value, ForgeError> {
+            self.calls.lock().unwrap().push(operation);
+            Ok(json!({ "ok": true }))
+        }
+    }
+
+    #[test]
+    fn runtime_rejects_missing_required_input_for_every_operation_before_connector_dispatch() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let runtime = runtime_for_connector(
+            Box::new(RecordingConnector {
+                calls: Arc::clone(&calls),
+            }),
+            HashMap::new(),
+        )
+        .unwrap()
+        .expect("test connector should compose");
+
+        for operation in Operation::ALL {
+            let tool_name = operation.canonical_name();
+            let required = runtime.tools[tool_name]
+                .input_schema
+                .get("required")
+                .and_then(Value::as_array)
+                .expect("operation schema should list required fields")
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .expect("required field should be a string")
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+
+            for missing_field in required {
+                calls.lock().unwrap().clear();
+                let mut input = valid_input(operation);
+                input
+                    .as_object_mut()
+                    .expect("test input should be an object")
+                    .remove(&missing_field);
+
+                let error = runtime
+                    .call_tool(tool_name, input)
+                    .expect_err("missing required input should be rejected");
+
+                assert!(
+                    error.to_string().contains(&missing_field),
+                    "{tool_name} error should name missing field {missing_field}: {error}"
+                );
+                assert!(
+                    calls.lock().unwrap().is_empty(),
+                    "{tool_name} dispatched to connector despite missing {missing_field}"
+                );
+            }
+        }
+    }
+
+    fn valid_input(operation: Operation) -> Value {
+        let work_unit = json!({
+            "id": "test:scope:issue:203",
+            "display": "scope#203"
+        });
+        let change = json!({
+            "id": "test:scope:change:12:version:1",
+            "display": "change#12"
+        });
+        let disposition = json!({
+            "kind": "approved",
+            "against_version": 1,
+            "reviewer": "reviewer",
+            "reviewed_at": "2026-06-17T00:00:00Z",
+            "findings": []
+        });
+        let completion = json!({
+            "criterion_summary": "done",
+            "gaps": [],
+            "change_reference": "abc123",
+            "documentation_status": "updated"
+        });
+
+        match operation {
+            Operation::ReadTicket => json!({ "reference": "203" }),
+            Operation::CreateTicket => json!({ "title": "title", "body": "body" }),
+            Operation::ClaimWorkUnit => json!({ "handle": work_unit }),
+            Operation::RecordProgress => json!({ "handle": work_unit, "body": "progress" }),
+            Operation::DeliverChangeProposal => json!({
+                "work_unit": work_unit,
+                "branch": "issue-203",
+                "commit": "abc123",
+                "base": "main",
+                "summary": "summary",
+                "body": "body",
+                "version": 1
+            }),
+            Operation::ReflectDisposition => json!({
+                "work_unit": work_unit,
+                "change": change,
+                "disposition": disposition,
+                "body": "approved"
+            }),
+            Operation::ApplyApprovedChange => json!({
+                "work_unit": work_unit,
+                "change": change,
+                "approved_version": 1,
+                "approved_commit": "abc123",
+                "base": "main"
+            }),
+            Operation::CloseOut => json!({
+                "work_unit": work_unit,
+                "completion": completion,
+                "body": "done"
+            }),
+        }
+    }
 }

--- a/runa-forge-compose/src/lib.rs
+++ b/runa-forge-compose/src/lib.rs
@@ -1,4 +1,4 @@
-use libagent::ForgeConfig;
+use libagent::{ForgeConfig, ResolvedForgeIdentity};
 use runa_forge_contract::{ComposedTool, ForgeConnector, ForgeError, Operation, compose_tool_sets};
 use runa_forge_github::{GithubConfig, GithubConnector, GithubHttpTransport};
 use runa_forge_sourcehut::{SourcehutConfig, SourcehutConnector, SourcehutHttpTransport};
@@ -43,7 +43,18 @@ impl fmt::Display for RuntimeError {
 impl std::error::Error for RuntimeError {}
 
 pub fn runtime_from_config(config: &ForgeConfig) -> Result<Option<ForgeRuntime>, RuntimeError> {
-    let forge_type = config.forge_type.as_deref().unwrap_or("github");
+    let identity = libagent::resolve_forge_identity(config);
+    runtime_from_config_with_identity(config, &identity)
+}
+
+pub fn runtime_from_config_with_identity(
+    config: &ForgeConfig,
+    identity: &ResolvedForgeIdentity,
+) -> Result<Option<ForgeRuntime>, RuntimeError> {
+    if !has_connector_identity_config(config) {
+        return Ok(None);
+    }
+    let forge_type = identity.forge_type.as_str();
     let aliases: HashMap<String, String> = config
         .tool_aliases
         .iter()
@@ -52,10 +63,10 @@ pub fn runtime_from_config(config: &ForgeConfig) -> Result<Option<ForgeRuntime>,
 
     match forge_type {
         "github" => {
-            let Some(owner) = config.owner.as_ref().filter(|value| !value.is_empty()) else {
+            let Some(owner) = identity.owner.as_ref().filter(|value| !value.is_empty()) else {
                 return Ok(None);
             };
-            let Some(repo) = config.name.as_ref().filter(|value| !value.is_empty()) else {
+            let Some(repo) = identity.name.as_ref().filter(|value| !value.is_empty()) else {
                 return Ok(None);
             };
             let connector = GithubConnector::new(
@@ -75,7 +86,10 @@ pub fn runtime_from_config(config: &ForgeConfig) -> Result<Option<ForgeRuntime>,
             runtime_for_connector(Box::new(connector), aliases)
         }
         "sourcehut" => {
-            let Some(tracker_id) = config.tracker_id.as_ref().filter(|value| !value.is_empty())
+            let Some(tracker_id) = identity
+                .tracker_id
+                .as_ref()
+                .filter(|value| !value.is_empty())
             else {
                 return Ok(None);
             };
@@ -86,7 +100,7 @@ pub fn runtime_from_config(config: &ForgeConfig) -> Result<Option<ForgeRuntime>,
                         .api_base
                         .clone()
                         .unwrap_or_else(|| "https://todo.sr.ht/query".to_string()),
-                    git_remote: config.git_remote.clone().unwrap_or_default(),
+                    git_remote: sourcehut_git_remote(config, identity),
                     credential_env: config.credential_env.clone(),
                     credential_command: non_empty_command(config),
                 },
@@ -109,6 +123,82 @@ fn runtime_for_connector(
 
 fn non_empty_command(config: &ForgeConfig) -> Option<Vec<String>> {
     (!config.credential_command.is_empty()).then(|| config.credential_command.clone())
+}
+
+fn has_connector_identity_config(config: &ForgeConfig) -> bool {
+    [
+        config.forge_type.as_deref(),
+        config.owner.as_deref(),
+        config.name.as_deref(),
+        config.tracker_id.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|value| !value.trim().is_empty())
+}
+
+fn sourcehut_git_remote(config: &ForgeConfig, identity: &ResolvedForgeIdentity) -> String {
+    let remote = config.git_remote.clone().unwrap_or_default();
+    let Some(owner) = identity.owner.as_deref().filter(|value| !value.is_empty()) else {
+        return remote;
+    };
+    let Some(name) = identity.name.as_deref().filter(|value| !value.is_empty()) else {
+        return remote;
+    };
+    if remote.trim().is_empty() {
+        return remote;
+    }
+    remote_with_repo_coordinate(&remote, owner, name)
+}
+
+fn remote_with_repo_coordinate(remote: &str, owner: &str, name: &str) -> String {
+    if let Some((prefix, path)) = split_url_remote(remote) {
+        return format!("{prefix}{}", replace_repo_path(path, owner, name));
+    }
+    if let Some((prefix, path)) = split_scp_remote(remote) {
+        return format!("{prefix}{}", replace_repo_path(path, owner, name));
+    }
+    replace_repo_path(remote, owner, name)
+}
+
+fn split_url_remote(remote: &str) -> Option<(&str, &str)> {
+    let scheme = remote.find("://")?;
+    let authority_start = scheme + 3;
+    let path_offset = remote[authority_start..].find('/')?;
+    let path_start = authority_start + path_offset + 1;
+    Some(remote.split_at(path_start))
+}
+
+fn split_scp_remote(remote: &str) -> Option<(&str, &str)> {
+    if remote.contains("://") {
+        return None;
+    }
+    let colon = remote.find(':')?;
+    let first_slash = remote.find('/');
+    if first_slash.is_some_and(|slash| slash < colon) {
+        return None;
+    }
+    Some(remote.split_at(colon + 1))
+}
+
+fn replace_repo_path(path: &str, owner: &str, name: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    let mut parts = trimmed.split('/').collect::<Vec<_>>();
+    if parts.first().is_some_and(|part| part.starts_with('~')) {
+        return format!("~{owner}/{name}");
+    }
+    match parts.len() {
+        0 => format!("{owner}/{name}"),
+        1 => format!("{owner}/{name}"),
+        _ => {
+            parts.truncate(parts.len() - 2);
+            if parts.is_empty() {
+                format!("{owner}/{name}")
+            } else {
+                format!("{}/{owner}/{name}", parts.join("/"))
+            }
+        }
+    }
 }
 
 pub fn operation_for_tool(runtime: &ForgeRuntime, exposed_name: &str) -> Option<Operation> {

--- a/runa-forge-compose/src/lib.rs
+++ b/runa-forge-compose/src/lib.rs
@@ -66,6 +66,7 @@ pub fn runtime_from_config(config: &ForgeConfig) -> Result<Option<ForgeRuntime>,
                         .api_base
                         .clone()
                         .unwrap_or_else(|| "https://api.github.com".to_string()),
+                    assignee: config.assignee.clone(),
                     credential_env: config.credential_env.clone(),
                     credential_command: non_empty_command(config),
                 },

--- a/runa-forge-compose/tests/compose.rs
+++ b/runa-forge-compose/tests/compose.rs
@@ -137,9 +137,11 @@ fn sourcehut_graphql_coordinates_follow_resolved_env_identity() {
         ("RUNA_FORGE_NAME", "override-repo"),
         ("RUNA_FORGE_TRACKER_ID", "9"),
     ]);
-    let (api_base, request_capture, server) = http_json_server(
+    let tracker_rid = "06fdktpsb5w8q09e22xy0m6fnr";
+    let (api_base, request_capture, server) = http_json_sequence_server(&[
+        r#"{"data":{"trackers":{"results":[{"id":9,"rid":"06fdktpsb5w8q09e22xy0m6fnr","name":"override-repo"}],"cursor":null}}}"#,
         r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"Override","description":"body","status":"open"}}}}"#,
-    );
+    ]);
 
     let runtime = runtime_from_config(&ForgeConfig {
         forge_type: Some("sourcehut".to_string()),
@@ -156,9 +158,16 @@ fn sourcehut_graphql_coordinates_follow_resolved_env_identity() {
         .call_tool("read-ticket", json!({ "reference": "203" }))
         .unwrap();
 
-    let request = request_capture.lock().unwrap().clone();
-    assert!(request.starts_with("POST /query "));
-    assert!(request.contains(r#""tracker":"9""#), "request: {request}");
+    let requests = request_capture.lock().unwrap().clone();
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].starts_with("POST /query "));
+    assert!(requests[0].contains("trackers"), "request: {}", requests[0]);
+    assert!(requests[1].starts_with("POST /query "));
+    assert!(
+        requests[1].contains(&format!(r#""tracker":"{tracker_rid}""#)),
+        "request: {}",
+        requests[1]
+    );
     assert_eq!(output["handle"]["id"], "sourcehut:tracker:9:ticket:203");
     server.join().unwrap();
 }
@@ -233,6 +242,35 @@ fn http_json_server(body: &'static str) -> (String, Arc<Mutex<String>>, thread::
             body
         )
         .unwrap();
+    });
+    (format!("http://{address}"), request_capture, server)
+}
+
+fn http_json_sequence_server(
+    bodies: &[&'static str],
+) -> (String, Arc<Mutex<Vec<String>>>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let request_capture = Arc::new(Mutex::new(Vec::new()));
+    let thread_capture = Arc::clone(&request_capture);
+    let bodies = bodies.to_vec();
+    let server = thread::spawn(move || {
+        for body in bodies {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).unwrap();
+            thread_capture
+                .lock()
+                .unwrap()
+                .push(String::from_utf8_lossy(&request[..size]).to_string());
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
     });
     (format!("http://{address}"), request_capture, server)
 }

--- a/runa-forge-compose/tests/compose.rs
+++ b/runa-forge-compose/tests/compose.rs
@@ -138,7 +138,7 @@ fn sourcehut_graphql_coordinates_follow_resolved_env_identity() {
         ("RUNA_FORGE_TRACKER_ID", "9"),
     ]);
     let (api_base, request_capture, server) = http_json_server(
-        r#"{"data":{"ticket":{"id":203,"subject":"Override","description":"body","status":"open"}}}"#,
+        r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"Override","description":"body","status":"open"}}}}"#,
     );
 
     let runtime = runtime_from_config(&ForgeConfig {

--- a/runa-forge-compose/tests/compose.rs
+++ b/runa-forge-compose/tests/compose.rs
@@ -1,0 +1,67 @@
+use libagent::ForgeConfig;
+use runa_forge_compose::runtime_from_config;
+use std::collections::BTreeMap;
+
+#[test]
+fn github_config_loads_a_forge_runtime_with_output_schemas() {
+    let runtime = runtime_from_config(&ForgeConfig {
+        forge_type: Some("github".to_string()),
+        owner: Some("tesserine".to_string()),
+        name: Some("runa".to_string()),
+        api_base: Some("https://api.github.test".to_string()),
+        ..ForgeConfig::default()
+    })
+    .unwrap()
+    .expect("github config should load a connector");
+
+    let read_ticket = runtime.tools.get("read-ticket").unwrap();
+    assert_eq!(runtime.tools.len(), 8);
+    assert_eq!(read_ticket.operation.canonical_name(), "read-ticket");
+    assert!(read_ticket.output_schema.get("$defs").is_some());
+}
+
+#[test]
+fn sourcehut_config_loads_a_forge_runtime() {
+    let runtime = runtime_from_config(&ForgeConfig {
+        forge_type: Some("sourcehut".to_string()),
+        tracker_id: Some("4".to_string()),
+        api_base: Some("https://todo.example/query".to_string()),
+        git_remote: Some("ssh://git@git.example/runa".to_string()),
+        ..ForgeConfig::default()
+    })
+    .unwrap()
+    .expect("sourcehut config should load a connector");
+
+    assert_eq!(runtime.tools.len(), 8);
+    assert!(runtime.tools.contains_key("create-ticket"));
+}
+
+#[test]
+fn explicit_aliases_are_applied_at_composition() {
+    let mut aliases = BTreeMap::new();
+    aliases.insert(
+        "github:read-ticket".to_string(),
+        "work-unit-read-ticket".to_string(),
+    );
+    let runtime = runtime_from_config(&ForgeConfig {
+        forge_type: Some("github".to_string()),
+        owner: Some("tesserine".to_string()),
+        name: Some("runa".to_string()),
+        tool_aliases: aliases,
+        ..ForgeConfig::default()
+    })
+    .unwrap()
+    .expect("github config should load a connector");
+
+    assert!(!runtime.tools.contains_key("read-ticket"));
+    assert!(runtime.tools.contains_key("work-unit-read-ticket"));
+}
+
+#[test]
+fn absent_connector_config_leaves_the_mcp_surface_unchanged() {
+    assert!(
+        runtime_from_config(&ForgeConfig::default())
+            .unwrap()
+            .is_none()
+    );
+}

--- a/runa-forge-compose/tests/compose.rs
+++ b/runa-forge-compose/tests/compose.rs
@@ -1,9 +1,17 @@
 use libagent::ForgeConfig;
 use runa_forge_compose::runtime_from_config;
+use serde_json::json;
 use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::thread;
 
 #[test]
 fn github_config_loads_a_forge_runtime_with_output_schemas() {
+    let _env = EnvGuard::unset();
     let runtime = runtime_from_config(&ForgeConfig {
         forge_type: Some("github".to_string()),
         owner: Some("tesserine".to_string()),
@@ -22,6 +30,7 @@ fn github_config_loads_a_forge_runtime_with_output_schemas() {
 
 #[test]
 fn sourcehut_config_loads_a_forge_runtime() {
+    let _env = EnvGuard::unset();
     let runtime = runtime_from_config(&ForgeConfig {
         forge_type: Some("sourcehut".to_string()),
         tracker_id: Some("4".to_string()),
@@ -38,6 +47,7 @@ fn sourcehut_config_loads_a_forge_runtime() {
 
 #[test]
 fn explicit_aliases_are_applied_at_composition() {
+    let _env = EnvGuard::unset();
     let mut aliases = BTreeMap::new();
     aliases.insert(
         "github:read-ticket".to_string(),
@@ -59,9 +69,259 @@ fn explicit_aliases_are_applied_at_composition() {
 
 #[test]
 fn absent_connector_config_leaves_the_mcp_surface_unchanged() {
+    let _env = EnvGuard::unset();
     assert!(
         runtime_from_config(&ForgeConfig::default())
             .unwrap()
             .is_none()
     );
+}
+
+#[test]
+fn environment_identity_without_file_forge_config_leaves_the_mcp_surface_unchanged() {
+    let _env = EnvGuard::set(&[
+        ("RUNA_FORGE_TYPE", "github"),
+        ("RUNA_FORGE_OWNER", "override-owner"),
+        ("RUNA_FORGE_NAME", "override-repo"),
+    ]);
+
+    assert!(
+        runtime_from_config(&ForgeConfig::default())
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn github_connector_coordinates_follow_resolved_env_identity() {
+    let _env = EnvGuard::set(&[
+        ("RUNA_FORGE_TYPE", "github"),
+        ("RUNA_FORGE_OWNER", "override-owner"),
+        ("RUNA_FORGE_NAME", "override-repo"),
+    ]);
+    let (api_base, request_capture, server) =
+        http_json_server(r#"{"number":203,"title":"Override","body":"body","state":"open"}"#);
+
+    let runtime = runtime_from_config(&ForgeConfig {
+        forge_type: Some("github".to_string()),
+        owner: Some("stale-owner".to_string()),
+        name: Some("stale-repo".to_string()),
+        api_base: Some(api_base),
+        ..ForgeConfig::default()
+    })
+    .unwrap()
+    .expect("github connector should compose from resolved identity");
+
+    let output = runtime
+        .call_tool("read-ticket", json!({ "reference": "203" }))
+        .unwrap();
+
+    assert!(
+        request_capture
+            .lock()
+            .unwrap()
+            .starts_with("GET /repos/override-owner/override-repo/issues/203 ")
+    );
+    assert_eq!(
+        output["handle"]["id"],
+        "github:override-owner/override-repo:issue:203"
+    );
+    server.join().unwrap();
+}
+
+#[test]
+fn sourcehut_graphql_coordinates_follow_resolved_env_identity() {
+    let _env = EnvGuard::set(&[
+        ("RUNA_FORGE_TYPE", "sourcehut"),
+        ("RUNA_FORGE_OWNER", "override-owner"),
+        ("RUNA_FORGE_NAME", "override-repo"),
+        ("RUNA_FORGE_TRACKER_ID", "9"),
+    ]);
+    let (api_base, request_capture, server) = http_json_server(
+        r#"{"data":{"ticket":{"id":203,"subject":"Override","description":"body","status":"open"}}}"#,
+    );
+
+    let runtime = runtime_from_config(&ForgeConfig {
+        forge_type: Some("sourcehut".to_string()),
+        owner: Some("stale-owner".to_string()),
+        name: Some("stale-repo".to_string()),
+        tracker_id: Some("4".to_string()),
+        api_base: Some(format!("{api_base}/query")),
+        ..ForgeConfig::default()
+    })
+    .unwrap()
+    .expect("sourcehut connector should compose from resolved identity");
+
+    let output = runtime
+        .call_tool("read-ticket", json!({ "reference": "203" }))
+        .unwrap();
+
+    let request = request_capture.lock().unwrap().clone();
+    assert!(request.starts_with("POST /query "));
+    assert!(request.contains(r#""tracker":"9""#), "request: {request}");
+    assert_eq!(output["handle"]["id"], "sourcehut:tracker:9:ticket:203");
+    server.join().unwrap();
+}
+
+#[test]
+fn sourcehut_git_remote_repo_follows_resolved_env_identity() {
+    let _env = EnvGuard::set(&[
+        ("RUNA_FORGE_TYPE", "sourcehut"),
+        ("RUNA_FORGE_OWNER", "override-owner"),
+        ("RUNA_FORGE_NAME", "override-repo"),
+        ("RUNA_FORGE_TRACKER_ID", "9"),
+    ]);
+    let temp = tempfile::tempdir().unwrap();
+    let stale_remote = temp.path().join("stale-owner").join("stale-repo");
+    let override_remote = temp.path().join("override-owner").join("override-repo");
+    init_bare_remote(&stale_remote);
+    init_bare_remote(&override_remote);
+    let commit = git(
+        &["rev-parse", "HEAD"],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+
+    let runtime = runtime_from_config(&ForgeConfig {
+        forge_type: Some("sourcehut".to_string()),
+        owner: Some("stale-owner".to_string()),
+        name: Some("stale-repo".to_string()),
+        tracker_id: Some("4".to_string()),
+        api_base: Some("http://127.0.0.1:1/query".to_string()),
+        git_remote: Some(stale_remote.to_string_lossy().into_owned()),
+        ..ForgeConfig::default()
+    })
+    .unwrap()
+    .expect("sourcehut connector should compose from resolved identity");
+
+    let output = runtime
+        .call_tool(
+            "deliver-change-proposal",
+            json!({
+                "work_unit": {
+                    "id": "sourcehut:tracker:9:ticket:203",
+                    "display": "sourcehut:9#203"
+                },
+                "branch": "issue-203",
+                "commit": commit,
+                "base": "main",
+                "summary": "summary",
+                "body": "body",
+                "version": 1
+            }),
+        )
+        .unwrap();
+
+    assert_eq!(output["commit"], commit);
+    assert!(remote_ref_exists(&override_remote, "refs/heads/issue-203"));
+    assert!(!remote_ref_exists(&stale_remote, "refs/heads/issue-203"));
+}
+
+fn http_json_server(body: &'static str) -> (String, Arc<Mutex<String>>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let request_capture = Arc::new(Mutex::new(String::new()));
+    let thread_capture = Arc::clone(&request_capture);
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        *thread_capture.lock().unwrap() = String::from_utf8_lossy(&request[..size]).to_string();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}"), request_capture, server)
+}
+
+fn init_bare_remote(path: &Path) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    git(
+        &["init", "--bare", path.to_str().unwrap()],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+}
+
+fn remote_ref_exists(remote: &Path, reference: &str) -> bool {
+    Command::new("git")
+        .args(["ls-remote", remote.to_str().unwrap(), reference])
+        .output()
+        .map(|output| output.status.success() && !output.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn unset() -> Self {
+        Self::apply(&[])
+    }
+
+    fn set(values: &[(&'static str, &str)]) -> Self {
+        Self::apply(values)
+    }
+
+    fn apply(values: &[(&'static str, &str)]) -> Self {
+        let lock = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let names = [
+            "RUNA_FORGE_TYPE",
+            "RUNA_FORGE_OWNER",
+            "RUNA_FORGE_NAME",
+            "RUNA_FORGE_TRACKER_ID",
+        ];
+        let previous = names
+            .iter()
+            .map(|name| (*name, std::env::var_os(name)))
+            .collect::<Vec<_>>();
+        for name in names {
+            unsafe { std::env::remove_var(name) };
+        }
+        for (name, value) in values {
+            unsafe { std::env::set_var(name, value) };
+        }
+        Self {
+            _lock: lock,
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in &self.previous {
+            match value {
+                Some(value) => unsafe { std::env::set_var(name, value) },
+                None => unsafe { std::env::remove_var(name) },
+            }
+        }
+    }
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }

--- a/runa-forge-contract/Cargo.toml
+++ b/runa-forge-contract/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "runa-forge-contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+jsonschema.workspace = true

--- a/runa-forge-contract/src/lib.rs
+++ b/runa-forge-contract/src/lib.rs
@@ -1,0 +1,438 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+pub const CAPABILITY_NAME: &str = "forge";
+pub const CAPABILITY_VERSION: &str = "1.1.0";
+pub const COMMONS_PROVENANCE: &str = "commons@6924159fc4ff58745f0e2c68ed16849ffd9b4086";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Operation {
+    ReadTicket,
+    CreateTicket,
+    ClaimWorkUnit,
+    RecordProgress,
+    DeliverChangeProposal,
+    ReflectDisposition,
+    ApplyApprovedChange,
+    CloseOut,
+}
+
+impl Operation {
+    pub const ALL: [Operation; 8] = [
+        Operation::ReadTicket,
+        Operation::CreateTicket,
+        Operation::ClaimWorkUnit,
+        Operation::RecordProgress,
+        Operation::DeliverChangeProposal,
+        Operation::ReflectDisposition,
+        Operation::ApplyApprovedChange,
+        Operation::CloseOut,
+    ];
+
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Operation::ReadTicket => "read-ticket",
+            Operation::CreateTicket => "create-ticket",
+            Operation::ClaimWorkUnit => "claim-work-unit",
+            Operation::RecordProgress => "record-progress",
+            Operation::DeliverChangeProposal => "deliver-change-proposal",
+            Operation::ReflectDisposition => "reflect-disposition",
+            Operation::ApplyApprovedChange => "apply-approved-change",
+            Operation::CloseOut => "close-out",
+        }
+    }
+}
+
+impl fmt::Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.canonical_name())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Handle {
+    pub id: String,
+    pub display: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolDefinition {
+    pub set_name: String,
+    pub operation: Operation,
+    pub name: String,
+    pub input_schema: Value,
+    pub output_schema: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct ForgeToolSet {
+    pub set_name: String,
+    pub tools: Vec<ToolDefinition>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComposedTool {
+    pub exposed_name: String,
+    pub original_name: String,
+    pub set_name: String,
+    pub operation: Operation,
+    pub input_schema: Value,
+    pub output_schema: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompositionError {
+    MissingOperation {
+        set_name: String,
+        operation: Operation,
+    },
+    DuplicateOperation {
+        set_name: String,
+        operation: Operation,
+    },
+    ToolNameCollision {
+        tool_name: String,
+        first_set: String,
+        second_set: String,
+    },
+}
+
+impl fmt::Display for CompositionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompositionError::MissingOperation {
+                set_name,
+                operation,
+            } => write!(
+                f,
+                "tool-set '{set_name}' is missing operation '{operation}'"
+            ),
+            CompositionError::DuplicateOperation {
+                set_name,
+                operation,
+            } => write!(
+                f,
+                "tool-set '{set_name}' exposes operation '{operation}' more than once"
+            ),
+            CompositionError::ToolNameCollision {
+                tool_name,
+                first_set,
+                second_set,
+            } => write!(
+                f,
+                "tool name '{tool_name}' is exposed by both '{first_set}' and '{second_set}'"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CompositionError {}
+
+pub fn forge_tool_set(set_name: &str) -> ForgeToolSet {
+    ForgeToolSet {
+        set_name: set_name.to_string(),
+        tools: Vec::new(),
+    }
+}
+
+pub fn compose_tool_sets(
+    sets: &[ForgeToolSet],
+    aliases: &HashMap<String, String>,
+) -> Result<BTreeMap<String, ComposedTool>, CompositionError> {
+    let mut composed: BTreeMap<String, ComposedTool> = BTreeMap::new();
+    for set in sets {
+        validate_tool_set(set)?;
+        for tool in &set.tools {
+            let alias_key = format!("{}:{}", set.set_name, tool.name);
+            let exposed_name = aliases
+                .get(&alias_key)
+                .cloned()
+                .unwrap_or_else(|| tool.name.clone());
+            if let Some(existing) = composed.get(&exposed_name) {
+                return Err(CompositionError::ToolNameCollision {
+                    tool_name: exposed_name,
+                    first_set: existing.set_name.clone(),
+                    second_set: set.set_name.clone(),
+                });
+            }
+            composed.insert(
+                exposed_name.clone(),
+                ComposedTool {
+                    exposed_name,
+                    original_name: tool.name.clone(),
+                    set_name: set.set_name.clone(),
+                    operation: tool.operation,
+                    input_schema: tool.input_schema.clone(),
+                    output_schema: tool.output_schema.clone(),
+                },
+            );
+        }
+    }
+    Ok(composed)
+}
+
+pub fn validate_tool_set(set: &ForgeToolSet) -> Result<(), CompositionError> {
+    let mut seen = BTreeMap::new();
+    for tool in &set.tools {
+        if seen.insert(tool.operation, ()).is_some() {
+            return Err(CompositionError::DuplicateOperation {
+                set_name: set.set_name.clone(),
+                operation: tool.operation,
+            });
+        }
+    }
+    for operation in Operation::ALL {
+        if !seen.contains_key(&operation) {
+            return Err(CompositionError::MissingOperation {
+                set_name: set.set_name.clone(),
+                operation,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn canonical_forge_tool_set(set_name: &str) -> ForgeToolSet {
+    ForgeToolSet {
+        set_name: set_name.to_string(),
+        tools: Operation::ALL
+            .into_iter()
+            .map(|operation| ToolDefinition {
+                set_name: set_name.to_string(),
+                operation,
+                name: operation.canonical_name().to_string(),
+                input_schema: operation_input_schema(operation),
+                output_schema: operation_output_schema(operation),
+            })
+            .collect(),
+    }
+}
+
+pub fn operation_input_schema(operation: Operation) -> Value {
+    schema_document(operation_input_properties(operation))
+}
+
+pub fn operation_output_schema(operation: Operation) -> Value {
+    schema_document(operation_output_properties(operation))
+}
+
+fn schema_document((required, properties): (Vec<&str>, BTreeMap<&str, Value>)) -> Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": required,
+        "additionalProperties": false,
+        "properties": properties,
+        "$defs": {
+            "handle": {
+                "type": "object",
+                "required": ["id", "display"],
+                "additionalProperties": false,
+                "properties": {
+                    "id": { "type": "string", "minLength": 1 },
+                    "display": { "type": "string", "minLength": 1 }
+                }
+            },
+            "disposition": {
+                "type": "object",
+                "required": ["kind", "against_version", "reviewer", "reviewed_at", "findings"],
+                "additionalProperties": false,
+                "properties": {
+                    "kind": { "type": "string", "enum": ["approved", "needs-revision"] },
+                    "against_version": { "type": "integer", "minimum": 1 },
+                    "reviewer": { "type": "string", "minLength": 1 },
+                    "reviewed_at": { "type": "string", "minLength": 1 },
+                    "findings": { "type": "array", "items": { "type": "object" } }
+                }
+            },
+            "completion": {
+                "type": "object",
+                "required": ["criterion_summary", "gaps", "change_reference", "documentation_status"],
+                "additionalProperties": false,
+                "properties": {
+                    "criterion_summary": { "type": "string", "minLength": 1 },
+                    "gaps": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+                    "change_reference": { "type": "string", "minLength": 1 },
+                    "documentation_status": { "type": "string", "minLength": 1 }
+                }
+            }
+        }
+    })
+}
+
+fn handle_ref() -> Value {
+    serde_json::json!({ "$ref": "#/$defs/handle" })
+}
+
+fn string_schema() -> Value {
+    serde_json::json!({ "type": "string", "minLength": 1 })
+}
+
+fn integer_schema() -> Value {
+    serde_json::json!({ "type": "integer", "minimum": 1 })
+}
+
+fn operation_input_properties(
+    operation: Operation,
+) -> (Vec<&'static str>, BTreeMap<&'static str, Value>) {
+    let mut properties = BTreeMap::new();
+    match operation {
+        Operation::ReadTicket => {
+            properties.insert("reference", string_schema());
+            (vec!["reference"], properties)
+        }
+        Operation::CreateTicket => {
+            properties.insert("title", string_schema());
+            properties.insert("body", string_schema());
+            (vec!["title", "body"], properties)
+        }
+        Operation::ClaimWorkUnit => {
+            properties.insert("handle", handle_ref());
+            (vec!["handle"], properties)
+        }
+        Operation::RecordProgress => {
+            properties.insert("handle", handle_ref());
+            properties.insert("body", string_schema());
+            (vec!["handle", "body"], properties)
+        }
+        Operation::DeliverChangeProposal => {
+            properties.insert("work_unit", handle_ref());
+            properties.insert("branch", string_schema());
+            properties.insert("commit", string_schema());
+            properties.insert("base", string_schema());
+            properties.insert("summary", string_schema());
+            properties.insert("body", string_schema());
+            properties.insert("version", integer_schema());
+            (
+                vec![
+                    "work_unit",
+                    "branch",
+                    "commit",
+                    "base",
+                    "summary",
+                    "body",
+                    "version",
+                ],
+                properties,
+            )
+        }
+        Operation::ReflectDisposition => {
+            properties.insert("work_unit", handle_ref());
+            properties.insert("change", handle_ref());
+            properties.insert(
+                "disposition",
+                serde_json::json!({ "$ref": "#/$defs/disposition" }),
+            );
+            properties.insert("body", string_schema());
+            (
+                vec!["work_unit", "change", "disposition", "body"],
+                properties,
+            )
+        }
+        Operation::ApplyApprovedChange => {
+            properties.insert("work_unit", handle_ref());
+            properties.insert("change", handle_ref());
+            properties.insert("approved_version", integer_schema());
+            properties.insert("approved_commit", string_schema());
+            properties.insert("base", string_schema());
+            (
+                vec![
+                    "work_unit",
+                    "change",
+                    "approved_version",
+                    "approved_commit",
+                    "base",
+                ],
+                properties,
+            )
+        }
+        Operation::CloseOut => {
+            properties.insert("work_unit", handle_ref());
+            properties.insert(
+                "completion",
+                serde_json::json!({ "$ref": "#/$defs/completion" }),
+            );
+            properties.insert("body", string_schema());
+            (vec!["work_unit", "completion", "body"], properties)
+        }
+    }
+}
+
+fn operation_output_properties(
+    operation: Operation,
+) -> (Vec<&'static str>, BTreeMap<&'static str, Value>) {
+    let mut properties = BTreeMap::new();
+    match operation {
+        Operation::ReadTicket | Operation::CreateTicket => {
+            properties.insert("handle", handle_ref());
+            properties.insert("title", string_schema());
+            properties.insert("body", serde_json::json!({ "type": ["string", "null"] }));
+            properties.insert("state", string_schema());
+            (vec!["handle", "title", "state"], properties)
+        }
+        Operation::ClaimWorkUnit | Operation::RecordProgress | Operation::CloseOut => {
+            properties.insert("handle", handle_ref());
+            properties.insert("receipt", string_schema());
+            (vec!["handle", "receipt"], properties)
+        }
+        Operation::DeliverChangeProposal => {
+            properties.insert("handle", handle_ref());
+            properties.insert("work_unit", handle_ref());
+            properties.insert("commit", string_schema());
+            properties.insert("version", integer_schema());
+            (vec!["handle", "work_unit", "commit", "version"], properties)
+        }
+        Operation::ReflectDisposition => {
+            properties.insert("work_unit", handle_ref());
+            properties.insert("change", handle_ref());
+            properties.insert("receipt", string_schema());
+            (vec!["work_unit", "change", "receipt"], properties)
+        }
+        Operation::ApplyApprovedChange => {
+            properties.insert("work_unit", handle_ref());
+            properties.insert("change", handle_ref());
+            properties.insert("applied_commit", string_schema());
+            properties.insert("receipt", string_schema());
+            (
+                vec!["work_unit", "change", "applied_commit", "receipt"],
+                properties,
+            )
+        }
+    }
+}
+
+pub trait ForgeConnector: Send + Sync {
+    fn set_name(&self) -> &str;
+    fn tool_set(&self) -> ForgeToolSet {
+        canonical_forge_tool_set(self.set_name())
+    }
+    fn call(&self, operation: Operation, input: Value) -> Result<Value, ForgeError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeError {
+    InvalidInput(String),
+    ForeignScope(String),
+    Transport(String),
+    ProviderResponse(String),
+    Unsupported(String),
+}
+
+impl fmt::Display for ForgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForgeError::InvalidInput(message) => write!(f, "invalid input: {message}"),
+            ForgeError::ForeignScope(message) => write!(f, "foreign scope: {message}"),
+            ForgeError::Transport(message) => write!(f, "transport error: {message}"),
+            ForgeError::ProviderResponse(message) => {
+                write!(f, "provider response error: {message}")
+            }
+            ForgeError::Unsupported(message) => write!(f, "unsupported: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ForgeError {}

--- a/runa-forge-contract/tests/contract.rs
+++ b/runa-forge-contract/tests/contract.rs
@@ -1,0 +1,125 @@
+use jsonschema::Validator;
+use runa_forge_contract::{
+    CompositionError, Operation, canonical_forge_tool_set, compose_tool_sets,
+    operation_input_schema, operation_output_schema, validate_tool_set,
+};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn canonical_tool_set_exposes_all_v1_1_operations() {
+    let set = canonical_forge_tool_set("github");
+
+    validate_tool_set(&set).unwrap();
+    assert_eq!(set.tools.len(), 8);
+    for operation in Operation::ALL {
+        assert!(
+            set.tools.iter().any(|tool| {
+                tool.operation == operation && tool.name == operation.canonical_name()
+            }),
+            "missing {operation}"
+        );
+    }
+}
+
+#[test]
+fn emitted_operation_schemas_are_self_contained() {
+    for operation in Operation::ALL {
+        let input_schema = operation_input_schema(operation);
+        let output_schema = operation_output_schema(operation);
+
+        Validator::options()
+            .build(&input_schema)
+            .unwrap_or_else(|error| panic!("{operation} input schema should compile: {error}"));
+        Validator::options()
+            .build(&output_schema)
+            .unwrap_or_else(|error| panic!("{operation} output schema should compile: {error}"));
+
+        assert!(
+            input_schema.get("$defs").is_some(),
+            "{operation} input schema should include local $defs"
+        );
+        assert!(
+            output_schema.get("$defs").is_some(),
+            "{operation} output schema should include local $defs"
+        );
+    }
+}
+
+#[test]
+fn composition_reports_colliding_tool_sets_by_name() {
+    let github = canonical_forge_tool_set("github");
+    let sourcehut = canonical_forge_tool_set("sourcehut");
+
+    let error = compose_tool_sets(&[github, sourcehut], &HashMap::new()).unwrap_err();
+
+    let CompositionError::ToolNameCollision {
+        tool_name,
+        first_set,
+        second_set,
+    } = error
+    else {
+        panic!("expected collision, got {error:?}");
+    };
+    assert!(
+        Operation::ALL
+            .iter()
+            .any(|operation| operation.canonical_name() == tool_name)
+    );
+    assert_eq!(first_set, "github");
+    assert_eq!(second_set, "sourcehut");
+}
+
+#[test]
+fn composition_accepts_role_qualified_aliases() {
+    let github = canonical_forge_tool_set("github");
+    let sourcehut = canonical_forge_tool_set("sourcehut");
+    let aliases = Operation::ALL
+        .into_iter()
+        .map(|operation| {
+            (
+                format!("sourcehut:{}", operation.canonical_name()),
+                format!("work-unit-{}", operation.canonical_name()),
+            )
+        })
+        .collect();
+
+    let composed = compose_tool_sets(&[github, sourcehut], &aliases).unwrap();
+
+    assert!(composed.contains_key("read-ticket"));
+    assert!(composed.contains_key("work-unit-read-ticket"));
+    assert_eq!(composed.len(), 16);
+}
+
+#[test]
+fn schemas_validate_representative_payloads() {
+    let handle = json!({"id": "github:tesserine/runa:issue:203", "display": "tesserine/runa#203"});
+    let cases = [
+        (
+            Operation::ReadTicket,
+            json!({"reference": "tesserine/runa#203"}),
+        ),
+        (Operation::ClaimWorkUnit, json!({"handle": handle.clone()})),
+        (
+            Operation::DeliverChangeProposal,
+            json!({
+                "work_unit": handle,
+                "branch": "issue-203/runa-mcp-forge-connectors",
+                "commit": "abc123",
+                "base": "main",
+                "summary": "summary",
+                "body": "body",
+                "version": 1
+            }),
+        ),
+    ];
+
+    for (operation, payload) in cases {
+        let schema = operation_input_schema(operation);
+        let validator = Validator::options().build(&schema).unwrap();
+        assert!(
+            validator.is_valid(&payload),
+            "{operation} schema should validate representative payload"
+        );
+    }
+}

--- a/runa-forge-github/Cargo.toml
+++ b/runa-forge-github/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-forge-github"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+runa-forge-contract.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -8,6 +8,7 @@ pub struct GithubConfig {
     pub owner: String,
     pub repo: String,
     pub api_base: String,
+    pub assignee: Option<String>,
     pub credential_env: Option<String>,
     pub credential_command: Option<Vec<String>>,
 }
@@ -243,13 +244,20 @@ impl<T: GithubTransport> GithubConnector<T> {
 
     fn claim_work_unit(&self, input: Value) -> Result<Value, ForgeError> {
         let number = self.issue_number(input.get("handle"))?;
+        let assignee = self
+            .config
+            .assignee
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| ForgeError::InvalidInput("github assignee is required".into()))?;
         let response = self.send(
             "POST",
             format!(
                 "/repos/{}/{}/issues/{number}/assignees",
                 self.config.owner, self.config.repo
             ),
-            Some(json!({})),
+            Some(json!({ "assignees": [assignee] })),
         )?;
         Ok(json!({ "handle": self.issue_handle(number), "receipt": receipt(response, "claimed") }))
     }
@@ -277,7 +285,7 @@ impl<T: GithubTransport> GithubConnector<T> {
         let base = required_string(&input, "base")?;
         let summary = required_string(&input, "summary")?;
         let body = required_string(&input, "body")?;
-        let commit = required_string(&input, "commit")?;
+        let _commit = required_string(&input, "commit")?;
         let version = required_u64(&input, "version")?;
         let response = self.send(
             "POST",
@@ -285,10 +293,11 @@ impl<T: GithubTransport> GithubConnector<T> {
             Some(json!({ "title": summary, "head": branch, "base": base, "body": body })),
         )?;
         let number = response.get("number").and_then(Value::as_u64).unwrap_or(0);
+        let delivered_commit = response_string(&response, &["/head/sha", "/head/ref", "/sha"])?;
         Ok(json!({
             "handle": self.pull_handle(number, version),
             "work_unit": work_unit,
-            "commit": commit,
+            "commit": delivered_commit,
             "version": version
         }))
     }
@@ -330,10 +339,11 @@ impl<T: GithubTransport> GithubConnector<T> {
             ),
             Some(json!({ "sha": approved_commit })),
         )?;
+        let applied_commit = response_string(&response, &["/sha", "/merge_commit_sha"])?;
         Ok(json!({
             "work_unit": work_unit,
             "change": input.get("change").cloned().unwrap_or(Value::Null),
-            "applied_commit": approved_commit,
+            "applied_commit": applied_commit,
             "receipt": receipt(response, "applied")
         }))
     }
@@ -466,6 +476,19 @@ fn parse_number(value: &str) -> Result<u64, ForgeError> {
         .ok()
         .filter(|number| *number > 0)
         .ok_or_else(|| ForgeError::InvalidInput(format!("invalid ticket number '{value}'")))
+}
+
+fn response_string<'a>(response: &'a Value, pointers: &[&str]) -> Result<&'a str, ForgeError> {
+    pointers
+        .iter()
+        .find_map(|pointer| response.pointer(pointer).and_then(Value::as_str))
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ForgeError::ProviderResponse(format!(
+                "missing provider response value at {}",
+                pointers.join(" or ")
+            ))
+        })
 }
 
 fn receipt(response: Value, fallback: &str) -> String {

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -3,6 +3,8 @@ use serde_json::{Value, json};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+const GITHUB_USER_AGENT: &str = concat!("runa-forge-github/", env!("CARGO_PKG_VERSION"));
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GithubConfig {
     pub owner: String,
@@ -112,7 +114,10 @@ pub struct GithubHttpTransport;
 impl GithubTransport for GithubHttpTransport {
     fn send(&self, config: &GithubConfig, request: ProviderRequest) -> Result<Value, ForgeError> {
         let url = format!("{}{}", config.api_base.trim_end_matches('/'), request.path);
-        let client = reqwest::blocking::Client::new();
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(GITHUB_USER_AGENT)
+            .build()
+            .map_err(|error| ForgeError::Transport(error.to_string()))?;
         let builder = match request.method.as_str() {
             "GET" => client.get(&url),
             "POST" => client.post(&url),
@@ -285,7 +290,7 @@ impl<T: GithubTransport> GithubConnector<T> {
         let base = required_string(&input, "base")?;
         let summary = required_string(&input, "summary")?;
         let body = required_string(&input, "body")?;
-        let _commit = required_string(&input, "commit")?;
+        let commit = required_string(&input, "commit")?;
         let version = required_u64(&input, "version")?;
         let response = self.send(
             "POST",
@@ -293,7 +298,12 @@ impl<T: GithubTransport> GithubConnector<T> {
             Some(json!({ "title": summary, "head": branch, "base": base, "body": body })),
         )?;
         let number = response.get("number").and_then(Value::as_u64).unwrap_or(0);
-        let delivered_commit = response_string(&response, &["/head/sha", "/head/ref", "/sha"])?;
+        let delivered_commit = response_string(&response, &["/head/sha"])?;
+        if delivered_commit != commit {
+            return Err(ForgeError::InvalidInput(format!(
+                "created PR head SHA '{delivered_commit}' does not match requested commit '{commit}'"
+            )));
+        }
         Ok(json!({
             "handle": self.pull_handle(number, version),
             "work_unit": work_unit,

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -331,6 +331,21 @@ impl<T: GithubTransport> GithubConnector<T> {
         self.issue_number(Some(work_unit))?;
         let pull = self.pull_number(input.get("change"))?;
         let approved_commit = required_string(&input, "approved_commit")?;
+        let base = required_string(&input, "base")?;
+        let pull_snapshot = self.send(
+            "GET",
+            format!(
+                "/repos/{}/{}/pulls/{pull}",
+                self.config.owner, self.config.repo
+            ),
+            None,
+        )?;
+        let actual_base = response_string(&pull_snapshot, &["/base/ref"])?;
+        if actual_base != base {
+            return Err(ForgeError::InvalidInput(format!(
+                "change base '{actual_base}' does not match requested base '{base}'"
+            )));
+        }
         let response = self.send(
             "PUT",
             format!(
@@ -354,13 +369,21 @@ impl<T: GithubTransport> GithubConnector<T> {
             .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
         let number = self.issue_number(Some(work_unit))?;
         let body = required_string(&input, "body")?;
+        self.send(
+            "POST",
+            format!(
+                "/repos/{}/{}/issues/{number}/comments",
+                self.config.owner, self.config.repo
+            ),
+            Some(json!({ "body": body })),
+        )?;
         let response = self.send(
             "PATCH",
             format!(
                 "/repos/{}/{}/issues/{number}",
                 self.config.owner, self.config.repo
             ),
-            Some(json!({ "state": "closed", "body": body })),
+            Some(json!({ "state": "closed" })),
         )?;
         Ok(json!({ "handle": self.issue_handle(number), "receipt": receipt(response, "closed") }))
     }

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -339,9 +339,15 @@ impl<T: GithubTransport> GithubConnector<T> {
             .get("work_unit")
             .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
         self.issue_number(Some(work_unit))?;
-        let pull = self.pull_number(input.get("change"))?;
+        let (pull, change_version) = self.pull_change(input.get("change"))?;
+        let approved_version = required_u64(&input, "approved_version")?;
         let approved_commit = required_string(&input, "approved_commit")?;
         let base = required_string(&input, "base")?;
+        if change_version != approved_version {
+            return Err(ForgeError::InvalidInput(format!(
+                "change version {change_version} does not match approved_version {approved_version}"
+            )));
+        }
         let pull_snapshot = self.send(
             "GET",
             format!(
@@ -354,6 +360,12 @@ impl<T: GithubTransport> GithubConnector<T> {
         if actual_base != base {
             return Err(ForgeError::InvalidInput(format!(
                 "change base '{actual_base}' does not match requested base '{base}'"
+            )));
+        }
+        let actual_head = response_string(&pull_snapshot, &["/head/sha"])?;
+        if actual_head != approved_commit {
+            return Err(ForgeError::InvalidInput(format!(
+                "change head SHA '{actual_head}' does not match approved commit '{approved_commit}'"
             )));
         }
         let response = self.send(
@@ -460,11 +472,28 @@ impl<T: GithubTransport> GithubConnector<T> {
     }
 
     fn pull_number(&self, value: Option<&Value>) -> Result<u64, ForgeError> {
+        Ok(self.pull_change(value)?.0)
+    }
+
+    fn pull_change(&self, value: Option<&Value>) -> Result<(u64, u64), ForgeError> {
         let handle = handle_id(value)?;
         let prefix = format!("github:{}:pull:", self.repo_scope());
         if let Some(rest) = handle.strip_prefix(&prefix) {
-            let number = rest.split(':').next().unwrap_or(rest);
-            return parse_number(number);
+            let mut parts = rest.split(':');
+            let number = parts.next().unwrap_or_default();
+            let version_label = parts.next();
+            let version = parts.next();
+            if version_label != Some("version") || parts.next().is_some() {
+                return Err(ForgeError::InvalidInput(format!(
+                    "handle '{handle}' is not a versioned GitHub pull handle"
+                )));
+            }
+            let version = version.ok_or_else(|| {
+                ForgeError::InvalidInput(format!(
+                    "handle '{handle}' is not a versioned GitHub pull handle"
+                ))
+            })?;
+            return Ok((parse_number(number)?, parse_number(version)?));
         }
         if handle.starts_with("github:") {
             return Err(ForgeError::ForeignScope(format!(

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -1,0 +1,479 @@
+use runa_forge_contract::{ForgeConnector, ForgeError, Handle, Operation};
+use serde_json::{Value, json};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubConfig {
+    pub owner: String,
+    pub repo: String,
+    pub api_base: String,
+    pub credential_env: Option<String>,
+    pub credential_command: Option<Vec<String>>,
+}
+
+impl GithubConfig {
+    fn credential(&self) -> Result<Option<String>, ForgeError> {
+        if let Some(name) = self
+            .credential_env
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            && let Ok(value) = std::env::var(name)
+            && !value.is_empty()
+        {
+            return Ok(Some(value));
+        }
+
+        let Some(command) = self
+            .credential_command
+            .as_ref()
+            .filter(|command| !command.is_empty())
+        else {
+            return Ok(None);
+        };
+        let Some((program, args)) = command.split_first() else {
+            return Ok(None);
+        };
+        let output = std::process::Command::new(program)
+            .args(args)
+            .output()
+            .map_err(|error| {
+                ForgeError::Transport(format!("credential command failed: {error}"))
+            })?;
+        if !output.status.success() {
+            return Err(ForgeError::Transport(format!(
+                "credential command exited with status {}",
+                output.status
+            )));
+        }
+        let token = String::from_utf8(output.stdout)
+            .map_err(|_| {
+                ForgeError::Transport("credential command produced non-UTF-8 output".to_string())
+            })?
+            .trim()
+            .to_string();
+        Ok((!token.is_empty()).then_some(token))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderRequest {
+    pub method: String,
+    pub path: String,
+    pub body: Option<Value>,
+}
+
+pub trait GithubTransport: Clone + Send + Sync + 'static {
+    fn send(&self, config: &GithubConfig, request: ProviderRequest) -> Result<Value, ForgeError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GithubRecordingTransport {
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+    responses: Arc<Mutex<VecDeque<Value>>>,
+    repeating: Arc<Mutex<Option<Value>>>,
+}
+
+impl GithubRecordingTransport {
+    pub fn with_response(response: Value) -> Self {
+        let transport = Self::default();
+        transport.responses.lock().unwrap().push_back(response);
+        transport
+    }
+
+    pub fn with_repeating_response(response: Value) -> Self {
+        let transport = Self::default();
+        *transport.repeating.lock().unwrap() = Some(response);
+        transport
+    }
+
+    pub fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl GithubTransport for GithubRecordingTransport {
+    fn send(&self, _config: &GithubConfig, request: ProviderRequest) -> Result<Value, ForgeError> {
+        self.requests.lock().unwrap().push(request);
+        if let Some(response) = self.responses.lock().unwrap().pop_front() {
+            return Ok(response);
+        }
+        if let Some(response) = self.repeating.lock().unwrap().clone() {
+            return Ok(response);
+        }
+        Ok(json!({}))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GithubHttpTransport;
+
+impl GithubTransport for GithubHttpTransport {
+    fn send(&self, config: &GithubConfig, request: ProviderRequest) -> Result<Value, ForgeError> {
+        let url = format!("{}{}", config.api_base.trim_end_matches('/'), request.path);
+        let client = reqwest::blocking::Client::new();
+        let builder = match request.method.as_str() {
+            "GET" => client.get(&url),
+            "POST" => client.post(&url),
+            "PATCH" => client.patch(&url),
+            "PUT" => client.put(&url),
+            other => {
+                return Err(ForgeError::Transport(format!(
+                    "unsupported HTTP method {other}"
+                )));
+            }
+        };
+        let builder = if let Some(token) = config.credential()? {
+            builder.bearer_auth(token)
+        } else {
+            builder
+        };
+        let builder = if let Some(body) = request.body {
+            builder.json(&body)
+        } else {
+            builder
+        };
+        let response = builder
+            .send()
+            .map_err(|error| ForgeError::Transport(error.to_string()))?;
+        let status = response.status();
+        let value = response
+            .json::<Value>()
+            .map_err(|error| ForgeError::ProviderResponse(error.to_string()))?;
+        if !status.is_success() {
+            return Err(ForgeError::Transport(format!("GitHub returned {status}")));
+        }
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GithubConnector<T> {
+    config: GithubConfig,
+    transport: T,
+}
+
+impl<T: GithubTransport> GithubConnector<T> {
+    pub fn new(config: GithubConfig, transport: T) -> Self {
+        Self { config, transport }
+    }
+
+    pub fn call(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
+        <Self as ForgeConnector>::call(self, operation, input)
+    }
+
+    fn repo_scope(&self) -> String {
+        format!("{}/{}", self.config.owner, self.config.repo)
+    }
+
+    fn issue_handle(&self, number: u64) -> Handle {
+        Handle {
+            id: format!("github:{}:issue:{number}", self.repo_scope()),
+            display: format!("{}#{number}", self.repo_scope()),
+        }
+    }
+
+    fn pull_handle(&self, number: u64, version: u64) -> Handle {
+        Handle {
+            id: format!(
+                "github:{}:pull:{number}:version:{version}",
+                self.repo_scope()
+            ),
+            display: format!("{}#{number}", self.repo_scope()),
+        }
+    }
+
+    fn send(&self, method: &str, path: String, body: Option<Value>) -> Result<Value, ForgeError> {
+        self.transport.send(
+            &self.config,
+            ProviderRequest {
+                method: method.to_string(),
+                path,
+                body,
+            },
+        )
+    }
+}
+
+impl<T: GithubTransport> ForgeConnector for GithubConnector<T> {
+    fn set_name(&self) -> &str {
+        "github"
+    }
+
+    fn call(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
+        match operation {
+            Operation::ReadTicket => self.read_ticket(input),
+            Operation::CreateTicket => self.create_ticket(input),
+            Operation::ClaimWorkUnit => self.claim_work_unit(input),
+            Operation::RecordProgress => self.record_progress(input),
+            Operation::DeliverChangeProposal => self.deliver_change_proposal(input),
+            Operation::ReflectDisposition => self.reflect_disposition(input),
+            Operation::ApplyApprovedChange => self.apply_approved_change(input),
+            Operation::CloseOut => self.close_out(input),
+        }
+    }
+}
+
+impl<T: GithubTransport> GithubConnector<T> {
+    fn read_ticket(&self, input: Value) -> Result<Value, ForgeError> {
+        let reference = required_string(&input, "reference")?;
+        let number = self.resolve_reference(reference)?;
+        let response = self.send(
+            "GET",
+            format!(
+                "/repos/{}/{}/issues/{number}",
+                self.config.owner, self.config.repo
+            ),
+            None,
+        )?;
+        self.ticket_snapshot(number, &response)
+    }
+
+    fn create_ticket(&self, input: Value) -> Result<Value, ForgeError> {
+        let title = required_string(&input, "title")?;
+        let body = required_string(&input, "body")?;
+        let response = self.send(
+            "POST",
+            format!("/repos/{}/{}/issues", self.config.owner, self.config.repo),
+            Some(json!({ "title": title, "body": body })),
+        )?;
+        let number = response.get("number").and_then(Value::as_u64).unwrap_or(0);
+        self.ticket_snapshot(number, &response)
+    }
+
+    fn claim_work_unit(&self, input: Value) -> Result<Value, ForgeError> {
+        let number = self.issue_number(input.get("handle"))?;
+        let response = self.send(
+            "POST",
+            format!(
+                "/repos/{}/{}/issues/{number}/assignees",
+                self.config.owner, self.config.repo
+            ),
+            Some(json!({})),
+        )?;
+        Ok(json!({ "handle": self.issue_handle(number), "receipt": receipt(response, "claimed") }))
+    }
+
+    fn record_progress(&self, input: Value) -> Result<Value, ForgeError> {
+        let number = self.issue_number(input.get("handle"))?;
+        let body = required_string(&input, "body")?;
+        let response = self.send(
+            "POST",
+            format!(
+                "/repos/{}/{}/issues/{number}/comments",
+                self.config.owner, self.config.repo
+            ),
+            Some(json!({ "body": body })),
+        )?;
+        Ok(json!({ "handle": self.issue_handle(number), "receipt": receipt(response, "progress") }))
+    }
+
+    fn deliver_change_proposal(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        self.issue_number(Some(work_unit))?;
+        let branch = required_string(&input, "branch")?;
+        let base = required_string(&input, "base")?;
+        let summary = required_string(&input, "summary")?;
+        let body = required_string(&input, "body")?;
+        let commit = required_string(&input, "commit")?;
+        let version = required_u64(&input, "version")?;
+        let response = self.send(
+            "POST",
+            format!("/repos/{}/{}/pulls", self.config.owner, self.config.repo),
+            Some(json!({ "title": summary, "head": branch, "base": base, "body": body })),
+        )?;
+        let number = response.get("number").and_then(Value::as_u64).unwrap_or(0);
+        Ok(json!({
+            "handle": self.pull_handle(number, version),
+            "work_unit": work_unit,
+            "commit": commit,
+            "version": version
+        }))
+    }
+
+    fn reflect_disposition(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        self.issue_number(Some(work_unit))?;
+        let pull = self.pull_number(input.get("change"))?;
+        let body = required_string(&input, "body")?;
+        let response = self.send(
+            "POST",
+            format!(
+                "/repos/{}/{}/issues/{pull}/comments",
+                self.config.owner, self.config.repo
+            ),
+            Some(json!({ "body": body })),
+        )?;
+        Ok(json!({
+            "work_unit": work_unit,
+            "change": input.get("change").cloned().unwrap_or(Value::Null),
+            "receipt": receipt(response, "disposition")
+        }))
+    }
+
+    fn apply_approved_change(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        self.issue_number(Some(work_unit))?;
+        let pull = self.pull_number(input.get("change"))?;
+        let approved_commit = required_string(&input, "approved_commit")?;
+        let response = self.send(
+            "PUT",
+            format!(
+                "/repos/{}/{}/pulls/{pull}/merge",
+                self.config.owner, self.config.repo
+            ),
+            Some(json!({ "sha": approved_commit })),
+        )?;
+        Ok(json!({
+            "work_unit": work_unit,
+            "change": input.get("change").cloned().unwrap_or(Value::Null),
+            "applied_commit": approved_commit,
+            "receipt": receipt(response, "applied")
+        }))
+    }
+
+    fn close_out(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        let number = self.issue_number(Some(work_unit))?;
+        let body = required_string(&input, "body")?;
+        let response = self.send(
+            "PATCH",
+            format!(
+                "/repos/{}/{}/issues/{number}",
+                self.config.owner, self.config.repo
+            ),
+            Some(json!({ "state": "closed", "body": body })),
+        )?;
+        Ok(json!({ "handle": self.issue_handle(number), "receipt": receipt(response, "closed") }))
+    }
+
+    fn ticket_snapshot(&self, number: u64, response: &Value) -> Result<Value, ForgeError> {
+        let number = if number == 0 {
+            response
+                .get("number")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| ForgeError::ProviderResponse("missing number".into()))?
+        } else {
+            number
+        };
+        Ok(json!({
+            "handle": self.issue_handle(number),
+            "title": response.get("title").and_then(Value::as_str).unwrap_or(""),
+            "body": response.get("body").cloned().unwrap_or(Value::Null),
+            "state": response.get("state").and_then(Value::as_str).unwrap_or("unknown")
+        }))
+    }
+
+    fn resolve_reference(&self, reference: &str) -> Result<u64, ForgeError> {
+        let reference = reference.trim();
+        if let Some(rest) = reference.strip_prefix("github:") {
+            return self.resolve_coordinate_reference(rest);
+        }
+        if let Some((repo, number)) = reference.split_once('#') {
+            if repo.is_empty() {
+                return parse_number(number);
+            }
+            return self.resolve_coordinate_reference(reference);
+        }
+        parse_number(reference.strip_prefix('#').unwrap_or(reference))
+    }
+
+    fn resolve_coordinate_reference(&self, reference: &str) -> Result<u64, ForgeError> {
+        let (repo, number) = reference.split_once('#').ok_or_else(|| {
+            ForgeError::InvalidInput(format!("invalid GitHub reference {reference}"))
+        })?;
+        if repo != self.repo_scope() {
+            return Err(ForgeError::ForeignScope(format!(
+                "{repo} does not match {}",
+                self.repo_scope()
+            )));
+        }
+        parse_number(number)
+    }
+
+    fn issue_number(&self, value: Option<&Value>) -> Result<u64, ForgeError> {
+        let handle = handle_id(value)?;
+        let prefix = format!("github:{}:issue:", self.repo_scope());
+        if let Some(number) = handle.strip_prefix(&prefix) {
+            return parse_number(number);
+        }
+        if handle.starts_with("github:") {
+            return Err(ForgeError::ForeignScope(format!(
+                "{handle} does not match {}",
+                self.repo_scope()
+            )));
+        }
+        Err(ForgeError::InvalidInput(format!(
+            "handle '{handle}' is not a GitHub issue handle"
+        )))
+    }
+
+    fn pull_number(&self, value: Option<&Value>) -> Result<u64, ForgeError> {
+        let handle = handle_id(value)?;
+        let prefix = format!("github:{}:pull:", self.repo_scope());
+        if let Some(rest) = handle.strip_prefix(&prefix) {
+            let number = rest.split(':').next().unwrap_or(rest);
+            return parse_number(number);
+        }
+        if handle.starts_with("github:") {
+            return Err(ForgeError::ForeignScope(format!(
+                "{handle} does not match {}",
+                self.repo_scope()
+            )));
+        }
+        Err(ForgeError::InvalidInput(format!(
+            "handle '{handle}' is not a GitHub pull handle"
+        )))
+    }
+}
+
+fn required_string<'a>(input: &'a Value, field: &str) -> Result<&'a str, ForgeError> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput(format!("{field} is required")))
+}
+
+fn required_u64(input: &Value, field: &str) -> Result<u64, ForgeError> {
+    input
+        .get(field)
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .ok_or_else(|| ForgeError::InvalidInput(format!("{field} is required")))
+}
+
+fn handle_id(value: Option<&Value>) -> Result<&str, ForgeError> {
+    value
+        .and_then(|value| value.get("id"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput("handle.id is required".into()))
+}
+
+fn parse_number(value: &str) -> Result<u64, ForgeError> {
+    value
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|number| *number > 0)
+        .ok_or_else(|| ForgeError::InvalidInput(format!("invalid ticket number '{value}'")))
+}
+
+fn receipt(response: Value, fallback: &str) -> String {
+    response
+        .get("html_url")
+        .or_else(|| response.get("url"))
+        .or_else(|| response.get("sha"))
+        .and_then(Value::as_str)
+        .unwrap_or(fallback)
+        .to_string()
+}

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -1,0 +1,181 @@
+use runa_forge_contract::Operation;
+use runa_forge_github::{
+    GithubConfig, GithubConnector, GithubHttpTransport, GithubRecordingTransport, ProviderRequest,
+};
+use serde_json::json;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+fn config(api_base: &str) -> GithubConfig {
+    GithubConfig {
+        owner: "tesserine".to_string(),
+        repo: "runa".to_string(),
+        api_base: api_base.to_string(),
+        credential_env: None,
+        credential_command: None,
+    }
+}
+
+fn handle(number: u64) -> serde_json::Value {
+    json!({
+        "id": format!("github:tesserine/runa:issue:{number}"),
+        "display": format!("tesserine/runa#{number}")
+    })
+}
+
+#[test]
+fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
+    let transport = GithubRecordingTransport::with_repeating_response(json!({
+        "number": 203,
+        "title": "Forge connectors",
+        "body": "body",
+        "state": "open"
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    for reference in [
+        "github:tesserine/runa#203",
+        "tesserine/runa#203",
+        "#203",
+        "203",
+    ] {
+        let output = connector
+            .call(Operation::ReadTicket, json!({ "reference": reference }))
+            .unwrap();
+
+        assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
+        assert_eq!(output["title"], "Forge connectors");
+    }
+}
+
+#[test]
+fn foreign_scope_is_rejected_before_transport() {
+    let transport = GithubRecordingTransport::default();
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let error = connector
+        .call(
+            Operation::RecordProgress,
+            json!({
+                "handle": {
+                    "id": "github:tesserine/groundwork:issue:203",
+                    "display": "tesserine/groundwork#203"
+                },
+                "body": "progress"
+            }),
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains("foreign scope"));
+    assert!(transport.requests().is_empty());
+}
+
+#[test]
+fn every_operation_constructs_the_expected_provider_request() {
+    let transport = GithubRecordingTransport::with_repeating_response(json!({
+        "number": 203,
+        "title": "Forge connectors",
+        "body": "body",
+        "state": "open",
+        "html_url": "https://github.com/tesserine/runa/pull/12",
+        "sha": "abc123",
+        "merged": true
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let cases = [
+        (
+            Operation::ReadTicket,
+            json!({"reference": "203"}),
+            "GET",
+            "/repos/tesserine/runa/issues/203",
+        ),
+        (
+            Operation::CreateTicket,
+            json!({"title": "title", "body": "body"}),
+            "POST",
+            "/repos/tesserine/runa/issues",
+        ),
+        (
+            Operation::ClaimWorkUnit,
+            json!({"handle": handle(203)}),
+            "POST",
+            "/repos/tesserine/runa/issues/203/assignees",
+        ),
+        (
+            Operation::RecordProgress,
+            json!({"handle": handle(203), "body": "progress"}),
+            "POST",
+            "/repos/tesserine/runa/issues/203/comments",
+        ),
+        (
+            Operation::DeliverChangeProposal,
+            json!({"work_unit": handle(203), "branch": "issue-203", "commit": "abc123", "base": "main", "summary": "summary", "body": "body", "version": 1}),
+            "POST",
+            "/repos/tesserine/runa/pulls",
+        ),
+        (
+            Operation::ReflectDisposition,
+            json!({"work_unit": handle(203), "change": {"id": "github:tesserine/runa:pull:12:version:1", "display": "tesserine/runa#12"}, "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"}),
+            "POST",
+            "/repos/tesserine/runa/issues/12/comments",
+        ),
+        (
+            Operation::ApplyApprovedChange,
+            json!({"work_unit": handle(203), "change": {"id": "github:tesserine/runa:pull:12:version:1", "display": "tesserine/runa#12"}, "approved_version": 1, "approved_commit": "abc123", "base": "main"}),
+            "PUT",
+            "/repos/tesserine/runa/pulls/12/merge",
+        ),
+        (
+            Operation::CloseOut,
+            json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"}),
+            "PATCH",
+            "/repos/tesserine/runa/issues/203",
+        ),
+    ];
+
+    for (operation, input, _, _) in &cases {
+        connector.call(*operation, input.clone()).unwrap();
+    }
+
+    let requests = transport.requests();
+    assert_eq!(requests.len(), cases.len());
+    for (request, (_, _, method, path)) in requests.iter().zip(cases) {
+        assert_eq!(request.method, method);
+        assert_eq!(request.path, path);
+    }
+}
+
+#[test]
+fn production_http_transport_executes_and_parses_read_ticket() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 2048];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert!(request.starts_with("GET /repos/tesserine/runa/issues/203 "));
+        let body = r#"{"number":203,"title":"Harness title","body":"Harness body","state":"open"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let connector = GithubConnector::new(config(&format!("http://{address}")), GithubHttpTransport);
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert_eq!(output["title"], "Harness title");
+    assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
+    server.join().unwrap();
+}
+
+#[allow(dead_code)]
+fn _request_type_is_public(_: ProviderRequest) {}

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -61,6 +61,8 @@ fn github_error_server() -> (String, thread::JoinHandle<()>) {
         let mut request = [0_u8; 4096];
         let size = stream.read(&mut request).unwrap();
         assert!(size > 0, "expected an HTTP request");
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert_github_user_agent(&request);
         let body = r#"{"message":"provider rejected request"}"#;
         write!(
             stream,
@@ -71,6 +73,14 @@ fn github_error_server() -> (String, thread::JoinHandle<()>) {
         .unwrap();
     });
     (format!("http://{address}"), server)
+}
+
+fn assert_github_user_agent(request: &str) {
+    let request = request.to_ascii_lowercase();
+    assert!(
+        request.contains("\r\nuser-agent: runa-forge-github/"),
+        "missing runa GitHub User-Agent header: {request}"
+    );
 }
 
 #[test]
@@ -129,6 +139,7 @@ fn every_operation_constructs_the_expected_provider_request() {
         "state": "open",
         "html_url": "https://github.com/tesserine/runa/pull/12",
         "base": { "ref": "main" },
+        "head": { "sha": "abc123" },
         "sha": "abc123",
         "merged": true
     }));
@@ -278,6 +289,40 @@ fn apply_approved_change_rejects_base_mismatch_before_merge() {
 }
 
 #[test]
+fn deliver_change_proposal_rejects_created_pr_head_sha_mismatch() {
+    let transport = GithubRecordingTransport::with_response(json!({
+        "number": 12,
+        "head": { "sha": "different-commit" }
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let error = connector
+        .call(
+            Operation::DeliverChangeProposal,
+            json!({
+                "work_unit": handle(203),
+                "branch": "issue-203",
+                "commit": "requested-commit",
+                "base": "main",
+                "summary": "summary",
+                "body": "body",
+                "version": 1
+            }),
+        )
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("requested-commit")
+            && error.to_string().contains("different-commit"),
+        "head SHA mismatch should report requested and actual commits: {error}"
+    );
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(requests[0].path, "/repos/tesserine/runa/pulls");
+}
+
+#[test]
 fn every_operation_rejects_http_error_status_without_success_receipts() {
     for operation in Operation::ALL {
         let (api_base, server) = github_error_server();
@@ -307,6 +352,7 @@ fn production_http_transport_executes_and_parses_read_ticket() {
         let size = stream.read(&mut request).unwrap();
         let request = String::from_utf8_lossy(&request[..size]);
         assert!(request.starts_with("GET /repos/tesserine/runa/issues/203 "));
+        assert_github_user_agent(&request);
         let body = r#"{"number":203,"title":"Harness title","body":"Harness body","state":"open"}"#;
         write!(
             stream,
@@ -355,7 +401,7 @@ fn production_http_transport_executes_and_parses_every_operation() {
         (
             "POST",
             "/repos/tesserine/runa/pulls",
-            r#"{"number":12,"head":{"sha":"harness-pr-head"}}"#,
+            r#"{"number":12,"head":{"sha":"input-commit"}}"#,
         ),
         (
             "POST",
@@ -393,6 +439,7 @@ fn production_http_transport_executes_and_parses_every_operation() {
                 request.starts_with(&format!("{method} {path} ")),
                 "unexpected request: {request}"
             );
+            assert_github_user_agent(&request);
             if path.ends_with("/assignees") {
                 assert!(request.contains(r#""assignees":["pentaxis93"]"#));
             }
@@ -455,7 +502,7 @@ fn production_http_transport_executes_and_parses_every_operation() {
     assert_eq!(created["title"], "Harness create");
     assert_eq!(claimed["receipt"], "https://api.github.test/claim/203");
     assert_eq!(progress["receipt"], "https://github.test/progress/1");
-    assert_eq!(delivered["commit"], "harness-pr-head");
+    assert_eq!(delivered["commit"], "input-commit");
     assert_eq!(disposition["receipt"], "https://github.test/disposition/1");
     assert_eq!(applied["applied_commit"], "merged-sha");
     assert_eq!(closed["receipt"], "https://github.test/closed/203");
@@ -475,6 +522,7 @@ fn production_http_close_out_preserves_issue_body_and_records_note() {
         let size = stream.read(&mut request).unwrap();
         let request = String::from_utf8_lossy(&request[..size]);
         assert!(request.starts_with("POST /repos/tesserine/runa/issues/203/comments "));
+        assert_github_user_agent(&request);
         comments.push("closing note".to_string());
         let body = r#"{"html_url":"https://github.test/comments/1"}"#;
         write!(
@@ -490,6 +538,7 @@ fn production_http_close_out_preserves_issue_body_and_records_note() {
         let size = stream.read(&mut request).unwrap();
         let request = String::from_utf8_lossy(&request[..size]);
         assert!(request.starts_with("PATCH /repos/tesserine/runa/issues/203 "));
+        assert_github_user_agent(&request);
         let patch: serde_json::Value =
             serde_json::from_str(request.split("\r\n\r\n").nth(1).unwrap()).unwrap();
         assert_eq!(patch, json!({ "state": "closed" }));

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -80,72 +80,64 @@ fn every_operation_constructs_the_expected_provider_request() {
         "body": "body",
         "state": "open",
         "html_url": "https://github.com/tesserine/runa/pull/12",
+        "base": { "ref": "main" },
         "sha": "abc123",
         "merged": true
     }));
     let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
 
     let cases = [
-        (
-            Operation::ReadTicket,
-            json!({"reference": "203"}),
-            "GET",
-            "/repos/tesserine/runa/issues/203",
-        ),
+        (Operation::ReadTicket, json!({"reference": "203"})),
         (
             Operation::CreateTicket,
             json!({"title": "title", "body": "body"}),
-            "POST",
-            "/repos/tesserine/runa/issues",
         ),
-        (
-            Operation::ClaimWorkUnit,
-            json!({"handle": handle(203)}),
-            "POST",
-            "/repos/tesserine/runa/issues/203/assignees",
-        ),
+        (Operation::ClaimWorkUnit, json!({"handle": handle(203)})),
         (
             Operation::RecordProgress,
             json!({"handle": handle(203), "body": "progress"}),
-            "POST",
-            "/repos/tesserine/runa/issues/203/comments",
         ),
         (
             Operation::DeliverChangeProposal,
             json!({"work_unit": handle(203), "branch": "issue-203", "commit": "abc123", "base": "main", "summary": "summary", "body": "body", "version": 1}),
-            "POST",
-            "/repos/tesserine/runa/pulls",
         ),
         (
             Operation::ReflectDisposition,
             json!({"work_unit": handle(203), "change": {"id": "github:tesserine/runa:pull:12:version:1", "display": "tesserine/runa#12"}, "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"}),
-            "POST",
-            "/repos/tesserine/runa/issues/12/comments",
         ),
         (
             Operation::ApplyApprovedChange,
             json!({"work_unit": handle(203), "change": {"id": "github:tesserine/runa:pull:12:version:1", "display": "tesserine/runa#12"}, "approved_version": 1, "approved_commit": "abc123", "base": "main"}),
-            "PUT",
-            "/repos/tesserine/runa/pulls/12/merge",
         ),
         (
             Operation::CloseOut,
             json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"}),
-            "PATCH",
-            "/repos/tesserine/runa/issues/203",
         ),
     ];
 
-    for (operation, input, _, _) in &cases {
+    for (operation, input) in &cases {
         connector.call(*operation, input.clone()).unwrap();
     }
 
+    let expected_requests = [
+        ("GET", "/repos/tesserine/runa/issues/203"),
+        ("POST", "/repos/tesserine/runa/issues"),
+        ("POST", "/repos/tesserine/runa/issues/203/assignees"),
+        ("POST", "/repos/tesserine/runa/issues/203/comments"),
+        ("POST", "/repos/tesserine/runa/pulls"),
+        ("POST", "/repos/tesserine/runa/issues/12/comments"),
+        ("GET", "/repos/tesserine/runa/pulls/12"),
+        ("PUT", "/repos/tesserine/runa/pulls/12/merge"),
+        ("POST", "/repos/tesserine/runa/issues/203/comments"),
+        ("PATCH", "/repos/tesserine/runa/issues/203"),
+    ];
     let requests = transport.requests();
-    assert_eq!(requests.len(), cases.len());
-    for (request, (_, _, method, path)) in requests.iter().zip(cases) {
+    assert_eq!(requests.len(), expected_requests.len());
+    for (request, (method, path)) in requests.iter().zip(expected_requests) {
         assert_eq!(request.method, method);
         assert_eq!(request.path, path);
     }
+    assert_eq!(requests[9].body, Some(json!({ "state": "closed" })));
 }
 
 #[test]
@@ -165,6 +157,76 @@ fn claim_work_unit_sends_assignee_payload() {
         requests[0].body,
         Some(json!({ "assignees": ["pentaxis93"] }))
     );
+}
+
+#[test]
+fn close_out_posts_note_then_closes_issue_without_overwriting_body() {
+    let transport = GithubRecordingTransport::with_repeating_response(json!({
+        "html_url": "https://github.test/closed/203"
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    connector
+        .call(
+            Operation::CloseOut,
+            json!({
+                "work_unit": handle(203),
+                "completion": {
+                    "criterion_summary": "done",
+                    "gaps": [],
+                    "change_reference": "abc123",
+                    "documentation_status": "updated"
+                },
+                "body": "closing note"
+            }),
+        )
+        .unwrap();
+
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(
+        requests[0].path,
+        "/repos/tesserine/runa/issues/203/comments"
+    );
+    assert_eq!(requests[0].body, Some(json!({ "body": "closing note" })));
+    assert_eq!(requests[1].method, "PATCH");
+    assert_eq!(requests[1].path, "/repos/tesserine/runa/issues/203");
+    assert_eq!(requests[1].body, Some(json!({ "state": "closed" })));
+}
+
+#[test]
+fn apply_approved_change_rejects_base_mismatch_before_merge() {
+    let transport = GithubRecordingTransport::with_response(json!({
+        "base": { "ref": "develop" },
+        "head": { "sha": "abc123" }
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let error = connector
+        .call(
+            Operation::ApplyApprovedChange,
+            json!({
+                "work_unit": handle(203),
+                "change": {
+                    "id": "github:tesserine/runa:pull:12:version:1",
+                    "display": "tesserine/runa#12"
+                },
+                "approved_version": 1,
+                "approved_commit": "abc123",
+                "base": "main"
+            }),
+        )
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("base") && error.to_string().contains("main"),
+        "base mismatch should be reported: {error}"
+    );
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].path, "/repos/tesserine/runa/pulls/12");
 }
 
 #[test]
@@ -233,9 +295,19 @@ fn production_http_transport_executes_and_parses_every_operation() {
             r#"{"html_url":"https://github.test/disposition/1"}"#,
         ),
         (
+            "GET",
+            "/repos/tesserine/runa/pulls/12",
+            r#"{"base":{"ref":"main"},"head":{"sha":"input-approved"}}"#,
+        ),
+        (
             "PUT",
             "/repos/tesserine/runa/pulls/12/merge",
             r#"{"sha":"merged-sha"}"#,
+        ),
+        (
+            "POST",
+            "/repos/tesserine/runa/issues/203/comments",
+            r#"{"html_url":"https://github.test/close-comment/1"}"#,
         ),
         (
             "PATCH",
@@ -319,6 +391,77 @@ fn production_http_transport_executes_and_parses_every_operation() {
     assert_eq!(disposition["receipt"], "https://github.test/disposition/1");
     assert_eq!(applied["applied_commit"], "merged-sha");
     assert_eq!(closed["receipt"], "https://github.test/closed/203");
+    server.join().unwrap();
+}
+
+#[test]
+fn production_http_close_out_preserves_issue_body_and_records_note() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let mut issue_body = "Original problem statement\n\nAcceptance criteria".to_string();
+        let mut comments = Vec::new();
+
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert!(request.starts_with("POST /repos/tesserine/runa/issues/203/comments "));
+        comments.push("closing note".to_string());
+        let body = r#"{"html_url":"https://github.test/comments/1"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert!(request.starts_with("PATCH /repos/tesserine/runa/issues/203 "));
+        let patch: serde_json::Value =
+            serde_json::from_str(request.split("\r\n\r\n").nth(1).unwrap()).unwrap();
+        assert_eq!(patch, json!({ "state": "closed" }));
+        if let Some(new_body) = patch.get("body").and_then(serde_json::Value::as_str) {
+            issue_body = new_body.to_string();
+        }
+        let body = r#"{"html_url":"https://github.test/closed/203"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+
+        assert_eq!(comments, vec!["closing note"]);
+        assert_eq!(
+            issue_body,
+            "Original problem statement\n\nAcceptance criteria"
+        );
+    });
+
+    let connector = GithubConnector::new(config(&format!("http://{address}")), GithubHttpTransport);
+    let output = connector
+        .call(
+            Operation::CloseOut,
+            json!({
+                "work_unit": handle(203),
+                "completion": {
+                    "criterion_summary": "done",
+                    "gaps": [],
+                    "change_reference": "abc123",
+                    "documentation_status": "updated"
+                },
+                "body": "closing note"
+            }),
+        )
+        .unwrap();
+
+    assert_eq!(output["receipt"], "https://github.test/closed/203");
     server.join().unwrap();
 }
 

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -12,6 +12,7 @@ fn config(api_base: &str) -> GithubConfig {
         owner: "tesserine".to_string(),
         repo: "runa".to_string(),
         api_base: api_base.to_string(),
+        assignee: Some("pentaxis93".to_string()),
         credential_env: None,
         credential_command: None,
     }
@@ -148,6 +149,25 @@ fn every_operation_constructs_the_expected_provider_request() {
 }
 
 #[test]
+fn claim_work_unit_sends_assignee_payload() {
+    let transport = GithubRecordingTransport::with_repeating_response(json!({
+        "url": "https://api.github.test/repos/tesserine/runa/issues/203"
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    connector
+        .call(Operation::ClaimWorkUnit, json!({"handle": handle(203)}))
+        .unwrap();
+
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].body,
+        Some(json!({ "assignees": ["pentaxis93"] }))
+    );
+}
+
+#[test]
 fn production_http_transport_executes_and_parses_read_ticket() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
@@ -174,6 +194,131 @@ fn production_http_transport_executes_and_parses_read_ticket() {
 
     assert_eq!(output["title"], "Harness title");
     assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
+    server.join().unwrap();
+}
+
+#[test]
+fn production_http_transport_executes_and_parses_every_operation() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let expected = [
+        (
+            "GET",
+            "/repos/tesserine/runa/issues/203",
+            r#"{"number":203,"title":"Harness read","body":"Harness body","state":"open"}"#,
+        ),
+        (
+            "POST",
+            "/repos/tesserine/runa/issues",
+            r#"{"number":204,"title":"Harness create","body":"Created body","state":"open"}"#,
+        ),
+        (
+            "POST",
+            "/repos/tesserine/runa/issues/203/assignees",
+            r#"{"url":"https://api.github.test/claim/203"}"#,
+        ),
+        (
+            "POST",
+            "/repos/tesserine/runa/issues/203/comments",
+            r#"{"html_url":"https://github.test/progress/1"}"#,
+        ),
+        (
+            "POST",
+            "/repos/tesserine/runa/pulls",
+            r#"{"number":12,"head":{"sha":"harness-pr-head"}}"#,
+        ),
+        (
+            "POST",
+            "/repos/tesserine/runa/issues/12/comments",
+            r#"{"html_url":"https://github.test/disposition/1"}"#,
+        ),
+        (
+            "PUT",
+            "/repos/tesserine/runa/pulls/12/merge",
+            r#"{"sha":"merged-sha"}"#,
+        ),
+        (
+            "PATCH",
+            "/repos/tesserine/runa/issues/203",
+            r#"{"html_url":"https://github.test/closed/203"}"#,
+        ),
+    ];
+    let server = thread::spawn(move || {
+        for (method, path, body) in expected {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
+            assert!(
+                request.starts_with(&format!("{method} {path} ")),
+                "unexpected request: {request}"
+            );
+            if path.ends_with("/assignees") {
+                assert!(request.contains(r#""assignees":["pentaxis93"]"#));
+            }
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
+    });
+
+    let connector = GithubConnector::new(config(&format!("http://{address}")), GithubHttpTransport);
+    let read = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+    let created = connector
+        .call(
+            Operation::CreateTicket,
+            json!({"title": "title", "body": "body"}),
+        )
+        .unwrap();
+    let claimed = connector
+        .call(Operation::ClaimWorkUnit, json!({"handle": handle(203)}))
+        .unwrap();
+    let progress = connector
+        .call(
+            Operation::RecordProgress,
+            json!({"handle": handle(203), "body": "progress"}),
+        )
+        .unwrap();
+    let delivered = connector
+        .call(
+            Operation::DeliverChangeProposal,
+            json!({"work_unit": handle(203), "branch": "issue-203", "commit": "input-commit", "base": "main", "summary": "summary", "body": "body", "version": 1}),
+        )
+        .unwrap();
+    let disposition = connector
+        .call(
+            Operation::ReflectDisposition,
+            json!({"work_unit": handle(203), "change": {"id": "github:tesserine/runa:pull:12:version:1", "display": "tesserine/runa#12"}, "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"}),
+        )
+        .unwrap();
+    let applied = connector
+        .call(
+            Operation::ApplyApprovedChange,
+            json!({"work_unit": handle(203), "change": {"id": "github:tesserine/runa:pull:12:version:1", "display": "tesserine/runa#12"}, "approved_version": 1, "approved_commit": "input-approved", "base": "main"}),
+        )
+        .unwrap();
+    let closed = connector
+        .call(
+            Operation::CloseOut,
+            json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"}),
+        )
+        .unwrap();
+
+    assert_eq!(read["title"], "Harness read");
+    assert_eq!(created["handle"]["id"], "github:tesserine/runa:issue:204");
+    assert_eq!(created["title"], "Harness create");
+    assert_eq!(claimed["receipt"], "https://api.github.test/claim/203");
+    assert_eq!(progress["receipt"], "https://github.test/progress/1");
+    assert_eq!(delivered["commit"], "harness-pr-head");
+    assert_eq!(disposition["receipt"], "https://github.test/disposition/1");
+    assert_eq!(applied["applied_commit"], "merged-sha");
+    assert_eq!(closed["receipt"], "https://github.test/closed/203");
     server.join().unwrap();
 }
 

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -2,7 +2,7 @@ use runa_forge_contract::Operation;
 use runa_forge_github::{
     GithubConfig, GithubConnector, GithubHttpTransport, GithubRecordingTransport, ProviderRequest,
 };
-use serde_json::json;
+use serde_json::{Value, json};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::thread;
@@ -23,6 +23,54 @@ fn handle(number: u64) -> serde_json::Value {
         "id": format!("github:tesserine/runa:issue:{number}"),
         "display": format!("tesserine/runa#{number}")
     })
+}
+
+fn change() -> serde_json::Value {
+    json!({
+        "id": "github:tesserine/runa:pull:12:version:1",
+        "display": "tesserine/runa#12"
+    })
+}
+
+fn input_for_operation(operation: Operation) -> Value {
+    match operation {
+        Operation::ReadTicket => json!({"reference": "203"}),
+        Operation::CreateTicket => json!({"title": "title", "body": "body"}),
+        Operation::ClaimWorkUnit => json!({"handle": handle(203)}),
+        Operation::RecordProgress => json!({"handle": handle(203), "body": "progress"}),
+        Operation::DeliverChangeProposal => {
+            json!({"work_unit": handle(203), "branch": "issue-203", "commit": "abc123", "base": "main", "summary": "summary", "body": "body", "version": 1})
+        }
+        Operation::ReflectDisposition => {
+            json!({"work_unit": handle(203), "change": change(), "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"})
+        }
+        Operation::ApplyApprovedChange => {
+            json!({"work_unit": handle(203), "change": change(), "approved_version": 1, "approved_commit": "abc123", "base": "main"})
+        }
+        Operation::CloseOut => {
+            json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"})
+        }
+    }
+}
+
+fn github_error_server() -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        assert!(size > 0, "expected an HTTP request");
+        let body = r#"{"message":"provider rejected request"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 500 Internal Server Error\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}"), server)
 }
 
 #[test]
@@ -227,6 +275,26 @@ fn apply_approved_change_rejects_base_mismatch_before_merge() {
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].method, "GET");
     assert_eq!(requests[0].path, "/repos/tesserine/runa/pulls/12");
+}
+
+#[test]
+fn every_operation_rejects_http_error_status_without_success_receipts() {
+    for operation in Operation::ALL {
+        let (api_base, server) = github_error_server();
+        let connector = GithubConnector::new(config(&api_base), GithubHttpTransport);
+
+        let result = connector.call(operation, input_for_operation(operation));
+
+        assert!(
+            result.is_err(),
+            "{operation} should reject GitHub HTTP errors, got {result:?}"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("500"),
+            "{operation} error should report the HTTP status"
+        );
+        server.join().unwrap();
+    }
 }
 
 #[test]

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -289,6 +289,41 @@ fn apply_approved_change_rejects_base_mismatch_before_merge() {
 }
 
 #[test]
+fn apply_approved_change_rejects_head_mismatch_before_merge() {
+    let transport = GithubRecordingTransport::with_response(json!({
+        "base": { "ref": "main" },
+        "head": { "sha": "delivered-commit" }
+    }));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let error = connector
+        .call(
+            Operation::ApplyApprovedChange,
+            json!({
+                "work_unit": handle(203),
+                "change": {
+                    "id": "github:tesserine/runa:pull:12:version:1",
+                    "display": "tesserine/runa#12"
+                },
+                "approved_version": 1,
+                "approved_commit": "different-commit",
+                "base": "main"
+            }),
+        )
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("different-commit")
+            && error.to_string().contains("delivered-commit"),
+        "head mismatch should report requested and actual commits: {error}"
+    );
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].path, "/repos/tesserine/runa/pulls/12");
+}
+
+#[test]
 fn deliver_change_proposal_rejects_created_pr_head_sha_mismatch() {
     let transport = GithubRecordingTransport::with_response(json!({
         "number": 12,

--- a/runa-forge-sourcehut/Cargo.toml
+++ b/runa-forge-sourcehut/Cargo.toml
@@ -11,4 +11,5 @@ serde_json.workspace = true
 reqwest.workspace = true
 
 [dev-dependencies]
+apollo-compiler.workspace = true
 tempfile.workspace = true

--- a/runa-forge-sourcehut/Cargo.toml
+++ b/runa-forge-sourcehut/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runa-forge-sourcehut"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+runa-forge-contract.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true

--- a/runa-forge-sourcehut/Cargo.toml
+++ b/runa-forge-sourcehut/Cargo.toml
@@ -9,3 +9,6 @@ runa-forge-contract.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -231,26 +231,29 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         let number = self.resolve_reference(reference)?;
         let response = self.graphql(
             "ticket",
-            "query ticket($id: Int!) { ticket(id: $id) { id subject description status } }",
+            "query ticket($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { ticket(id: $id) { id subject body status } } }",
             json!({ "id": number, "tracker": self.config.tracker_id }),
         )?;
         self.ticket_snapshot(
             number,
-            response.pointer("/data/ticket").unwrap_or(&response),
+            response
+                .pointer("/data/tracker/ticket")
+                .unwrap_or(&response),
         )
     }
 
     fn create_ticket(&self, input: Value) -> Result<Value, ForgeError> {
         let title = required_string(&input, "title")?;
         let body = required_string(&input, "body")?;
+        let tracker_id = self.tracker_id_number()?;
         let response = self.graphql(
-            "createTicket",
-            "mutation createTicket($subject: String!, $description: String!) { createTicket(subject: $subject, description: $description) { id subject description status } }",
-            json!({ "subject": title, "description": body, "tracker": self.config.tracker_id }),
+            "submitTicket",
+            "mutation submitTicket($trackerId: Int!, $input: SubmitTicketInput!) { submitTicket(trackerId: $trackerId, input: $input) { id subject body status } }",
+            json!({ "trackerId": tracker_id, "input": { "subject": title, "body": body } }),
         )?;
         let ticket = response
-            .pointer("/data/createTicket")
-            .or_else(|| response.pointer("/data/ticket"))
+            .pointer("/data/submitTicket")
+            .or_else(|| response.pointer("/data/tracker/ticket"))
             .unwrap_or(&response);
         let number = ticket.get("id").and_then(Value::as_u64).unwrap_or(0);
         self.ticket_snapshot(number, ticket)
@@ -258,10 +261,11 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
 
     fn claim_work_unit(&self, input: Value) -> Result<Value, ForgeError> {
         let number = self.ticket_number(input.get("handle"))?;
+        let tracker_id = self.tracker_id_number()?;
         let response = self.graphql(
-            "claimWorkUnit",
-            "mutation claimWorkUnit($id: Int!) { updateTicket(id: $id) { id } }",
-            json!({ "id": number }),
+            "updateTicketStatus",
+            "mutation claimWorkUnit($trackerId: Int!, $ticketId: Int!, $input: UpdateStatusInput!) { updateTicketStatus(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
+            json!({ "trackerId": tracker_id, "ticketId": number, "input": { "status": "IN_PROGRESS" } }),
         )?;
         Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "claimed") }))
     }
@@ -269,10 +273,11 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
     fn record_progress(&self, input: Value) -> Result<Value, ForgeError> {
         let number = self.ticket_number(input.get("handle"))?;
         let body = required_string(&input, "body")?;
+        let tracker_id = self.tracker_id_number()?;
         let response = self.graphql(
-            "recordProgress",
-            "mutation recordProgress($id: Int!, $body: String!) { createComment(id: $id, body: $body) { id } }",
-            json!({ "id": number, "body": body }),
+            "submitComment",
+            "mutation submitComment($trackerId: Int!, $ticketId: Int!, $input: SubmitCommentInput!) { submitComment(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
+            json!({ "trackerId": tracker_id, "ticketId": number, "input": { "text": body } }),
         )?;
         Ok(
             json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "progress") }),
@@ -312,10 +317,11 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         let number = self.ticket_number(Some(work_unit))?;
         self.change_id(input.get("change"))?;
         let body = required_string(&input, "body")?;
+        let tracker_id = self.tracker_id_number()?;
         let response = self.graphql(
-            "reflectDisposition",
-            "mutation reflectDisposition($id: Int!, $body: String!) { createComment(id: $id, body: $body) { id } }",
-            json!({ "id": number, "body": body }),
+            "submitComment",
+            "mutation submitComment($trackerId: Int!, $ticketId: Int!, $input: SubmitCommentInput!) { submitComment(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
+            json!({ "trackerId": tracker_id, "ticketId": number, "input": { "text": body } }),
         )?;
         Ok(json!({
             "work_unit": work_unit,
@@ -357,10 +363,19 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
         let number = self.ticket_number(Some(work_unit))?;
         let body = required_string(&input, "body")?;
+        let tracker_id = self.tracker_id_number()?;
         let response = self.graphql(
-            "closeOut",
-            "mutation closeOut($id: Int!, $body: String!) { closeTicket(id: $id, body: $body) { id } }",
-            json!({ "id": number, "body": body }),
+            "submitComment",
+            "mutation submitComment($trackerId: Int!, $ticketId: Int!, $input: SubmitCommentInput!) { submitComment(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
+            json!({
+                "trackerId": tracker_id,
+                "ticketId": number,
+                "input": {
+                    "text": body,
+                    "status": "RESOLVED",
+                    "resolution": "IMPLEMENTED"
+                }
+            }),
         )?;
         Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "closed") }))
     }
@@ -377,9 +392,22 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         Ok(json!({
             "handle": self.ticket_handle(number),
             "title": ticket.get("subject").and_then(Value::as_str).unwrap_or(""),
-            "body": ticket.get("description").cloned().unwrap_or(Value::Null),
+            "body": ticket
+                .get("body")
+                .or_else(|| ticket.get("description"))
+                .cloned()
+                .unwrap_or(Value::Null),
             "state": ticket.get("status").and_then(Value::as_str).unwrap_or("unknown")
         }))
+    }
+
+    fn tracker_id_number(&self) -> Result<u64, ForgeError> {
+        parse_number(&self.config.tracker_id).map_err(|_| {
+            ForgeError::InvalidInput(format!(
+                "sourcehut tracker_id '{}' must be a positive integer",
+                self.config.tracker_id
+            ))
+        })
     }
 
     fn resolve_reference(&self, reference: &str) -> Result<u64, ForgeError> {

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -1,0 +1,459 @@
+use runa_forge_contract::{ForgeConnector, ForgeError, Handle, Operation};
+use serde_json::{Value, json};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourcehutConfig {
+    pub tracker_id: String,
+    pub api_base: String,
+    pub git_remote: String,
+    pub credential_env: Option<String>,
+    pub credential_command: Option<Vec<String>>,
+}
+
+impl SourcehutConfig {
+    fn credential(&self) -> Result<Option<String>, ForgeError> {
+        if let Some(name) = self
+            .credential_env
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            && let Ok(value) = std::env::var(name)
+            && !value.is_empty()
+        {
+            return Ok(Some(value));
+        }
+
+        let Some(command) = self
+            .credential_command
+            .as_ref()
+            .filter(|command| !command.is_empty())
+        else {
+            return Ok(None);
+        };
+        let Some((program, args)) = command.split_first() else {
+            return Ok(None);
+        };
+        let output = std::process::Command::new(program)
+            .args(args)
+            .output()
+            .map_err(|error| {
+                ForgeError::Transport(format!("credential command failed: {error}"))
+            })?;
+        if !output.status.success() {
+            return Err(ForgeError::Transport(format!(
+                "credential command exited with status {}",
+                output.status
+            )));
+        }
+        let token = String::from_utf8(output.stdout)
+            .map_err(|_| {
+                ForgeError::Transport("credential command produced non-UTF-8 output".to_string())
+            })?
+            .trim()
+            .to_string();
+        Ok((!token.is_empty()).then_some(token))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderRequest {
+    pub kind: String,
+    pub operation: String,
+    pub path: String,
+    pub body: Option<Value>,
+}
+
+pub trait SourcehutTransport: Clone + Send + Sync + 'static {
+    fn send(&self, config: &SourcehutConfig, request: ProviderRequest)
+    -> Result<Value, ForgeError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SourcehutRecordingTransport {
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+    responses: Arc<Mutex<VecDeque<Value>>>,
+    repeating: Arc<Mutex<Option<Value>>>,
+}
+
+impl SourcehutRecordingTransport {
+    pub fn with_repeating_response(response: Value) -> Self {
+        let transport = Self::default();
+        *transport.repeating.lock().unwrap() = Some(response);
+        transport
+    }
+
+    pub fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl SourcehutTransport for SourcehutRecordingTransport {
+    fn send(
+        &self,
+        _config: &SourcehutConfig,
+        request: ProviderRequest,
+    ) -> Result<Value, ForgeError> {
+        self.requests.lock().unwrap().push(request);
+        if let Some(response) = self.responses.lock().unwrap().pop_front() {
+            return Ok(response);
+        }
+        if let Some(response) = self.repeating.lock().unwrap().clone() {
+            return Ok(response);
+        }
+        Ok(json!({}))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SourcehutHttpTransport;
+
+impl SourcehutTransport for SourcehutHttpTransport {
+    fn send(
+        &self,
+        config: &SourcehutConfig,
+        request: ProviderRequest,
+    ) -> Result<Value, ForgeError> {
+        if request.kind != "GRAPHQL" {
+            return Err(ForgeError::Unsupported(format!(
+                "production HTTP transport cannot execute {}",
+                request.kind
+            )));
+        }
+        let client = reqwest::blocking::Client::new();
+        let mut builder = client.post(&config.api_base);
+        if let Some(token) = config.credential()? {
+            builder = builder.bearer_auth(token);
+        }
+        let response = builder
+            .json(&request.body.unwrap_or_else(|| json!({})))
+            .send()
+            .map_err(|error| ForgeError::Transport(error.to_string()))?;
+        let status = response.status();
+        let value = response
+            .json::<Value>()
+            .map_err(|error| ForgeError::ProviderResponse(error.to_string()))?;
+        if !status.is_success() {
+            return Err(ForgeError::Transport(format!(
+                "SourceHut returned {status}"
+            )));
+        }
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SourcehutConnector<T> {
+    config: SourcehutConfig,
+    transport: T,
+}
+
+impl<T: SourcehutTransport> SourcehutConnector<T> {
+    pub fn new(config: SourcehutConfig, transport: T) -> Self {
+        Self { config, transport }
+    }
+
+    pub fn call(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
+        <Self as ForgeConnector>::call(self, operation, input)
+    }
+
+    fn ticket_handle(&self, number: u64) -> Handle {
+        Handle {
+            id: format!(
+                "sourcehut:tracker:{}:ticket:{number}",
+                self.config.tracker_id
+            ),
+            display: format!("sourcehut:{}#{number}", self.config.tracker_id),
+        }
+    }
+
+    fn change_handle(&self, branch: &str, version: u64) -> Handle {
+        Handle {
+            id: format!(
+                "sourcehut:tracker:{}:change:{branch}:version:{version}",
+                self.config.tracker_id
+            ),
+            display: branch.to_string(),
+        }
+    }
+
+    fn graphql(&self, operation: &str, query: &str, variables: Value) -> Result<Value, ForgeError> {
+        self.transport.send(
+            &self.config,
+            ProviderRequest {
+                kind: "GRAPHQL".to_string(),
+                operation: operation.to_string(),
+                path: "/query".to_string(),
+                body: Some(json!({ "query": query, "variables": variables })),
+            },
+        )
+    }
+
+    fn git(&self, operation: &str, body: Value) -> Result<Value, ForgeError> {
+        self.transport.send(
+            &self.config,
+            ProviderRequest {
+                kind: "GIT".to_string(),
+                operation: operation.to_string(),
+                path: self.config.git_remote.clone(),
+                body: Some(body),
+            },
+        )
+    }
+}
+
+impl<T: SourcehutTransport> ForgeConnector for SourcehutConnector<T> {
+    fn set_name(&self) -> &str {
+        "sourcehut"
+    }
+
+    fn call(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
+        match operation {
+            Operation::ReadTicket => self.read_ticket(input),
+            Operation::CreateTicket => self.create_ticket(input),
+            Operation::ClaimWorkUnit => self.claim_work_unit(input),
+            Operation::RecordProgress => self.record_progress(input),
+            Operation::DeliverChangeProposal => self.deliver_change_proposal(input),
+            Operation::ReflectDisposition => self.reflect_disposition(input),
+            Operation::ApplyApprovedChange => self.apply_approved_change(input),
+            Operation::CloseOut => self.close_out(input),
+        }
+    }
+}
+
+impl<T: SourcehutTransport> SourcehutConnector<T> {
+    fn read_ticket(&self, input: Value) -> Result<Value, ForgeError> {
+        let reference = required_string(&input, "reference")?;
+        let number = self.resolve_reference(reference)?;
+        let response = self.graphql(
+            "ticket",
+            "query ticket($id: Int!) { ticket(id: $id) { id subject description status } }",
+            json!({ "id": number, "tracker": self.config.tracker_id }),
+        )?;
+        self.ticket_snapshot(
+            number,
+            response.pointer("/data/ticket").unwrap_or(&response),
+        )
+    }
+
+    fn create_ticket(&self, input: Value) -> Result<Value, ForgeError> {
+        let title = required_string(&input, "title")?;
+        let body = required_string(&input, "body")?;
+        let response = self.graphql(
+            "createTicket",
+            "mutation createTicket($subject: String!, $description: String!) { createTicket(subject: $subject, description: $description) { id subject description status } }",
+            json!({ "subject": title, "description": body, "tracker": self.config.tracker_id }),
+        )?;
+        let ticket = response
+            .pointer("/data/createTicket")
+            .or_else(|| response.pointer("/data/ticket"))
+            .unwrap_or(&response);
+        let number = ticket.get("id").and_then(Value::as_u64).unwrap_or(0);
+        self.ticket_snapshot(number, ticket)
+    }
+
+    fn claim_work_unit(&self, input: Value) -> Result<Value, ForgeError> {
+        let number = self.ticket_number(input.get("handle"))?;
+        let response = self.graphql(
+            "claimWorkUnit",
+            "mutation claimWorkUnit($id: Int!) { updateTicket(id: $id) { id } }",
+            json!({ "id": number }),
+        )?;
+        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "claimed") }))
+    }
+
+    fn record_progress(&self, input: Value) -> Result<Value, ForgeError> {
+        let number = self.ticket_number(input.get("handle"))?;
+        let body = required_string(&input, "body")?;
+        let response = self.graphql(
+            "recordProgress",
+            "mutation recordProgress($id: Int!, $body: String!) { createComment(id: $id, body: $body) { id } }",
+            json!({ "id": number, "body": body }),
+        )?;
+        Ok(
+            json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "progress") }),
+        )
+    }
+
+    fn deliver_change_proposal(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        self.ticket_number(Some(work_unit))?;
+        let branch = required_string(&input, "branch")?;
+        let commit = required_string(&input, "commit")?;
+        let version = required_u64(&input, "version")?;
+        let _ = self.git(
+            "deliverChangeProposal",
+            json!({ "remote": self.config.git_remote, "branch": branch, "commit": commit }),
+        )?;
+        Ok(json!({
+            "handle": self.change_handle(branch, version),
+            "work_unit": work_unit,
+            "commit": commit,
+            "version": version
+        }))
+    }
+
+    fn reflect_disposition(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        let number = self.ticket_number(Some(work_unit))?;
+        self.change_id(input.get("change"))?;
+        let body = required_string(&input, "body")?;
+        let response = self.graphql(
+            "reflectDisposition",
+            "mutation reflectDisposition($id: Int!, $body: String!) { createComment(id: $id, body: $body) { id } }",
+            json!({ "id": number, "body": body }),
+        )?;
+        Ok(json!({
+            "work_unit": work_unit,
+            "change": input.get("change").cloned().unwrap_or(Value::Null),
+            "receipt": receipt(response, "disposition")
+        }))
+    }
+
+    fn apply_approved_change(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        self.ticket_number(Some(work_unit))?;
+        let change = self.change_id(input.get("change"))?;
+        let approved_commit = required_string(&input, "approved_commit")?;
+        let _ = self.git(
+            "applyApprovedChange",
+            json!({ "remote": self.config.git_remote, "change": change, "commit": approved_commit }),
+        )?;
+        Ok(json!({
+            "work_unit": work_unit,
+            "change": input.get("change").cloned().unwrap_or(Value::Null),
+            "applied_commit": approved_commit,
+            "receipt": "applied"
+        }))
+    }
+
+    fn close_out(&self, input: Value) -> Result<Value, ForgeError> {
+        let work_unit = input
+            .get("work_unit")
+            .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
+        let number = self.ticket_number(Some(work_unit))?;
+        let body = required_string(&input, "body")?;
+        let response = self.graphql(
+            "closeOut",
+            "mutation closeOut($id: Int!, $body: String!) { closeTicket(id: $id, body: $body) { id } }",
+            json!({ "id": number, "body": body }),
+        )?;
+        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "closed") }))
+    }
+
+    fn ticket_snapshot(&self, number: u64, ticket: &Value) -> Result<Value, ForgeError> {
+        let number = if number == 0 {
+            ticket
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| ForgeError::ProviderResponse("missing ticket id".into()))?
+        } else {
+            number
+        };
+        Ok(json!({
+            "handle": self.ticket_handle(number),
+            "title": ticket.get("subject").and_then(Value::as_str).unwrap_or(""),
+            "body": ticket.get("description").cloned().unwrap_or(Value::Null),
+            "state": ticket.get("status").and_then(Value::as_str).unwrap_or("unknown")
+        }))
+    }
+
+    fn resolve_reference(&self, reference: &str) -> Result<u64, ForgeError> {
+        let reference = reference.trim();
+        if let Some(rest) = reference.strip_prefix("sourcehut:") {
+            let (tracker, number) = rest.split_once('#').ok_or_else(|| {
+                ForgeError::InvalidInput(format!("invalid SourceHut reference {reference}"))
+            })?;
+            if tracker != self.config.tracker_id {
+                return Err(ForgeError::ForeignScope(format!(
+                    "{tracker} does not match {}",
+                    self.config.tracker_id
+                )));
+            }
+            return parse_number(number);
+        }
+        parse_number(reference.strip_prefix('#').unwrap_or(reference))
+    }
+
+    fn ticket_number(&self, value: Option<&Value>) -> Result<u64, ForgeError> {
+        let handle = handle_id(value)?;
+        let prefix = format!("sourcehut:tracker:{}:ticket:", self.config.tracker_id);
+        if let Some(number) = handle.strip_prefix(&prefix) {
+            return parse_number(number);
+        }
+        if handle.starts_with("sourcehut:tracker:") {
+            return Err(ForgeError::ForeignScope(format!(
+                "{handle} does not match tracker {}",
+                self.config.tracker_id
+            )));
+        }
+        Err(ForgeError::InvalidInput(format!(
+            "handle '{handle}' is not a SourceHut ticket handle"
+        )))
+    }
+
+    fn change_id<'a>(&self, value: Option<&'a Value>) -> Result<&'a str, ForgeError> {
+        let handle = handle_id(value)?;
+        let prefix = format!("sourcehut:tracker:{}:change:", self.config.tracker_id);
+        if let Some(change) = handle.strip_prefix(&prefix) {
+            return Ok(change);
+        }
+        if handle.starts_with("sourcehut:tracker:") {
+            return Err(ForgeError::ForeignScope(format!(
+                "{handle} does not match tracker {}",
+                self.config.tracker_id
+            )));
+        }
+        Err(ForgeError::InvalidInput(format!(
+            "handle '{handle}' is not a SourceHut change handle"
+        )))
+    }
+}
+
+fn required_string<'a>(input: &'a Value, field: &str) -> Result<&'a str, ForgeError> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput(format!("{field} is required")))
+}
+
+fn required_u64(input: &Value, field: &str) -> Result<u64, ForgeError> {
+    input
+        .get(field)
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .ok_or_else(|| ForgeError::InvalidInput(format!("{field} is required")))
+}
+
+fn handle_id(value: Option<&Value>) -> Result<&str, ForgeError> {
+    value
+        .and_then(|value| value.get("id"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput("handle.id is required".into()))
+}
+
+fn parse_number(value: &str) -> Result<u64, ForgeError> {
+    value
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|number| *number > 0)
+        .ok_or_else(|| ForgeError::InvalidInput(format!("invalid ticket number '{value}'")))
+}
+
+fn receipt(response: Value, fallback: &str) -> String {
+    response
+        .pointer("/data/id")
+        .or_else(|| response.get("id"))
+        .and_then(Value::as_u64)
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| fallback.to_string())
+}

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -134,14 +134,15 @@ impl SourcehutTransport for SourcehutHttpTransport {
             .send()
             .map_err(|error| ForgeError::Transport(error.to_string()))?;
         let status = response.status();
-        let value = response
-            .json::<Value>()
-            .map_err(|error| ForgeError::ProviderResponse(error.to_string()))?;
         if !status.is_success() {
             return Err(ForgeError::Transport(format!(
                 "SourceHut returned {status}"
             )));
         }
+        let value = response
+            .json::<Value>()
+            .map_err(|error| ForgeError::ProviderResponse(error.to_string()))?;
+        reject_provider_error_payload(&value)?;
         Ok(value)
     }
 }
@@ -182,7 +183,7 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
     }
 
     fn graphql(&self, operation: &str, query: &str, variables: Value) -> Result<Value, ForgeError> {
-        self.transport.send(
+        let response = self.transport.send(
             &self.config,
             ProviderRequest {
                 kind: "GRAPHQL".to_string(),
@@ -190,11 +191,13 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
                 path: "/query".to_string(),
                 body: Some(json!({ "query": query, "variables": variables })),
             },
-        )
+        )?;
+        reject_provider_error_payload(&response)?;
+        Ok(response)
     }
 
     fn git(&self, operation: &str, body: Value) -> Result<Value, ForgeError> {
-        self.transport.send(
+        let response = self.transport.send(
             &self.config,
             ProviderRequest {
                 kind: "GIT".to_string(),
@@ -202,7 +205,9 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
                 path: self.config.git_remote.clone(),
                 body: Some(body),
             },
-        )
+        )?;
+        reject_provider_error_payload(&response)?;
+        Ok(response)
     }
 }
 
@@ -517,6 +522,17 @@ fn git_result_commit(value: &Value) -> Result<&str, ForgeError> {
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| ForgeError::ProviderResponse("missing git result commit".into()))
+}
+
+fn reject_provider_error_payload(value: &Value) -> Result<(), ForgeError> {
+    let Some(errors) = value.get("errors").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    Err(ForgeError::ProviderResponse(format!(
+        "SourceHut GraphQL provider response contained top-level errors array with {} entr{}",
+        errors.len(),
+        if errors.len() == 1 { "y" } else { "ies" }
+    )))
 }
 
 fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Value, ForgeError> {

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -1,6 +1,7 @@
 use runa_forge_contract::{ForgeConnector, ForgeError, Handle, Operation};
 use serde_json::{Value, json};
 use std::collections::VecDeque;
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,6 +115,9 @@ impl SourcehutTransport for SourcehutHttpTransport {
         config: &SourcehutConfig,
         request: ProviderRequest,
     ) -> Result<Value, ForgeError> {
+        if request.kind == "GIT" {
+            return execute_git(config, request);
+        }
         if request.kind != "GRAPHQL" {
             return Err(ForgeError::Unsupported(format!(
                 "production HTTP transport cannot execute {}",
@@ -283,14 +287,19 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         let branch = required_string(&input, "branch")?;
         let commit = required_string(&input, "commit")?;
         let version = required_u64(&input, "version")?;
-        let _ = self.git(
+        let destination_ref = git_ref(branch);
+        let response = self.git(
             "deliverChangeProposal",
-            json!({ "remote": self.config.git_remote, "branch": branch, "commit": commit }),
+            json!({
+                "source": commit,
+                "destination": destination_ref,
+            }),
         )?;
+        let produced_ref = git_result_ref(&response)?;
         Ok(json!({
             "handle": self.change_handle(branch, version),
             "work_unit": work_unit,
-            "commit": commit,
+            "commit": produced_ref,
             "version": version
         }))
     }
@@ -321,15 +330,22 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         self.ticket_number(Some(work_unit))?;
         let change = self.change_id(input.get("change"))?;
         let approved_commit = required_string(&input, "approved_commit")?;
-        let _ = self.git(
+        let base = required_string(&input, "base")?;
+        let destination_ref = git_ref(base);
+        let response = self.git(
             "applyApprovedChange",
-            json!({ "remote": self.config.git_remote, "change": change, "commit": approved_commit }),
+            json!({
+                "change": change,
+                "source": approved_commit,
+                "destination": destination_ref,
+            }),
         )?;
+        let produced_ref = git_result_ref(&response)?;
         Ok(json!({
             "work_unit": work_unit,
             "change": input.get("change").cloned().unwrap_or(Value::Null),
-            "applied_commit": approved_commit,
-            "receipt": "applied"
+            "applied_commit": produced_ref,
+            "receipt": produced_ref
         }))
     }
 
@@ -449,11 +465,113 @@ fn parse_number(value: &str) -> Result<u64, ForgeError> {
         .ok_or_else(|| ForgeError::InvalidInput(format!("invalid ticket number '{value}'")))
 }
 
+fn git_ref(value: &str) -> String {
+    if value.starts_with("refs/") {
+        value.to_string()
+    } else {
+        format!("refs/heads/{value}")
+    }
+}
+
+fn git_result_ref(value: &Value) -> Result<&str, ForgeError> {
+    value
+        .get("ref")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::ProviderResponse("missing git result ref".into()))
+}
+
+fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Value, ForgeError> {
+    let remote = config.git_remote.trim();
+    if remote.is_empty() {
+        return Err(ForgeError::InvalidInput(
+            "sourcehut git_remote is required".into(),
+        ));
+    }
+    let body = request
+        .body
+        .ok_or_else(|| ForgeError::InvalidInput("git request body is required".into()))?;
+    let source = body
+        .get("source")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput("git source is required".into()))?;
+    let destination = body
+        .get("destination")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::InvalidInput("git destination is required".into()))?;
+
+    let push = Command::new("git")
+        .args([
+            "push",
+            "--porcelain",
+            remote,
+            &format!("{source}:{destination}"),
+        ])
+        .output()
+        .map_err(|error| ForgeError::Transport(format!("git push failed: {error}")))?;
+    if !push.status.success() {
+        return Err(ForgeError::Transport(format!(
+            "git push exited with status {}\n{}",
+            push.status,
+            String::from_utf8_lossy(&push.stderr)
+        )));
+    }
+
+    let ls_remote = Command::new("git")
+        .args(["ls-remote", remote, destination])
+        .output()
+        .map_err(|error| ForgeError::Transport(format!("git ls-remote failed: {error}")))?;
+    if !ls_remote.status.success() {
+        return Err(ForgeError::Transport(format!(
+            "git ls-remote exited with status {}\n{}",
+            ls_remote.status,
+            String::from_utf8_lossy(&ls_remote.stderr)
+        )));
+    }
+    let stdout = String::from_utf8(ls_remote.stdout).map_err(|_| {
+        ForgeError::ProviderResponse("git ls-remote produced non-UTF-8 output".into())
+    })?;
+    let Some((commit, produced_ref)) = stdout
+        .lines()
+        .find_map(|line| line.split_once('\t'))
+        .filter(|(_, produced_ref)| *produced_ref == destination)
+    else {
+        return Err(ForgeError::ProviderResponse(format!(
+            "git push did not produce ref {destination}"
+        )));
+    };
+
+    Ok(json!({
+        "commit": commit,
+        "ref": produced_ref,
+        "push": String::from_utf8_lossy(&push.stdout).to_string()
+    }))
+}
+
 fn receipt(response: Value, fallback: &str) -> String {
     response
-        .pointer("/data/id")
-        .or_else(|| response.get("id"))
-        .and_then(Value::as_u64)
-        .map(|id| id.to_string())
+        .pointer("/data")
+        .and_then(first_id)
+        .or_else(|| first_id(&response))
         .unwrap_or_else(|| fallback.to_string())
+}
+
+fn first_id(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            if let Some(id) = map.get("id") {
+                if let Some(id) = id.as_str().filter(|id| !id.is_empty()) {
+                    return Some(id.to_string());
+                }
+                if let Some(id) = id.as_u64() {
+                    return Some(id.to_string());
+                }
+            }
+            map.values().find_map(first_id)
+        }
+        Value::Array(values) => values.iter().find_map(first_id),
+        _ => None,
+    }
 }

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -151,11 +151,16 @@ impl SourcehutTransport for SourcehutHttpTransport {
 pub struct SourcehutConnector<T> {
     config: SourcehutConfig,
     transport: T,
+    tracker_rid: Arc<Mutex<Option<String>>>,
 }
 
 impl<T: SourcehutTransport> SourcehutConnector<T> {
     pub fn new(config: SourcehutConfig, transport: T) -> Self {
-        Self { config, transport }
+        Self {
+            config,
+            transport,
+            tracker_rid: Arc::new(Mutex::new(None)),
+        }
     }
 
     pub fn call(&self, operation: Operation, input: Value) -> Result<Value, ForgeError> {
@@ -209,6 +214,77 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         reject_provider_error_payload(&response)?;
         Ok(response)
     }
+
+    fn tracker_rid(&self) -> Result<String, ForgeError> {
+        if let Some(rid) = self.tracker_rid_cache()?.clone() {
+            return Ok(rid);
+        }
+
+        let resolved = self.resolve_tracker_rid()?;
+        let mut cache = self.tracker_rid_cache()?;
+        if let Some(rid) = cache.as_ref() {
+            return Ok(rid.clone());
+        }
+        *cache = Some(resolved.clone());
+        Ok(resolved)
+    }
+
+    fn tracker_rid_cache(&self) -> Result<std::sync::MutexGuard<'_, Option<String>>, ForgeError> {
+        self.tracker_rid.lock().map_err(|_| {
+            ForgeError::Transport("sourcehut tracker rid cache lock poisoned".to_string())
+        })
+    }
+
+    fn resolve_tracker_rid(&self) -> Result<String, ForgeError> {
+        let tracker_id = self.tracker_id_number()?;
+        let mut cursor = Value::Null;
+        loop {
+            // SourceHut's trackers(cursor:) lists trackers owned by the credential
+            // user. The runa deployment credential owns its configured tracker;
+            // grant-only trackers need owner+name resolution outside this fix.
+            let response = self.graphql(
+                "trackers",
+                "query trackers($cursor: Cursor) { trackers(cursor: $cursor) { results { id rid name } cursor } }",
+                json!({ "cursor": cursor }),
+            )?;
+            let trackers = required_provider_object(&response, "/data/trackers", "trackers")?;
+            let results = trackers
+                .get("results")
+                .and_then(Value::as_array)
+                .ok_or_else(|| ForgeError::ProviderResponse("missing trackers results".into()))?;
+            for tracker in results {
+                if tracker.get("id").and_then(Value::as_u64) == Some(tracker_id) {
+                    return tracker
+                        .get("rid")
+                        .and_then(Value::as_str)
+                        .filter(|rid| !rid.is_empty())
+                        .map(str::to_string)
+                        .ok_or_else(|| {
+                            ForgeError::ProviderResponse(format!(
+                                "SourceHut tracker {} did not include an opaque rid",
+                                self.config.tracker_id
+                            ))
+                        });
+                }
+            }
+
+            match trackers.get("cursor") {
+                None | Some(Value::Null) => break,
+                Some(Value::String(next)) if next.is_empty() => break,
+                Some(Value::String(next)) => cursor = json!(next),
+                Some(_) => {
+                    return Err(ForgeError::ProviderResponse(
+                        "SourceHut trackers cursor was not a string or null".into(),
+                    ));
+                }
+            }
+        }
+
+        Err(ForgeError::ProviderResponse(format!(
+            "SourceHut tracker_id {} was not returned by trackers(cursor:)",
+            self.config.tracker_id
+        )))
+    }
 }
 
 impl<T: SourcehutTransport> ForgeConnector for SourcehutConnector<T> {
@@ -234,10 +310,11 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
     fn read_ticket(&self, input: Value) -> Result<Value, ForgeError> {
         let reference = required_string(&input, "reference")?;
         let number = self.resolve_reference(reference)?;
+        let tracker_rid = self.tracker_rid()?;
         let response = self.graphql(
             "ticket",
-            "query ticket($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { ticket(id: $id) { id subject body status } } }",
-            json!({ "id": number, "tracker": self.config.tracker_id }),
+            "query ticket($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { id rid name ticket(id: $id) { id subject body status } } }",
+            json!({ "id": number, "tracker": tracker_rid }),
         )?;
         self.ticket_snapshot(
             number,

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -295,11 +295,12 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
                 "destination": destination_ref,
             }),
         )?;
-        let produced_ref = git_result_ref(&response)?;
+        let _produced_ref = git_result_ref(&response)?;
+        let produced_commit = git_result_commit(&response)?;
         Ok(json!({
             "handle": self.change_handle(branch, version),
             "work_unit": work_unit,
-            "commit": produced_ref,
+            "commit": produced_commit,
             "version": version
         }))
     }
@@ -341,10 +342,11 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             }),
         )?;
         let produced_ref = git_result_ref(&response)?;
+        let produced_commit = git_result_commit(&response)?;
         Ok(json!({
             "work_unit": work_unit,
             "change": input.get("change").cloned().unwrap_or(Value::Null),
-            "applied_commit": produced_ref,
+            "applied_commit": produced_commit,
             "receipt": produced_ref
         }))
     }
@@ -479,6 +481,14 @@ fn git_result_ref(value: &Value) -> Result<&str, ForgeError> {
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| ForgeError::ProviderResponse("missing git result ref".into()))
+}
+
+fn git_result_commit(value: &Value) -> Result<&str, ForgeError> {
+    value
+        .get("commit")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ForgeError::ProviderResponse("missing git result commit".into()))
 }
 
 fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Value, ForgeError> {

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -241,9 +241,7 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         )?;
         self.ticket_snapshot(
             number,
-            response
-                .pointer("/data/tracker/ticket")
-                .unwrap_or(&response),
+            required_provider_object(&response, "/data/tracker/ticket", "ticket")?,
         )
     }
 
@@ -256,10 +254,7 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             "mutation submitTicket($trackerId: Int!, $input: SubmitTicketInput!) { submitTicket(trackerId: $trackerId, input: $input) { id subject body status } }",
             json!({ "trackerId": tracker_id, "input": { "subject": title, "body": body } }),
         )?;
-        let ticket = response
-            .pointer("/data/submitTicket")
-            .or_else(|| response.pointer("/data/tracker/ticket"))
-            .unwrap_or(&response);
+        let ticket = required_provider_object(&response, "/data/submitTicket", "submitTicket")?;
         let number = ticket.get("id").and_then(Value::as_u64).unwrap_or(0);
         self.ticket_snapshot(number, ticket)
     }
@@ -272,7 +267,9 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             "mutation claimWorkUnit($trackerId: Int!, $ticketId: Int!, $input: UpdateStatusInput!) { updateTicketStatus(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
             json!({ "trackerId": tracker_id, "ticketId": number, "input": { "status": "IN_PROGRESS" } }),
         )?;
-        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "claimed") }))
+        let result =
+            required_provider_object(&response, "/data/updateTicketStatus", "updateTicketStatus")?;
+        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(result, "claimed") }))
     }
 
     fn record_progress(&self, input: Value) -> Result<Value, ForgeError> {
@@ -284,9 +281,8 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             "mutation submitComment($trackerId: Int!, $ticketId: Int!, $input: SubmitCommentInput!) { submitComment(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
             json!({ "trackerId": tracker_id, "ticketId": number, "input": { "text": body } }),
         )?;
-        Ok(
-            json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "progress") }),
-        )
+        let result = required_provider_object(&response, "/data/submitComment", "submitComment")?;
+        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(result, "progress") }))
     }
 
     fn deliver_change_proposal(&self, input: Value) -> Result<Value, ForgeError> {
@@ -328,10 +324,11 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             "mutation submitComment($trackerId: Int!, $ticketId: Int!, $input: SubmitCommentInput!) { submitComment(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id } }",
             json!({ "trackerId": tracker_id, "ticketId": number, "input": { "text": body } }),
         )?;
+        let result = required_provider_object(&response, "/data/submitComment", "submitComment")?;
         Ok(json!({
             "work_unit": work_unit,
             "change": input.get("change").cloned().unwrap_or(Value::Null),
-            "receipt": receipt(response, "disposition")
+            "receipt": receipt(result, "disposition")
         }))
     }
 
@@ -382,7 +379,8 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
                 }
             }),
         )?;
-        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(response, "closed") }))
+        let result = required_provider_object(&response, "/data/submitComment", "submitComment")?;
+        Ok(json!({ "handle": self.ticket_handle(number), "receipt": receipt(result, "closed") }))
     }
 
     fn ticket_snapshot(&self, number: u64, ticket: &Value) -> Result<Value, ForgeError> {
@@ -535,6 +533,17 @@ fn reject_provider_error_payload(value: &Value) -> Result<(), ForgeError> {
     )))
 }
 
+fn required_provider_object<'a>(
+    value: &'a Value,
+    pointer: &str,
+    name: &str,
+) -> Result<&'a Value, ForgeError> {
+    value
+        .pointer(pointer)
+        .filter(|candidate| candidate.is_object())
+        .ok_or_else(|| ForgeError::ProviderResponse(format!("missing {name} result")))
+}
+
 fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Value, ForgeError> {
     let remote = config.git_remote.trim();
     if remote.is_empty() {
@@ -604,11 +613,11 @@ fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Val
     }))
 }
 
-fn receipt(response: Value, fallback: &str) -> String {
+fn receipt(response: &Value, fallback: &str) -> String {
     response
         .pointer("/data")
         .and_then(first_id)
-        .or_else(|| first_id(&response))
+        .or_else(|| first_id(response))
         .unwrap_or_else(|| fallback.to_string())
 }
 

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -337,14 +337,33 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             .get("work_unit")
             .ok_or_else(|| ForgeError::InvalidInput("work_unit is required".into()))?;
         self.ticket_number(Some(work_unit))?;
-        let change = self.change_id(input.get("change"))?;
+        let (change_branch, change_version) = self.change_parts(input.get("change"))?;
+        let approved_version = required_u64(&input, "approved_version")?;
         let approved_commit = required_string(&input, "approved_commit")?;
         let base = required_string(&input, "base")?;
+        if change_version != approved_version {
+            return Err(ForgeError::InvalidInput(format!(
+                "change version {change_version} does not match approved_version {approved_version}"
+            )));
+        }
+        let change_ref = git_ref(change_branch);
+        let delivered = self.git(
+            "resolveChangeProposal",
+            json!({
+                "ref": change_ref,
+            }),
+        )?;
+        let delivered_ref = git_result_ref(&delivered)?;
+        let delivered_commit = git_result_commit(&delivered)?;
+        if delivered_commit != approved_commit {
+            return Err(ForgeError::InvalidInput(format!(
+                "change ref {delivered_ref} points at '{delivered_commit}', not approved commit '{approved_commit}'"
+            )));
+        }
         let destination_ref = git_ref(base);
         let response = self.git(
             "applyApprovedChange",
             json!({
-                "change": change,
                 "source": approved_commit,
                 "destination": destination_ref,
             }),
@@ -448,10 +467,38 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
     }
 
     fn change_id<'a>(&self, value: Option<&'a Value>) -> Result<&'a str, ForgeError> {
+        let _ = self.change_parts(value)?;
         let handle = handle_id(value)?;
         let prefix = format!("sourcehut:tracker:{}:change:", self.config.tracker_id);
         if let Some(change) = handle.strip_prefix(&prefix) {
             return Ok(change);
+        }
+        if handle.starts_with("sourcehut:tracker:") {
+            return Err(ForgeError::ForeignScope(format!(
+                "{handle} does not match tracker {}",
+                self.config.tracker_id
+            )));
+        }
+        Err(ForgeError::InvalidInput(format!(
+            "handle '{handle}' is not a SourceHut change handle"
+        )))
+    }
+
+    fn change_parts<'a>(&self, value: Option<&'a Value>) -> Result<(&'a str, u64), ForgeError> {
+        let handle = handle_id(value)?;
+        let prefix = format!("sourcehut:tracker:{}:change:", self.config.tracker_id);
+        if let Some(change) = handle.strip_prefix(&prefix) {
+            let (branch, version) = change.rsplit_once(":version:").ok_or_else(|| {
+                ForgeError::InvalidInput(format!(
+                    "handle '{handle}' is not a versioned SourceHut change handle"
+                ))
+            })?;
+            if branch.is_empty() {
+                return Err(ForgeError::InvalidInput(format!(
+                    "handle '{handle}' is not a versioned SourceHut change handle"
+                )));
+            }
+            return Ok((branch, parse_number(version)?));
         }
         if handle.starts_with("sourcehut:tracker:") {
             return Err(ForgeError::ForeignScope(format!(
@@ -554,6 +601,14 @@ fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Val
     let body = request
         .body
         .ok_or_else(|| ForgeError::InvalidInput("git request body is required".into()))?;
+    if request.operation == "resolveChangeProposal" {
+        let change_ref = body
+            .get("ref")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| ForgeError::InvalidInput("git ref is required".into()))?;
+        return resolve_git_ref(remote, change_ref);
+    }
     let source = body
         .get("source")
         .and_then(Value::as_str)
@@ -582,8 +637,18 @@ fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Val
         )));
     }
 
+    let resolved = resolve_git_ref(remote, destination)?;
+
+    Ok(json!({
+        "commit": git_result_commit(&resolved)?,
+        "ref": git_result_ref(&resolved)?,
+        "push": String::from_utf8_lossy(&push.stdout).to_string()
+    }))
+}
+
+fn resolve_git_ref(remote: &str, target_ref: &str) -> Result<Value, ForgeError> {
     let ls_remote = Command::new("git")
-        .args(["ls-remote", remote, destination])
+        .args(["ls-remote", remote, target_ref])
         .output()
         .map_err(|error| ForgeError::Transport(format!("git ls-remote failed: {error}")))?;
     if !ls_remote.status.success() {
@@ -599,17 +664,16 @@ fn execute_git(config: &SourcehutConfig, request: ProviderRequest) -> Result<Val
     let Some((commit, produced_ref)) = stdout
         .lines()
         .find_map(|line| line.split_once('\t'))
-        .filter(|(_, produced_ref)| *produced_ref == destination)
+        .filter(|(_, produced_ref)| *produced_ref == target_ref)
     else {
         return Err(ForgeError::ProviderResponse(format!(
-            "git push did not produce ref {destination}"
+            "git remote did not contain ref {target_ref}"
         )));
     };
 
     Ok(json!({
         "commit": commit,
-        "ref": produced_ref,
-        "push": String::from_utf8_lossy(&push.stdout).to_string()
+        "ref": produced_ref
     }))
 }
 

--- a/runa-forge-sourcehut/tests/fixtures/todo.sr.ht.schema.graphqls
+++ b/runa-forge-sourcehut/tests/fixtures/todo.sr.ht.schema.graphqls
@@ -1,0 +1,1028 @@
+# Vendored from SourceHut todo.sr.ht:
+# https://git.sr.ht/~sircmpwn/todo.sr.ht/blob/17d3ea871aa206b0d4b4fd908bcc063c3179eefe/api/graph/schema.graphqls
+#
+# This schema definition is available in the public domain, or under the terms
+# of CC-0, at your choice.
+scalar Cursor
+scalar Time
+scalar URL
+scalar Upload
+
+"Used to provide a human-friendly description of an access scope"
+directive @scopehelp(details: String!) on ENUM_VALUE
+
+"""
+This is used to decorate fields which are only accessible with a personal
+access token, and are not available to clients using OAuth 2.0 access tokens.
+"""
+directive @private on FIELD_DEFINITION
+
+"""
+This is used to decorate fields which are for internal use, and are not
+available to normal API users.
+"""
+directive @internal on FIELD_DEFINITION
+
+enum AccessScope {
+  PROFILE       @scopehelp(details: "profile information")
+  TRACKERS      @scopehelp(details: "trackers")
+  TICKETS       @scopehelp(details: "tickets")
+  ACLS          @scopehelp(details: "access control lists")
+  EVENTS        @scopehelp(details: "events")
+  SUBSCRIPTIONS @scopehelp(details: "tracker & ticket subscriptions")
+}
+
+enum AccessKind {
+  RO @scopehelp(details: "read")
+  RW @scopehelp(details: "read and write")
+}
+
+"""
+Decorates fields for which access requires a particular OAuth 2.0 scope with
+read or write access.
+"""
+directive @access(scope: AccessScope!, kind: AccessKind!) on FIELD_DEFINITION
+
+# https://semver.org
+type Version {
+  major: Int!
+  minor: Int!
+  patch: Int!
+  buildVersion: String!
+  buildDate: String!
+
+  """
+  If this API version is scheduled for deprecation, this is the date on which
+  it will stop working; or null if this API version is not scheduled for
+  deprecation.
+  """
+  deprecationDate: Time
+}
+
+interface Entity {
+  canonicalName: String!
+}
+
+type User implements Entity {
+  id: Int!
+  created: Time!
+  updated: Time!
+  canonicalName: String!
+  username: String!
+  email: String!
+  url: String
+  location: String
+  bio: String
+
+  "Returns a specific tracker."
+  tracker(name: String!): Tracker @access(scope: TRACKERS, kind: RO)
+
+  trackers(cursor: Cursor): TrackerCursor! @access(scope: TRACKERS, kind: RO)
+}
+
+type EmailAddress implements Entity {
+  canonicalName: String!
+
+  """
+  "jdoe@example.org" of "Jane Doe <jdoe@example.org>"
+  """
+  mailbox: String!
+  """
+  "Jane Doe" of "Jane Doe <jdoe@example.org>"
+  """
+  name: String
+}
+
+type ExternalUser implements Entity {
+  canonicalName: String!
+
+  """
+  <service>:<service specific details...>
+  e.g. github:ddevault
+  """
+  externalId: String!
+  "The canonical external URL for this user, e.g. https://github.com/ddevault"
+  externalUrl: String
+}
+
+enum Visibility {
+  PUBLIC
+  UNLISTED
+  PRIVATE
+}
+
+type Tracker {
+  id: Int!
+  rid: ID!
+  created: Time!
+  updated: Time!
+  owner: Entity! @access(scope: PROFILE, kind: RO)
+  name: String!
+  description: String
+  visibility: Visibility!
+
+  ticket(id: Int!): Ticket @access(scope: TICKETS, kind: RO)
+  tickets(cursor: Cursor): TicketCursor! @access(scope: TICKETS, kind: RO)
+  label(name: String!): Label
+  labels(cursor: Cursor): LabelCursor!
+
+  """
+  If the authenticated user is subscribed to this tracker, this is that
+  subscription.
+  """
+  subscription: TrackerSubscription @access(scope: SUBSCRIPTIONS, kind: RO)
+
+  """
+  The access control list entry (or the default ACL) which describes the
+  authenticated user's permissions with respect to this tracker.
+  """
+  acl: ACL
+
+  # Only available to the tracker owner:
+  defaultACL: DefaultACL!
+  acls(cursor: Cursor): ACLCursor! @access(scope: ACLS, kind: RO)
+
+  """
+  Returns a URL from which the tracker owner may download a gzipped JSON
+  archive of the tracker.
+  """
+  export: URL!
+
+  """
+  Returns a list of tracker webhook subscriptions. For clients
+  authenticated with a personal access token, this returns all webhooks
+  configured by all GraphQL clients for your account. For clients
+  authenticated with an OAuth 2.0 access token, this returns only webhooks
+  registered for your client.
+  """
+  webhooks(cursor: Cursor): WebhookSubscriptionCursor!
+
+  "Returns details of a tracker webhook subscription by its ID."
+  webhook(id: Int!): WebhookSubscription
+}
+
+type OAuthClient {
+  uuid: String!
+}
+
+enum WebhookEvent {
+  TRACKER_CREATED
+  TRACKER_UPDATE
+  TRACKER_DELETED
+  TICKET_CREATED
+  TICKET_UPDATE
+  TICKET_DELETED
+  LABEL_CREATED
+  LABEL_UPDATE
+  LABEL_DELETED
+  EVENT_CREATED
+}
+
+interface WebhookSubscription {
+  id: Int!
+  events: [WebhookEvent!]!
+  query: String!
+  url: String!
+
+  """
+  If this webhook was registered by an authorized OAuth 2.0 client, this
+  field is non-null.
+  """
+  client: OAuthClient @private
+
+  "All deliveries which have been sent to this webhook."
+  deliveries(cursor: Cursor): WebhookDeliveryCursor!
+
+  "Returns a sample payload for this subscription, for testing purposes"
+  sample(event: WebhookEvent!): String!
+}
+
+type UserWebhookSubscription implements WebhookSubscription {
+  id: Int!
+  events: [WebhookEvent!]!
+  query: String!
+  url: String!
+  client: OAuthClient @private
+  deliveries(cursor: Cursor): WebhookDeliveryCursor!
+  sample(event: WebhookEvent!): String!
+}
+
+type TrackerWebhookSubscription implements WebhookSubscription {
+  id: Int!
+  events: [WebhookEvent!]!
+  query: String!
+  url: String!
+  client: OAuthClient @private
+  deliveries(cursor: Cursor): WebhookDeliveryCursor!
+  sample(event: WebhookEvent!): String!
+
+  tracker: Tracker!
+}
+
+type TicketWebhookSubscription implements WebhookSubscription {
+  id: Int!
+  events: [WebhookEvent!]!
+  query: String!
+  url: String!
+  client: OAuthClient @private
+  deliveries(cursor: Cursor): WebhookDeliveryCursor!
+  sample(event: WebhookEvent!): String!
+
+  ticket: Ticket!
+}
+
+type WebhookDelivery {
+  uuid: String!
+  date: Time!
+  event: WebhookEvent!
+  subscription: WebhookSubscription!
+  requestBody: String!
+
+  """
+  These details are provided only after a response is received from the
+  remote server. If a response is sent whose Content-Type is not text/*, or
+  cannot be decoded as UTF-8, the response body will be null. It will be
+  truncated after 64 KiB.
+  """
+  responseBody: String
+  responseHeaders: String
+  responseStatus: Int
+}
+
+interface WebhookPayload {
+  uuid: String!
+  event: WebhookEvent!
+  date: Time!
+}
+
+type TrackerEvent implements WebhookPayload {
+  uuid: String!
+  event: WebhookEvent!
+  date: Time!
+
+  tracker: Tracker!
+}
+
+type TicketEvent implements WebhookPayload {
+  uuid: String!
+  event: WebhookEvent!
+  date: Time!
+
+  ticket: Ticket!
+}
+
+type TicketDeletedEvent implements WebhookPayload {
+  uuid: String!
+  event: WebhookEvent!
+  date: Time!
+
+  trackerId: Int!
+  ticketId: Int!
+}
+
+type EventCreated implements WebhookPayload {
+  uuid: String!
+  event: WebhookEvent!
+  date: Time!
+
+  newEvent: Event!
+}
+
+type LabelEvent implements WebhookPayload {
+  uuid: String!
+  event: WebhookEvent!
+  date: Time!
+
+  label: Label!
+}
+
+enum TicketStatus {
+  REPORTED
+  CONFIRMED
+  IN_PROGRESS
+  PENDING
+  RESOLVED
+}
+
+enum TicketResolution {
+  UNRESOLVED
+  CLOSED
+  FIXED
+  IMPLEMENTED
+  WONT_FIX
+  BY_DESIGN
+  INVALID
+  DUPLICATE
+  NOT_OUR_BUG
+}
+
+enum Authenticity {
+  """
+  The server vouches for this information as entered verbatim by the
+  attributed entity.
+  """
+  AUTHENTIC
+  """
+  The server does not vouch for this information as entered by the attributed
+  entity, no authentication was provided.
+  """
+  UNAUTHENTICATED
+  """
+  The server has evidence that the information has likely been manipulated by
+  a third party.
+  """
+  TAMPERED
+}
+
+type Ticket {
+  """
+  The ticket ID is unique within each tracker, but is not globally unique.
+  The first ticket opened on a given tracker will have ID 1, then 2, and so
+  on.
+  """
+  id: Int!
+
+  created: Time!
+  updated: Time!
+  submitter: Entity! @access(scope: PROFILE, kind: RO)
+  tracker: Tracker! @access(scope: TRACKERS, kind: RO)
+
+  """
+  Canonical ticket reference string; may be used in comments to identify the
+  ticket from anywhere.
+  """
+  ref: String!
+
+  subject: String!
+  body: String
+  status: TicketStatus!
+  resolution: TicketResolution!
+  authenticity: Authenticity!
+
+  labels: [Label!]!
+  assignees: [Entity!]! @access(scope: PROFILE, kind: RO)
+  events(cursor: Cursor): EventCursor! @access(scope: EVENTS, kind: RO)
+
+  """
+  If the authenticated user is subscribed to this ticket, this is that
+  subscription.
+  """
+  subscription: TicketSubscription @access(scope: SUBSCRIPTIONS, kind: RO)
+
+  """
+  Returns a list of ticket webhook subscriptions. For clients
+  authenticated with a personal access token, this returns all webhooks
+  configured by all GraphQL clients for your account. For clients
+  authenticated with an OAuth 2.0 access token, this returns only webhooks
+  registered for your client.
+  """
+  webhooks(cursor: Cursor): WebhookSubscriptionCursor!
+
+  "Returns details of a ticket webhook subscription by its ID."
+  webhook(id: Int!): WebhookSubscription
+}
+
+interface ACL {
+  "Permission to view tickets"
+  browse: Boolean!
+  "Permission to submit tickets"
+  submit: Boolean!
+  "Permission to comment on tickets"
+  comment: Boolean!
+  "Permission to edit tickets"
+  edit: Boolean!
+  "Permission to resolve, re-open, transfer, or label tickets"
+  triage: Boolean!
+}
+
+"""
+These ACLs are configured for specific entities, and may be used to expand or
+constrain the rights of a participant.
+"""
+type TrackerACL implements ACL {
+  id: Int!
+  created: Time!
+  tracker: Tracker! @access(scope: TRACKERS, kind: RO)
+  entity: Entity! @access(scope: PROFILE, kind: RO)
+
+  browse: Boolean!
+  submit: Boolean!
+  comment: Boolean!
+  edit: Boolean!
+  triage: Boolean!
+}
+
+"""
+These ACL policies are applied non-specifically, e.g. the default ACL for all
+authenticated users.
+"""
+type DefaultACL implements ACL {
+  browse: Boolean!
+  submit: Boolean!
+  comment: Boolean!
+  edit: Boolean!
+  triage: Boolean!
+}
+
+type Label {
+  id: Int!
+  created: Time!
+  name: String!
+  tracker: Tracker! @access(scope: TRACKERS, kind: RO)
+
+  "In CSS hexadecimal format"
+  backgroundColor: String!
+  foregroundColor: String!
+
+  tickets(cursor: Cursor): TicketCursor! @access(scope: TICKETS, kind: RO)
+}
+
+enum EventType {
+  CREATED
+  COMMENT
+  STATUS_CHANGE
+  LABEL_ADDED
+  LABEL_REMOVED
+  ASSIGNED_USER
+  UNASSIGNED_USER
+  USER_MENTIONED
+  TICKET_MENTIONED
+}
+
+"""
+Represents an event which affects a ticket. Multiple changes can occur in a
+single event, and are enumerated in the "changes" field.
+"""
+type Event {
+  id: Int!
+  created: Time!
+  changes: [EventDetail!]!
+
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+}
+
+interface EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+}
+
+type Created implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+  author: Entity! @access(scope: PROFILE, kind: RO)
+}
+
+type Assignment implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+
+  assigner: Entity! @access(scope: PROFILE, kind: RO)
+  assignee: Entity! @access(scope: PROFILE, kind: RO)
+}
+
+type Comment implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+  author: Entity! @access(scope: PROFILE, kind: RO)
+
+  text: String!
+  authenticity: Authenticity!
+
+  "If this comment has been edited, this field points to the new revision."
+  supersededBy: Comment
+}
+
+type LabelUpdate implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+  labeler: Entity! @access(scope: PROFILE, kind: RO)
+  label: Label!
+}
+
+type StatusChange implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+  editor: Entity! @access(scope: PROFILE, kind: RO)
+
+  oldStatus: TicketStatus!
+  newStatus: TicketStatus!
+  oldResolution: TicketResolution!
+  newResolution: TicketResolution!
+}
+
+type UserMention implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+  author: Entity! @access(scope: PROFILE, kind: RO)
+  mentioned: Entity! @access(scope: PROFILE, kind: RO)
+}
+
+type TicketMention implements EventDetail {
+  eventType: EventType!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+  author: Entity! @access(scope: PROFILE, kind: RO)
+  mentioned: Ticket! @access(scope: TICKETS, kind: RO)
+}
+
+interface ActivitySubscription {
+  id: Int!
+  created: Time!
+}
+
+"""
+A tracker subscription will notify a participant of all activity for a
+tracker, including all new tickets and their events.
+"""
+type TrackerSubscription implements ActivitySubscription {
+  id: Int!
+  created: Time!
+  tracker: Tracker! @access(scope: TRACKERS, kind: RO)
+}
+
+"""
+A ticket subscription will notify a participant when activity occurs on a
+ticket.
+"""
+type TicketSubscription implements ActivitySubscription {
+  id: Int!
+  created: Time!
+  ticket: Ticket! @access(scope: TICKETS, kind: RO)
+}
+
+"""
+A cursor for enumerating trackers
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type TrackerCursor {
+  results: [Tracker!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating tickets
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type TicketCursor {
+  results: [Ticket!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating labels
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type LabelCursor {
+  results: [Label!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating access control list entries
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type ACLCursor {
+  results: [TrackerACL!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating events
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type EventCursor {
+  results: [Event!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating subscriptions
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type ActivitySubscriptionCursor {
+  results: [ActivitySubscription!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating a list of webhook deliveries
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type WebhookDeliveryCursor {
+  results: [WebhookDelivery!]!
+  cursor: Cursor
+}
+
+"""
+A cursor for enumerating a list of webhook subscriptions
+
+If there are additional results available, the cursor object may be passed
+back into the same endpoint to retrieve another page. If the cursor is null,
+there are no remaining results to return.
+"""
+type WebhookSubscriptionCursor {
+  results: [WebhookSubscription!]!
+  cursor: Cursor
+}
+
+type Preferences {
+  notifySelf: Boolean!
+}
+
+type Query {
+  "Returns API version information."
+  version: Version!
+
+  "Returns the authenticated user."
+  me: User! @access(scope: PROFILE, kind: RO)
+
+  "Returns a specific user."
+  user(username: String!): User @access(scope: PROFILE, kind: RO)
+
+  "Looks up a tracker based on its resource ID."
+  tracker(rid: ID!): Tracker @access(scope: TRACKERS, kind: RO)
+
+  """
+  Returns trackers that the authenticated user has access to.
+
+  NOTE: in this version of the API, only trackers owned by the authenticated
+  user are returned, but in the future the default behavior will be to return
+  all trackers that the user either (1) has been given explicit access to via
+  ACLs or (2) has implicit access to either by ownership or group membership.
+  """
+  trackers(cursor: Cursor): TrackerCursor @access(scope: TRACKERS, kind: RO)
+
+  """
+  List of events which the authenticated user is subscribed to or implicated
+  in, ordered by the event date (recent events first).
+  """
+  events(cursor: Cursor): EventCursor @access(scope: EVENTS, kind: RO)
+
+  "List of subscriptions of the authenticated user."
+  subscriptions(cursor: Cursor): ActivitySubscriptionCursor @access(scope: SUBSCRIPTIONS, kind: RO)
+
+  """
+  Returns a list of user webhook subscriptions. For clients
+  authenticated with a personal access token, this returns all webhooks
+  configured by all GraphQL clients for your account. For clients
+  authenticated with an OAuth 2.0 access token, this returns only webhooks
+  registered for your client.
+  """
+  userWebhooks(cursor: Cursor): WebhookSubscriptionCursor!
+
+  "Returns details of a user webhook subscription by its ID."
+  userWebhook(id: Int!): WebhookSubscription
+
+  """
+  Returns information about the webhook currently being processed. This is
+  not valid during normal queries over HTTP, and will return an error if used
+  outside of a webhook context.
+  """
+  webhook: WebhookPayload!
+
+  """
+  Returns the preferences associated with this user account.
+  """
+  preferences: Preferences! @access(scope: PROFILE, kind: RO)
+}
+
+"You may omit any fields to leave them unchanged."
+input TrackerInput {
+  name: String
+  description: String
+  visibility: Visibility
+}
+
+"You may omit any fields to leave them unchanged."
+input UpdateLabelInput {
+  name: String
+  foregroundColor: String
+  backgroundColor: String
+}
+
+input ACLInput {
+  "Permission to view tickets"
+  browse: Boolean!
+  "Permission to submit tickets"
+  submit: Boolean!
+  "Permission to comment on tickets"
+  comment: Boolean!
+  "Permission to edit tickets"
+  edit: Boolean!
+  "Permission to resolve, re-open, transfer, or label tickets"
+  triage: Boolean!
+}
+
+"""
+This is used for importing tickets from third-party services, and may only be
+used by the tracker owner. It causes a ticket submission, update, or comment
+to be attributed to an external user and appear as if it were submitted at a
+specific time.
+"""
+input ImportInput {
+  created: Time!
+  """
+  External user ID. By convention this should be "service:username", e.g.
+  "codeberg:ddevault".
+  """
+  externalId: String!
+  """
+  A URL at which the user's external profile may be found, e.g.
+  "https://codeberg.org/ddevault".
+  """
+  externalUrl: String!
+}
+
+input SubmitTicketInput {
+  subject: String!
+  body: String
+
+  # These fields are meant for use when importing tickets from third-party
+  # services, and may only be used by the tracker owner.
+  # TODO: Use ImportInput here
+  created: Time
+  externalId: String
+  externalUrl: String
+}
+
+# For internal use only.
+input SubmitTicketEmailInput {
+  subject: String!
+  body: String
+  senderId: Int!
+  messageId: String!
+}
+
+# For internal use only.
+enum EmailCmd {
+  RESOLVE
+  REOPEN
+  LABEL
+  UNLABEL
+}
+
+# For internal use only.
+input SubmitCommentEmailInput {
+  text: String!
+  senderId: Int!
+  cmd: EmailCmd
+  resolution: TicketResolution
+  labelIds: [Int!]
+  messageId: String!
+}
+
+"""
+You may omit any fields to leave them unchanged. To remove the ticket body,
+set it to null.
+"""
+input UpdateTicketInput {
+  subject: String
+  body: String
+
+  "For use by the tracker owner only"
+  import: ImportInput
+}
+
+"""
+You may omit the status or resolution fields to leave them unchanged (or if
+you do not have permission to change them). "resolution" is required if
+status is RESOLVED.
+"""
+input SubmitCommentInput {
+  text: String!
+  status: TicketStatus
+  resolution: TicketResolution
+
+  "For use by the tracker owner only"
+  import: ImportInput
+}
+
+"""
+"resolution" is required if status is RESOLVED.
+"""
+input UpdateStatusInput {
+  status: TicketStatus!
+  resolution: TicketResolution
+
+  "For use by the tracker owner only"
+  import: ImportInput
+}
+
+input UserWebhookInput {
+  url: String!
+  events: [WebhookEvent!]!
+  query: String!
+}
+
+input TrackerWebhookInput {
+  url: String!
+  events: [WebhookEvent!]!
+  query: String!
+}
+
+input TicketWebhookInput {
+  url: String!
+  events: [WebhookEvent!]!
+  query: String!
+}
+
+input PreferencesInput {
+  notifySelf: Boolean!
+}
+
+type Mutation {
+  """
+  Creates a new bug tracker. If specified, the 'import' field specifies a
+  gzipped dump of a tracker to populate tickets from; see Tracker.export.
+  """
+  createTracker(
+    name: String!,
+    description: String,
+    visibility: Visibility!,
+    importUpload: Upload): Tracker! @access(scope: TRACKERS, kind: RW)
+
+  "Updates an existing bug tracker"
+  updateTracker(
+    id: Int!,
+    input: TrackerInput!): Tracker! @access(scope: TRACKERS, kind: RW)
+
+  "Deletes a bug tracker"
+  deleteTracker(id: Int!): Tracker! @access(scope: TRACKERS, kind: RW)
+
+  "Adds or updates the ACL for a specific user on a bug tracker"
+  updateUserACL(
+    trackerId: Int!,
+    userId: Int!,
+    input: ACLInput!): TrackerACL! @access(scope: ACLS, kind: RW)
+
+  # "Adds or updates the ACL for an email address on a bug tracker"
+  # TODO: This requires internal changes
+  #updateSenderACL(
+  #  trackerId: Int!,
+  #  address: String!,
+  #  input: ACLInput!): TrackerACL! @access(scope: ACLS, kind: RW)
+
+  """
+  Updates the default ACL for a bug tracker, which applies to users and
+  senders for whom a more specific ACL does not exist.
+  """
+  updateTrackerACL(
+    trackerId: Int!,
+    input: ACLInput!): DefaultACL! @access(scope: ACLS, kind: RW)
+
+  """
+  Removes a tracker ACL. Following this change, the default tracker ACL will
+  apply to this user.
+  """
+  deleteACL(id: Int!): TrackerACL! @access(scope: ACLS, kind: RW)
+
+  "Subscribes to all email notifications for a tracker"
+  trackerSubscribe(
+    trackerId: Int!): TrackerSubscription! @access(scope: SUBSCRIPTIONS, kind: RW)
+
+  """
+  Unsubscribes from email notifications for a tracker. If "tickets" is true,
+  also unsubscribe from all tickets on this tracker.
+  """
+  trackerUnsubscribe(
+    trackerId: Int!,
+    tickets: Boolean!): TrackerSubscription! @access(scope: SUBSCRIPTIONS, kind: RW)
+
+  "Subscribes to all email notifications for a ticket"
+  ticketSubscribe(
+    trackerId: Int!,
+    ticketId: Int!): TicketSubscription! @access(scope: SUBSCRIPTIONS, kind: RW)
+
+  "Unsubscribes from email notifications for a ticket"
+  ticketUnsubscribe(
+    trackerId: Int!,
+    ticketId: Int!): TicketSubscription! @access(scope: SUBSCRIPTIONS, kind: RW)
+
+  """
+  Creates a new ticket label for a tracker. The colors must be in CSS
+  hexadecimal RGB format "#RRGGBB", i.e. "#000000" for black and "#FF0000" for
+  red.
+  """
+  createLabel(trackerId: Int!, name: String!,
+    foregroundColor: String!, backgroundColor: String!): Label! @access(scope: TRACKERS, kind: RW)
+
+  "Changes the name or colors for a label."
+  updateLabel(id: Int!, input: UpdateLabelInput!): Label! @access(scope: TRACKERS, kind: RW)
+
+  """
+  Deletes a label, removing it from any tickets which currently have it
+  applied.
+  """
+  deleteLabel(id: Int!): Label! @access(scope: TRACKERS, kind: RW)
+
+  "Creates a new ticket."
+  submitTicket(trackerId: Int!,
+    input: SubmitTicketInput!): Ticket! @access(scope: TICKETS, kind: RW)
+
+  "Deletes a ticket."
+  deleteTicket(trackerId: Int!, ticketId: Int!): Ticket! @access(scope: TICKETS, kind: RW)
+
+  # Creates a new ticket from an incoming email. (For internal use only)
+  submitTicketEmail(trackerId: Int!,
+    input: SubmitTicketEmailInput!): Ticket! @internal
+
+  # Creates a new comment from an incoming email. (For internal use only)
+  submitCommentEmail(trackerId: Int!, ticketId: Int!,
+    input: SubmitCommentEmailInput!): Event! @internal
+
+  "Updates a ticket's subject or body"
+  updateTicket(trackerId: Int!, ticketId: Int!,
+    input: UpdateTicketInput!): Ticket! @access(scope: TICKETS, kind: RW)
+
+  "Updates the status or resolution of a ticket"
+  updateTicketStatus(trackerId: Int!, ticketId: Int!,
+    input: UpdateStatusInput!): Event! @access(scope: TICKETS, kind: RW)
+
+  "Submits a comment for a ticket"
+  submitComment(trackerId: Int!, ticketId: Int!,
+    input: SubmitCommentInput!): Event! @access(scope: TICKETS, kind: RW)
+
+  "Adds a user to the list of assigned users for a ticket"
+  assignUser(trackerId: Int!, ticketId: Int!,
+    userId: Int!): Event! @access(scope: TICKETS, kind: RW)
+
+  "Removes a user from the list of assigned users for a ticket"
+  unassignUser(trackerId: Int!, ticketId: Int!,
+    userId: Int!): Event! @access(scope: TICKETS, kind: RW)
+
+  "Adds a label to the list of labels for a ticket"
+  labelTicket(trackerId: Int!, ticketId: Int!,
+    labelId: Int!): Event! @access(scope: TICKETS, kind: RW)
+
+  "Removes a list from the list of labels for a ticket"
+  unlabelTicket(trackerId: Int!, ticketId: Int!,
+    labelId: Int!): Event! @access(scope: TICKETS, kind: RW)
+
+  "Imports a gzipped JSON dump of tracker data"
+  importTrackerDump(trackerId: Int!, dump: Upload!): Boolean! @access(scope: TRACKERS, kind: RW)
+
+  """
+  Creates a new user webhook subscription. When an event from the
+  provided list of events occurs, the 'query' parameter (a GraphQL query)
+  will be evaluated and the results will be sent to the provided URL as the
+  body of an HTTP POST request. The list of events must include at least one
+  event, and no duplicates.
+
+  This query is evaluated in the webhook context, such that query { webhook }
+  may be used to access details of the event which trigged the webhook. The
+  query may not make any mutations.
+  """
+  createUserWebhook(config: UserWebhookInput!): WebhookSubscription!
+
+  """
+  Deletes a user webhook. Any events already queued may still be
+  delivered after this request completes. Clients authenticated with a
+  personal access token may delete any webhook registered for their account,
+  but authorized OAuth 2.0 clients may only delete their own webhooks.
+  Manually deleting a webhook configured by a third-party client may cause
+  unexpected behavior with the third-party integration.
+  """
+  deleteUserWebhook(id: Int!): WebhookSubscription!
+
+  "Creates a new tracker webhook."
+  createTrackerWebhook(trackerId: Int!, config: TrackerWebhookInput!): WebhookSubscription!
+
+  "Deletes a tracker webhook."
+  deleteTrackerWebhook(id: Int!): WebhookSubscription!
+
+  "Creates a new ticket webhook."
+  createTicketWebhook(trackerId: Int!, ticketId: Int!, config: TicketWebhookInput!): WebhookSubscription!
+
+  "Deletes a ticket webhook."
+  deleteTicketWebhook(id: Int!): WebhookSubscription!
+
+  """
+  Deletes the authenticated user's account. Internal use only.
+  """
+  deleteUser: Int! @internal
+
+  """
+  Updates the user's preferences.
+  """
+  updatePreferences(preferences: PreferencesInput!): Preferences! @access(scope: PROFILE, kind: RW)
+}

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -1,0 +1,198 @@
+use runa_forge_contract::Operation;
+use runa_forge_sourcehut::{
+    ProviderRequest, SourcehutConfig, SourcehutConnector, SourcehutHttpTransport,
+    SourcehutRecordingTransport,
+};
+use serde_json::json;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+fn config(api_base: &str) -> SourcehutConfig {
+    SourcehutConfig {
+        tracker_id: "4".to_string(),
+        api_base: api_base.to_string(),
+        git_remote: "ssh://git@git.sr.ht/~tesserine/runa".to_string(),
+        credential_env: None,
+        credential_command: None,
+    }
+}
+
+fn handle(number: u64) -> serde_json::Value {
+    json!({
+        "id": format!("sourcehut:tracker:4:ticket:{number}"),
+        "display": format!("sourcehut:4#{number}")
+    })
+}
+
+#[test]
+fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
+    let transport = SourcehutRecordingTransport::with_repeating_response(json!({
+        "data": {
+            "ticket": {
+                "id": 203,
+                "subject": "Forge connectors",
+                "description": "body",
+                "status": "open"
+            }
+        }
+    }));
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    for reference in ["sourcehut:4#203", "#203", "203"] {
+        let output = connector
+            .call(Operation::ReadTicket, json!({ "reference": reference }))
+            .unwrap();
+
+        assert_eq!(output["handle"]["id"], "sourcehut:tracker:4:ticket:203");
+        assert_eq!(output["title"], "Forge connectors");
+    }
+}
+
+#[test]
+fn foreign_scope_is_rejected_before_transport() {
+    let transport = SourcehutRecordingTransport::default();
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let error = connector
+        .call(
+            Operation::CloseOut,
+            json!({
+                "work_unit": {
+                    "id": "sourcehut:tracker:9:ticket:203",
+                    "display": "sourcehut:9#203"
+                },
+                "completion": {
+                    "criterion_summary": "done",
+                    "gaps": [],
+                    "change_reference": "abc123",
+                    "documentation_status": "updated"
+                },
+                "body": "done"
+            }),
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains("foreign scope"));
+    assert!(transport.requests().is_empty());
+}
+
+#[test]
+fn every_operation_constructs_the_expected_provider_request() {
+    let transport = SourcehutRecordingTransport::with_repeating_response(json!({
+        "data": {
+            "ticket": {
+                "id": 203,
+                "subject": "Forge connectors",
+                "description": "body",
+                "status": "open"
+            },
+            "createTicket": {
+                "id": 203,
+                "subject": "Forge connectors",
+                "description": "body",
+                "status": "open"
+            }
+        }
+    }));
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let cases = [
+        (
+            Operation::ReadTicket,
+            json!({"reference": "203"}),
+            "GRAPHQL",
+            "ticket",
+        ),
+        (
+            Operation::CreateTicket,
+            json!({"title": "title", "body": "body"}),
+            "GRAPHQL",
+            "createTicket",
+        ),
+        (
+            Operation::ClaimWorkUnit,
+            json!({"handle": handle(203)}),
+            "GRAPHQL",
+            "claimWorkUnit",
+        ),
+        (
+            Operation::RecordProgress,
+            json!({"handle": handle(203), "body": "progress"}),
+            "GRAPHQL",
+            "recordProgress",
+        ),
+        (
+            Operation::DeliverChangeProposal,
+            json!({"work_unit": handle(203), "branch": "issue-203", "commit": "abc123", "base": "main", "summary": "summary", "body": "body", "version": 1}),
+            "GIT",
+            "deliverChangeProposal",
+        ),
+        (
+            Operation::ReflectDisposition,
+            json!({"work_unit": handle(203), "change": {"id": "sourcehut:tracker:4:change:issue-203:version:1", "display": "issue-203"}, "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"}),
+            "GRAPHQL",
+            "reflectDisposition",
+        ),
+        (
+            Operation::ApplyApprovedChange,
+            json!({"work_unit": handle(203), "change": {"id": "sourcehut:tracker:4:change:issue-203:version:1", "display": "issue-203"}, "approved_version": 1, "approved_commit": "abc123", "base": "main"}),
+            "GIT",
+            "applyApprovedChange",
+        ),
+        (
+            Operation::CloseOut,
+            json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"}),
+            "GRAPHQL",
+            "closeOut",
+        ),
+    ];
+
+    for (operation, input, _, _) in &cases {
+        connector.call(*operation, input.clone()).unwrap();
+    }
+
+    let requests = transport.requests();
+    assert_eq!(requests.len(), cases.len());
+    for (request, (_, _, kind, operation_name)) in requests.iter().zip(cases) {
+        assert_eq!(request.kind, kind);
+        assert_eq!(request.operation, operation_name);
+    }
+}
+
+#[test]
+fn production_http_transport_executes_and_parses_read_ticket() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert!(request.starts_with("POST /query "));
+        assert!(request.contains("ticket"));
+        let body = r#"{"data":{"ticket":{"id":203,"subject":"Harness title","description":"Harness body","status":"open"}}}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let connector = SourcehutConnector::new(
+        config(&format!("http://{address}/query")),
+        SourcehutHttpTransport,
+    );
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert_eq!(output["title"], "Harness title");
+    assert_eq!(output["handle"]["id"], "sourcehut:tracker:4:ticket:203");
+    server.join().unwrap();
+}
+
+#[allow(dead_code)]
+fn _request_type_is_public(_: ProviderRequest) {}

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -1,17 +1,19 @@
 use apollo_compiler::{ExecutableDocument, Schema};
-use runa_forge_contract::Operation;
+use runa_forge_contract::{ForgeError, Operation};
 use runa_forge_sourcehut::{
     ProviderRequest, SourcehutConfig, SourcehutConnector, SourcehutHttpTransport,
-    SourcehutRecordingTransport,
+    SourcehutRecordingTransport, SourcehutTransport,
 };
 use serde_json::{Value, json};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 const SOURCEHUT_TODO_SCHEMA: &str = include_str!("fixtures/todo.sr.ht.schema.graphqls");
+const TRACKER_RID: &str = "06fdktpsb5w8q09e22xy0m6fnr";
 
 fn config(api_base: &str) -> SourcehutConfig {
     SourcehutConfig {
@@ -120,20 +122,115 @@ fn assert_graphql_request_validates(request: &str, expected_field: &str) {
     );
 }
 
-#[test]
-fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
-    let transport = SourcehutRecordingTransport::with_repeating_response(json!({
-        "data": {
-            "tracker": {
-                "ticket": {
-                    "id": 203,
-                    "subject": "Forge connectors",
-                    "body": "body",
-                    "status": "REPORTED"
+#[derive(Debug, Clone, Default)]
+struct SourcehutTrackerFakeTransport {
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl SourcehutTrackerFakeTransport {
+    fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl SourcehutTransport for SourcehutTrackerFakeTransport {
+    fn send(
+        &self,
+        _config: &SourcehutConfig,
+        request: ProviderRequest,
+    ) -> Result<Value, ForgeError> {
+        self.requests.lock().unwrap().push(request.clone());
+        if request.kind == "GIT" {
+            return Ok(json!({
+                "commit": "abc123",
+                "ref": "refs/heads/issue-203"
+            }));
+        }
+        if request.kind != "GRAPHQL" {
+            return Err(ForgeError::Unsupported(format!(
+                "fake cannot execute {}",
+                request.kind
+            )));
+        }
+
+        let variables = request
+            .body
+            .as_ref()
+            .and_then(|body| body.get("variables"))
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        match request.operation.as_str() {
+            "trackers" => {
+                if variables.get("cursor").and_then(Value::as_str) == Some("next") {
+                    Ok(json!({
+                        "data": {
+                            "trackers": {
+                                "results": [
+                                    { "id": 4, "rid": TRACKER_RID, "name": "runa" }
+                                ],
+                                "cursor": null
+                            }
+                        }
+                    }))
+                } else {
+                    Ok(json!({
+                        "data": {
+                            "trackers": {
+                                "results": [
+                                    { "id": 1, "rid": "01not-the-runa-tracker", "name": "other" }
+                                ],
+                                "cursor": "next"
+                            }
+                        }
+                    }))
                 }
             }
+            "ticket" => {
+                if variables.get("tracker").and_then(Value::as_str) != Some(TRACKER_RID) {
+                    return Ok(json!({
+                        "errors": [{ "message": "tracker(rid:) requires an opaque resource id" }]
+                    }));
+                }
+                Ok(json!({
+                    "data": {
+                        "tracker": {
+                            "id": 4,
+                            "rid": TRACKER_RID,
+                            "name": "runa",
+                            "ticket": {
+                                "id": 203,
+                                "subject": "Forge connectors",
+                                "body": "body",
+                                "status": "REPORTED"
+                            }
+                        }
+                    }
+                }))
+            }
+            "submitTicket" => Ok(json!({
+                "data": {
+                    "submitTicket": {
+                        "id": 203,
+                        "subject": "Forge connectors",
+                        "body": "body",
+                        "status": "REPORTED"
+                    }
+                }
+            })),
+            "updateTicketStatus" => {
+                Ok(json!({ "data": { "updateTicketStatus": { "id": "claim-203" } } }))
+            }
+            "submitComment" => Ok(json!({ "data": { "submitComment": { "id": "comment-203" } } })),
+            operation => Err(ForgeError::Unsupported(format!(
+                "fake cannot execute operation {operation}"
+            ))),
         }
-    }));
+    }
+}
+
+#[test]
+fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
+    let transport = SourcehutTrackerFakeTransport::default();
     let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
 
     for reference in ["sourcehut:4#203", "#203", "203"] {
@@ -144,6 +241,52 @@ fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
         assert_eq!(output["handle"]["id"], "sourcehut:tracker:4:ticket:203");
         assert_eq!(output["title"], "Forge connectors");
     }
+
+    let requests = transport.requests();
+    let tracker_list_requests = requests
+        .iter()
+        .filter(|request| request.operation == "trackers")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tracker_list_requests.len(),
+        2,
+        "tracker rid should be resolved through one paged listing sequence"
+    );
+    let ticket_tracker_variables = requests
+        .iter()
+        .filter(|request| request.operation == "ticket")
+        .map(|request| {
+            request
+                .body
+                .as_ref()
+                .and_then(|body| body.pointer("/variables/tracker"))
+                .and_then(Value::as_str)
+                .unwrap()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(ticket_tracker_variables, vec![TRACKER_RID; 3]);
+}
+
+#[test]
+fn sourcehut_fake_rejects_numeric_tracker_id_as_tracker_rid() {
+    let transport = SourcehutTrackerFakeTransport::default();
+    let response = transport
+        .send(
+            &config("https://todo.test/query"),
+            ProviderRequest {
+                kind: "GRAPHQL".to_string(),
+                operation: "ticket".to_string(),
+                path: "/query".to_string(),
+                body: Some(json!({
+                    "query": "query ticket($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { ticket(id: $id) { id subject body status } } }",
+                    "variables": { "tracker": "4", "id": 203 }
+                })),
+            },
+        )
+        .unwrap();
+
+    assert!(response.get("errors").is_some(), "{response}");
 }
 
 #[test]
@@ -176,35 +319,7 @@ fn foreign_scope_is_rejected_before_transport() {
 
 #[test]
 fn every_operation_constructs_the_expected_provider_request() {
-    let transport = SourcehutRecordingTransport::with_repeating_response(json!({
-        "data": {
-            "tracker": {
-                "ticket": {
-                    "id": 203,
-                    "subject": "Forge connectors",
-                    "body": "body",
-                    "status": "REPORTED"
-                }
-            },
-            "submitTicket": {
-                "id": 203,
-                "subject": "Forge connectors",
-                "body": "body",
-                "status": "REPORTED"
-            },
-            "updateTicketStatus": {
-                "id": "claim-203"
-            },
-            "submitComment": {
-                "id": "comment-203"
-            },
-            "closeOut": {
-                "id": "closed-203"
-            },
-        },
-        "commit": "abc123",
-        "ref": "refs/heads/issue-203"
-    }));
+    let transport = SourcehutTrackerFakeTransport::default();
     let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
 
     let cases = [
@@ -263,6 +378,8 @@ fn every_operation_constructs_the_expected_provider_request() {
     }
 
     let expected_requests = [
+        ("GRAPHQL", "trackers"),
+        ("GRAPHQL", "trackers"),
         ("GRAPHQL", "ticket"),
         ("GRAPHQL", "submitTicket"),
         ("GRAPHQL", "updateTicketStatus"),
@@ -288,10 +405,17 @@ fn every_operation_constructs_the_expected_provider_request() {
                 .and_then(Value::as_str)
                 .expect("GraphQL request should include query string");
             validate_sourcehut_graphql(query);
-            assert!(
-                query.contains(operation_name),
-                "query did not contain {operation_name}: {query}"
-            );
+            if operation_name == "trackers" {
+                assert!(
+                    query.contains("trackers"),
+                    "query did not list trackers: {query}"
+                );
+            } else {
+                assert!(
+                    query.contains(operation_name),
+                    "query did not contain {operation_name}: {query}"
+                );
+            }
         }
     }
 }
@@ -430,10 +554,47 @@ fn sourcehut_schema_rejects_nonexistent_top_level_ticket_operations() {
 }
 
 #[test]
+fn sourcehut_schema_models_tracker_rid_and_tracker_listing_accessors() {
+    validate_sourcehut_graphql(
+        "query trackerByRid($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { id rid name ticket(id: $id) { id subject body status } } }",
+    );
+    validate_sourcehut_graphql(
+        "query trackerRid($cursor: Cursor) { trackers(cursor: $cursor) { results { id rid name } cursor } }",
+    );
+
+    let schema =
+        Schema::parse_and_validate(SOURCEHUT_TODO_SCHEMA, "todo.sr.ht.schema.graphqls").unwrap();
+    let numeric_root_lookup =
+        "query trackerById($tracker: Int!) { tracker(id: $tracker) { id rid name } }";
+    assert!(
+        ExecutableDocument::parse_and_validate(&schema, numeric_root_lookup, "operation.graphql")
+            .is_err(),
+        "root tracker(id:) must not validate against the SourceHut schema"
+    );
+}
+
+#[test]
 fn production_http_transport_executes_and_parses_read_ticket() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
     let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert!(request.starts_with("POST /query "));
+        assert_graphql_request_validates(&request, "trackers");
+        let body = format!(
+            r#"{{"data":{{"trackers":{{"results":[{{"id":4,"rid":"{TRACKER_RID}","name":"runa"}}],"cursor":null}}}}}}"#
+        );
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+
         let (mut stream, _) = listener.accept().unwrap();
         let mut request = [0_u8; 4096];
         let size = stream.read(&mut request).unwrap();
@@ -468,6 +629,10 @@ fn production_http_transport_executes_and_parses_every_graphql_operation() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
     let expected = [
+        (
+            "trackers",
+            r#"{"data":{"trackers":{"results":[{"id":4,"rid":"06fdktpsb5w8q09e22xy0m6fnr","name":"runa"}],"cursor":null}}}"#,
+        ),
         (
             "tracker",
             r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"Harness read","body":"Read body","status":"REPORTED"}}}}"#,

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -129,6 +129,7 @@ fn every_operation_constructs_the_expected_provider_request() {
                 "status": "open"
             }
         },
+        "commit": "abc123",
         "ref": "refs/heads/issue-203"
     }));
     let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
@@ -364,7 +365,7 @@ fn production_git_transport_delivers_change_proposal_to_remote_ref() {
         Path::new(env!("CARGO_MANIFEST_DIR")),
     );
     assert!(remote_commit.starts_with(&commit));
-    assert_eq!(output["commit"], "refs/heads/issue-203");
+    assert_eq!(output["commit"], commit);
 }
 
 #[test]
@@ -400,7 +401,7 @@ fn production_git_transport_applies_approved_change_to_base_ref() {
         Path::new(env!("CARGO_MANIFEST_DIR")),
     );
     assert!(remote_commit.starts_with(&commit));
-    assert_eq!(output["applied_commit"], "refs/heads/main");
+    assert_eq!(output["applied_commit"], commit);
     assert_eq!(output["receipt"], "refs/heads/main");
 }
 

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -305,6 +305,36 @@ fn every_operation_rejects_provider_error_payloads_without_success_receipts() {
 }
 
 #[test]
+fn every_operation_rejects_null_or_absent_required_provider_results() {
+    for response in [
+        json!({
+            "data": {
+                "tracker": {
+                    "ticket": null
+                },
+                "submitTicket": null,
+                "updateTicketStatus": null,
+                "submitComment": null
+            }
+        }),
+        json!({ "data": {} }),
+    ] {
+        let transport = SourcehutRecordingTransport::with_repeating_response(response);
+        let connector =
+            SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+        for operation in Operation::ALL {
+            let result = connector.call(operation, input_for_operation(operation));
+
+            assert!(
+                result.is_err(),
+                "{operation} should reject absent/null required provider result, got {result:?}"
+            );
+        }
+    }
+}
+
+#[test]
 fn production_http_transport_rejects_graphql_errors_under_http_200() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -30,6 +30,34 @@ fn handle(number: u64) -> serde_json::Value {
     })
 }
 
+fn change() -> serde_json::Value {
+    json!({
+        "id": "sourcehut:tracker:4:change:issue-203:version:1",
+        "display": "issue-203"
+    })
+}
+
+fn input_for_operation(operation: Operation) -> serde_json::Value {
+    match operation {
+        Operation::ReadTicket => json!({"reference": "203"}),
+        Operation::CreateTicket => json!({"title": "title", "body": "body"}),
+        Operation::ClaimWorkUnit => json!({"handle": handle(203)}),
+        Operation::RecordProgress => json!({"handle": handle(203), "body": "progress"}),
+        Operation::DeliverChangeProposal => {
+            json!({"work_unit": handle(203), "branch": "issue-203", "commit": "abc123", "base": "main", "summary": "summary", "body": "body", "version": 1})
+        }
+        Operation::ReflectDisposition => {
+            json!({"work_unit": handle(203), "change": change(), "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"})
+        }
+        Operation::ApplyApprovedChange => {
+            json!({"work_unit": handle(203), "change": change(), "approved_version": 1, "approved_commit": "abc123", "base": "main"})
+        }
+        Operation::CloseOut => {
+            json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"})
+        }
+    }
+}
+
 fn config_with_remote(api_base: &str, git_remote: String) -> SourcehutConfig {
     SourcehutConfig {
         git_remote,
@@ -255,6 +283,58 @@ fn every_operation_constructs_the_expected_provider_request() {
             );
         }
     }
+}
+
+#[test]
+fn every_operation_rejects_provider_error_payloads_without_success_receipts() {
+    let transport = SourcehutRecordingTransport::with_repeating_response(json!({
+        "errors": [{"message": "provider rejected mutation"}]
+    }));
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    for operation in Operation::ALL {
+        let result = connector.call(operation, input_for_operation(operation));
+
+        assert!(
+            result.is_err(),
+            "{operation} should reject SourceHut provider errors, got {result:?}"
+        );
+    }
+
+    assert_eq!(transport.requests().len(), Operation::ALL.len());
+}
+
+#[test]
+fn production_http_transport_rejects_graphql_errors_under_http_200() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert!(request.starts_with("POST /query "));
+        assert_graphql_request_validates(&request, "tracker");
+        let body = r#"{"errors":[{"message":"provider rejected mutation"}]}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let connector = SourcehutConnector::new(
+        config(&format!("http://{address}/query")),
+        SourcehutHttpTransport,
+    );
+    let error = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap_err();
+
+    assert!(error.to_string().contains("GraphQL"));
+    server.join().unwrap();
 }
 
 #[test]

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -6,6 +6,8 @@ use runa_forge_sourcehut::{
 use serde_json::json;
 use std::io::{Read, Write};
 use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
 use std::thread;
 
 fn config(api_base: &str) -> SourcehutConfig {
@@ -23,6 +25,39 @@ fn handle(number: u64) -> serde_json::Value {
         "id": format!("sourcehut:tracker:4:ticket:{number}"),
         "display": format!("sourcehut:4#{number}")
     })
+}
+
+fn config_with_remote(api_base: &str, git_remote: String) -> SourcehutConfig {
+    SourcehutConfig {
+        git_remote,
+        ..config(api_base)
+    }
+}
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn local_git_fixture() -> (tempfile::TempDir, String) {
+    let remote = tempfile::tempdir().unwrap();
+    git(&["init", "--bare"], remote.path());
+    let commit = git(
+        &["rev-parse", "HEAD"],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+    (remote, commit)
 }
 
 #[test]
@@ -93,7 +128,8 @@ fn every_operation_constructs_the_expected_provider_request() {
                 "description": "body",
                 "status": "open"
             }
-        }
+        },
+        "ref": "refs/heads/issue-203"
     }));
     let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
 
@@ -192,6 +228,180 @@ fn production_http_transport_executes_and_parses_read_ticket() {
     assert_eq!(output["title"], "Harness title");
     assert_eq!(output["handle"]["id"], "sourcehut:tracker:4:ticket:203");
     server.join().unwrap();
+}
+
+#[test]
+fn production_http_transport_executes_and_parses_every_graphql_operation() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let expected = [
+        (
+            "ticket",
+            r#"{"data":{"ticket":{"id":203,"subject":"Harness read","description":"Read body","status":"open"}}}"#,
+        ),
+        (
+            "createTicket",
+            r#"{"data":{"createTicket":{"id":204,"subject":"Harness create","description":"Created body","status":"open"}}}"#,
+        ),
+        (
+            "claimWorkUnit",
+            r#"{"data":{"updateTicket":{"id":"claim-203"}}}"#,
+        ),
+        (
+            "recordProgress",
+            r#"{"data":{"createComment":{"id":"progress-1"}}}"#,
+        ),
+        (
+            "reflectDisposition",
+            r#"{"data":{"createComment":{"id":"disposition-1"}}}"#,
+        ),
+        (
+            "closeOut",
+            r#"{"data":{"closeTicket":{"id":"closed-203"}}}"#,
+        ),
+    ];
+    let server = thread::spawn(move || {
+        for (operation_name, body) in expected {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
+            assert!(
+                request.starts_with("POST /query "),
+                "unexpected request: {request}"
+            );
+            assert!(
+                request.contains(operation_name),
+                "request did not contain {operation_name}: {request}"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
+    });
+
+    let connector = SourcehutConnector::new(
+        config(&format!("http://{address}/query")),
+        SourcehutHttpTransport,
+    );
+    let read = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+    let created = connector
+        .call(
+            Operation::CreateTicket,
+            json!({"title": "title", "body": "body"}),
+        )
+        .unwrap();
+    let claimed = connector
+        .call(Operation::ClaimWorkUnit, json!({"handle": handle(203)}))
+        .unwrap();
+    let progress = connector
+        .call(
+            Operation::RecordProgress,
+            json!({"handle": handle(203), "body": "progress"}),
+        )
+        .unwrap();
+    let disposition = connector
+        .call(
+            Operation::ReflectDisposition,
+            json!({"work_unit": handle(203), "change": {"id": "sourcehut:tracker:4:change:issue-203:version:1", "display": "issue-203"}, "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"}),
+        )
+        .unwrap();
+    let closed = connector
+        .call(
+            Operation::CloseOut,
+            json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"}),
+        )
+        .unwrap();
+
+    assert_eq!(read["title"], "Harness read");
+    assert_eq!(created["handle"]["id"], "sourcehut:tracker:4:ticket:204");
+    assert_eq!(created["title"], "Harness create");
+    assert_eq!(claimed["receipt"], "claim-203");
+    assert_eq!(progress["receipt"], "progress-1");
+    assert_eq!(disposition["receipt"], "disposition-1");
+    assert_eq!(closed["receipt"], "closed-203");
+    server.join().unwrap();
+}
+
+#[test]
+fn production_git_transport_delivers_change_proposal_to_remote_ref() {
+    let (remote, commit) = local_git_fixture();
+    let connector = SourcehutConnector::new(
+        config_with_remote(
+            "http://127.0.0.1:1/query",
+            remote.path().to_string_lossy().into_owned(),
+        ),
+        SourcehutHttpTransport,
+    );
+
+    let output = connector
+        .call(
+            Operation::DeliverChangeProposal,
+            json!({
+                "work_unit": handle(203),
+                "branch": "issue-203",
+                "commit": commit,
+                "base": "main",
+                "summary": "summary",
+                "body": "body",
+                "version": 1
+            }),
+        )
+        .unwrap();
+
+    let remote_commit = git(
+        &[
+            "ls-remote",
+            remote.path().to_str().unwrap(),
+            "refs/heads/issue-203",
+        ],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+    assert!(remote_commit.starts_with(&commit));
+    assert_eq!(output["commit"], "refs/heads/issue-203");
+}
+
+#[test]
+fn production_git_transport_applies_approved_change_to_base_ref() {
+    let (remote, commit) = local_git_fixture();
+    let connector = SourcehutConnector::new(
+        config_with_remote(
+            "http://127.0.0.1:1/query",
+            remote.path().to_string_lossy().into_owned(),
+        ),
+        SourcehutHttpTransport,
+    );
+
+    let output = connector
+        .call(
+            Operation::ApplyApprovedChange,
+            json!({
+                "work_unit": handle(203),
+                "change": {"id": "sourcehut:tracker:4:change:issue-203:version:1", "display": "issue-203"},
+                "approved_version": 1,
+                "approved_commit": commit,
+                "base": "main"
+            }),
+        )
+        .unwrap();
+
+    let remote_commit = git(
+        &[
+            "ls-remote",
+            remote.path().to_str().unwrap(),
+            "refs/heads/main",
+        ],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+    assert!(remote_commit.starts_with(&commit));
+    assert_eq!(output["applied_commit"], "refs/heads/main");
+    assert_eq!(output["receipt"], "refs/heads/main");
 }
 
 #[allow(dead_code)]

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -262,9 +262,20 @@ fn every_operation_constructs_the_expected_provider_request() {
         connector.call(*operation, input.clone()).unwrap();
     }
 
+    let expected_requests = [
+        ("GRAPHQL", "ticket"),
+        ("GRAPHQL", "submitTicket"),
+        ("GRAPHQL", "updateTicketStatus"),
+        ("GRAPHQL", "submitComment"),
+        ("GIT", "deliverChangeProposal"),
+        ("GRAPHQL", "submitComment"),
+        ("GIT", "resolveChangeProposal"),
+        ("GIT", "applyApprovedChange"),
+        ("GRAPHQL", "submitComment"),
+    ];
     let requests = transport.requests();
-    assert_eq!(requests.len(), cases.len());
-    for (request, (_, _, kind, operation_name)) in requests.iter().zip(cases) {
+    assert_eq!(requests.len(), expected_requests.len());
+    for (request, (kind, operation_name)) in requests.iter().zip(expected_requests) {
         assert_eq!(request.kind, kind);
         assert_eq!(request.operation, operation_name);
         if request.kind == "GRAPHQL" {
@@ -332,6 +343,41 @@ fn every_operation_rejects_null_or_absent_required_provider_results() {
             );
         }
     }
+}
+
+#[test]
+fn apply_approved_change_rejects_delivered_ref_mismatch_before_push() {
+    let transport = SourcehutRecordingTransport::with_repeating_response(json!({
+        "commit": "delivered-commit",
+        "ref": "refs/heads/issue-203"
+    }));
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let error = connector
+        .call(
+            Operation::ApplyApprovedChange,
+            json!({
+                "work_unit": handle(203),
+                "change": {
+                    "id": "sourcehut:tracker:4:change:issue-203:version:1",
+                    "display": "issue-203"
+                },
+                "approved_version": 1,
+                "approved_commit": "different-commit",
+                "base": "main"
+            }),
+        )
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("different-commit")
+            && error.to_string().contains("delivered-commit"),
+        "delivered ref mismatch should report requested and actual commits: {error}"
+    );
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].kind, "GIT");
+    assert_eq!(requests[0].operation, "resolveChangeProposal");
 }
 
 #[test]
@@ -561,6 +607,21 @@ fn production_git_transport_applies_approved_change_to_base_ref() {
         ),
         SourcehutHttpTransport,
     );
+
+    connector
+        .call(
+            Operation::DeliverChangeProposal,
+            json!({
+                "work_unit": handle(203),
+                "branch": "issue-203",
+                "commit": commit,
+                "base": "main",
+                "summary": "summary",
+                "body": "body",
+                "version": 1
+            }),
+        )
+        .unwrap();
 
     let output = connector
         .call(

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -1,14 +1,17 @@
+use apollo_compiler::{ExecutableDocument, Schema};
 use runa_forge_contract::Operation;
 use runa_forge_sourcehut::{
     ProviderRequest, SourcehutConfig, SourcehutConnector, SourcehutHttpTransport,
     SourcehutRecordingTransport,
 };
-use serde_json::json;
+use serde_json::{Value, json};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
 use std::process::Command;
 use std::thread;
+
+const SOURCEHUT_TODO_SCHEMA: &str = include_str!("fixtures/todo.sr.ht.schema.graphqls");
 
 fn config(api_base: &str) -> SourcehutConfig {
     SourcehutConfig {
@@ -60,15 +63,46 @@ fn local_git_fixture() -> (tempfile::TempDir, String) {
     (remote, commit)
 }
 
+fn validate_sourcehut_graphql(query: &str) {
+    let schema =
+        Schema::parse_and_validate(SOURCEHUT_TODO_SCHEMA, "todo.sr.ht.schema.graphqls").unwrap();
+    ExecutableDocument::parse_and_validate(&schema, query, "operation.graphql").unwrap();
+}
+
+fn graphql_request_from_http(request: &str) -> Value {
+    let body = request
+        .split("\r\n\r\n")
+        .nth(1)
+        .expect("HTTP request should include a body");
+    serde_json::from_str(body).unwrap_or_else(|error| {
+        panic!("request body should be GraphQL JSON: {error}\nrequest:\n{request}")
+    })
+}
+
+fn assert_graphql_request_validates(request: &str, expected_field: &str) {
+    let body = graphql_request_from_http(request);
+    let query = body
+        .get("query")
+        .and_then(Value::as_str)
+        .expect("GraphQL request should include a query string");
+    validate_sourcehut_graphql(query);
+    assert!(
+        query.contains(expected_field),
+        "query did not contain {expected_field}: {query}"
+    );
+}
+
 #[test]
 fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
     let transport = SourcehutRecordingTransport::with_repeating_response(json!({
         "data": {
-            "ticket": {
-                "id": 203,
-                "subject": "Forge connectors",
-                "description": "body",
-                "status": "open"
+            "tracker": {
+                "ticket": {
+                    "id": 203,
+                    "subject": "Forge connectors",
+                    "body": "body",
+                    "status": "REPORTED"
+                }
             }
         }
     }));
@@ -116,18 +150,29 @@ fn foreign_scope_is_rejected_before_transport() {
 fn every_operation_constructs_the_expected_provider_request() {
     let transport = SourcehutRecordingTransport::with_repeating_response(json!({
         "data": {
-            "ticket": {
-                "id": 203,
-                "subject": "Forge connectors",
-                "description": "body",
-                "status": "open"
+            "tracker": {
+                "ticket": {
+                    "id": 203,
+                    "subject": "Forge connectors",
+                    "body": "body",
+                    "status": "REPORTED"
+                }
             },
-            "createTicket": {
+            "submitTicket": {
                 "id": 203,
                 "subject": "Forge connectors",
-                "description": "body",
-                "status": "open"
-            }
+                "body": "body",
+                "status": "REPORTED"
+            },
+            "updateTicketStatus": {
+                "id": "claim-203"
+            },
+            "submitComment": {
+                "id": "comment-203"
+            },
+            "closeOut": {
+                "id": "closed-203"
+            },
         },
         "commit": "abc123",
         "ref": "refs/heads/issue-203"
@@ -145,19 +190,19 @@ fn every_operation_constructs_the_expected_provider_request() {
             Operation::CreateTicket,
             json!({"title": "title", "body": "body"}),
             "GRAPHQL",
-            "createTicket",
+            "submitTicket",
         ),
         (
             Operation::ClaimWorkUnit,
             json!({"handle": handle(203)}),
             "GRAPHQL",
-            "claimWorkUnit",
+            "updateTicketStatus",
         ),
         (
             Operation::RecordProgress,
             json!({"handle": handle(203), "body": "progress"}),
             "GRAPHQL",
-            "recordProgress",
+            "submitComment",
         ),
         (
             Operation::DeliverChangeProposal,
@@ -169,7 +214,7 @@ fn every_operation_constructs_the_expected_provider_request() {
             Operation::ReflectDisposition,
             json!({"work_unit": handle(203), "change": {"id": "sourcehut:tracker:4:change:issue-203:version:1", "display": "issue-203"}, "disposition": {"kind": "approved", "against_version": 1, "reviewer": "reviewer", "reviewed_at": "2026-06-17T00:00:00Z", "findings": []}, "body": "approved"}),
             "GRAPHQL",
-            "reflectDisposition",
+            "submitComment",
         ),
         (
             Operation::ApplyApprovedChange,
@@ -181,7 +226,7 @@ fn every_operation_constructs_the_expected_provider_request() {
             Operation::CloseOut,
             json!({"work_unit": handle(203), "completion": {"criterion_summary": "done", "gaps": [], "change_reference": "abc123", "documentation_status": "updated"}, "body": "done"}),
             "GRAPHQL",
-            "closeOut",
+            "submitComment",
         ),
     ];
 
@@ -194,6 +239,37 @@ fn every_operation_constructs_the_expected_provider_request() {
     for (request, (_, _, kind, operation_name)) in requests.iter().zip(cases) {
         assert_eq!(request.kind, kind);
         assert_eq!(request.operation, operation_name);
+        if request.kind == "GRAPHQL" {
+            let body = request
+                .body
+                .as_ref()
+                .expect("GraphQL request should have body");
+            let query = body
+                .get("query")
+                .and_then(Value::as_str)
+                .expect("GraphQL request should include query string");
+            validate_sourcehut_graphql(query);
+            assert!(
+                query.contains(operation_name),
+                "query did not contain {operation_name}: {query}"
+            );
+        }
+    }
+}
+
+#[test]
+fn sourcehut_schema_rejects_nonexistent_top_level_ticket_operations() {
+    let schema =
+        Schema::parse_and_validate(SOURCEHUT_TODO_SCHEMA, "todo.sr.ht.schema.graphqls").unwrap();
+    for query in [
+        "query ticket($id: Int!) { ticket(id: $id) { id subject body status } }",
+        "mutation createTicket($subject: String!, $body: String!) { createTicket(subject: $subject, body: $body) { id subject body status } }",
+        "mutation closeTicket($id: Int!, $body: String!) { closeTicket(id: $id, body: $body) { id } }",
+    ] {
+        assert!(
+            ExecutableDocument::parse_and_validate(&schema, query, "operation.graphql").is_err(),
+            "query should fail against real SourceHut schema: {query}"
+        );
     }
 }
 
@@ -207,8 +283,8 @@ fn production_http_transport_executes_and_parses_read_ticket() {
         let size = stream.read(&mut request).unwrap();
         let request = String::from_utf8_lossy(&request[..size]);
         assert!(request.starts_with("POST /query "));
-        assert!(request.contains("ticket"));
-        let body = r#"{"data":{"ticket":{"id":203,"subject":"Harness title","description":"Harness body","status":"open"}}}"#;
+        assert_graphql_request_validates(&request, "tracker");
+        let body = r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"Harness title","body":"Harness body","status":"REPORTED"}}}}"#;
         write!(
             stream,
             "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
@@ -237,28 +313,28 @@ fn production_http_transport_executes_and_parses_every_graphql_operation() {
     let address = listener.local_addr().unwrap();
     let expected = [
         (
-            "ticket",
-            r#"{"data":{"ticket":{"id":203,"subject":"Harness read","description":"Read body","status":"open"}}}"#,
+            "tracker",
+            r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"Harness read","body":"Read body","status":"REPORTED"}}}}"#,
         ),
         (
-            "createTicket",
-            r#"{"data":{"createTicket":{"id":204,"subject":"Harness create","description":"Created body","status":"open"}}}"#,
+            "submitTicket",
+            r#"{"data":{"submitTicket":{"id":204,"subject":"Harness create","body":"Created body","status":"REPORTED"}}}"#,
         ),
         (
-            "claimWorkUnit",
-            r#"{"data":{"updateTicket":{"id":"claim-203"}}}"#,
+            "updateTicketStatus",
+            r#"{"data":{"updateTicketStatus":{"id":"claim-203"}}}"#,
         ),
         (
-            "recordProgress",
-            r#"{"data":{"createComment":{"id":"progress-1"}}}"#,
+            "submitComment",
+            r#"{"data":{"submitComment":{"id":"progress-1"}}}"#,
         ),
         (
-            "reflectDisposition",
-            r#"{"data":{"createComment":{"id":"disposition-1"}}}"#,
+            "submitComment",
+            r#"{"data":{"submitComment":{"id":"disposition-1"}}}"#,
         ),
         (
-            "closeOut",
-            r#"{"data":{"closeTicket":{"id":"closed-203"}}}"#,
+            "submitComment",
+            r#"{"data":{"submitComment":{"id":"closed-203"}}}"#,
         ),
     ];
     let server = thread::spawn(move || {
@@ -271,10 +347,7 @@ fn production_http_transport_executes_and_parses_every_graphql_operation() {
                 request.starts_with("POST /query "),
                 "unexpected request: {request}"
             );
-            assert!(
-                request.contains(operation_name),
-                "request did not contain {operation_name}: {request}"
-            );
+            assert_graphql_request_validates(&request, operation_name);
             write!(
                 stream,
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",

--- a/runa-mcp/Cargo.toml
+++ b/runa-mcp/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 libagent.workspace = true
+runa-forge-compose.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rmcp.workspace = true

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -173,6 +173,29 @@ impl RunaHandler {
         })())
     }
 
+    fn forge_tool_collision_message(&self, tool_name: &str) -> Result<Option<String>, McpError> {
+        let Some(runtime) = self.forge_runtime.as_ref() else {
+            return Ok(None);
+        };
+        if !runtime.tools.contains_key(tool_name) {
+            return Ok(None);
+        }
+
+        let collides = if let Some(session) = &self.session {
+            let session = session.lock().unwrap();
+            let (tools, _) = session_tools_and_schemas(&session)
+                .map_err(|error| McpError::internal_error(error, None))?;
+            tools.iter().any(|tool| tool.name.as_ref() == tool_name)
+        } else {
+            self.tools
+                .iter()
+                .any(|tool| tool.name.as_ref() == tool_name)
+        };
+
+        Ok(collides
+            .then(|| format!("tool name collision while composing MCP surface: {tool_name}")))
+    }
+
     fn transcript_context(&self) -> (Option<String>, Option<String>) {
         if let Some(session) = &self.session {
             let current_step = session.lock().unwrap().current_step().cloned();
@@ -935,6 +958,9 @@ impl ServerHandler for RunaHandler {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let tool_name = request.name.to_string();
+        if let Some(message) = self.forge_tool_collision_message(&tool_name)? {
+            return Ok(CallToolResult::error(vec![Content::text(message)]));
+        }
         if let Some(result) = self.call_forge_tool(
             &tool_name,
             request

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use rmcp::Error as McpError;
+use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::*;
 use rmcp::service::{RequestContext, RoleServer};
@@ -14,6 +14,7 @@ use libagent::validation::validate_artifact;
 use libagent::{
     ArtifactStore, ArtifactType, ProtocolDeclaration, SessionState, validate_output_scope,
 };
+use runa_forge_compose::ForgeRuntime;
 
 const DRIVER_TOOL_NAMES: [&str; 3] = ["readiness", "next-protocol-context", "advance"];
 
@@ -26,6 +27,7 @@ pub struct RunaHandler {
     /// Maps artifact type name → full JSON Schema (with work_unit intact).
     tool_schemas: HashMap<String, Value>,
     session: Option<Mutex<SessionState>>,
+    forge_runtime: Option<ForgeRuntime>,
 }
 
 struct HandlerState {
@@ -38,6 +40,7 @@ impl RunaHandler {
         work_unit: Option<String>,
         store: ArtifactStore,
         workspace_dir: PathBuf,
+        forge_runtime: Option<ForgeRuntime>,
     ) -> Self {
         let (tools, tool_schemas) =
             output_tools_for_protocol(&protocol, work_unit.as_deref(), &store, false);
@@ -50,6 +53,7 @@ impl RunaHandler {
             tools,
             tool_schemas,
             session: None,
+            forge_runtime,
         }
     }
 
@@ -59,11 +63,15 @@ impl RunaHandler {
         work_unit: Option<String>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let session = SessionState::open_with_validator(
-            working_dir,
+            working_dir.clone(),
             config_override,
             work_unit,
             validate_session_step_output_types,
         )?;
+
+        let config = libagent::project::read_config(&working_dir, config_override)?;
+        let forge_runtime = runa_forge_compose::runtime_from_config(&config.forge)
+            .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
 
         Ok(Self {
             protocol: None,
@@ -75,6 +83,7 @@ impl RunaHandler {
             tools: Vec::new(),
             tool_schemas: HashMap::new(),
             session: Some(Mutex::new(session)),
+            forge_runtime,
         })
     }
 
@@ -84,11 +93,15 @@ impl RunaHandler {
         ticket: libagent::TicketRef,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let session = SessionState::open_entry(
-            working_dir,
+            working_dir.clone(),
             config_override,
             ticket,
             validate_session_step_output_types,
         )?;
+
+        let config = libagent::project::read_config(&working_dir, config_override)?;
+        let forge_runtime = runa_forge_compose::runtime_from_config(&config.forge)
+            .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
 
         Ok(Self {
             protocol: None,
@@ -100,6 +113,24 @@ impl RunaHandler {
             tools: Vec::new(),
             tool_schemas: HashMap::new(),
             session: Some(Mutex::new(session)),
+            forge_runtime,
+        })
+    }
+
+    fn call_forge_tool(
+        &self,
+        tool_name: &str,
+        input: Value,
+    ) -> Option<Result<CallToolResult, McpError>> {
+        let runtime = self.forge_runtime.as_ref()?;
+        if !runtime.tools.contains_key(tool_name) {
+            return None;
+        }
+        Some(match runtime.call_tool(tool_name, input) {
+            Ok(payload) => json_tool_result_with_content(&payload).map(|(result, _)| result),
+            Err(error) => Ok(CallToolResult::error(vec![Content::text(
+                error.to_string(),
+            )])),
         })
     }
 
@@ -107,7 +138,7 @@ impl RunaHandler {
         &self,
         session: &Mutex<SessionState>,
         tool_name: &str,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         match tool_name {
@@ -539,6 +570,50 @@ fn driver_tools() -> Vec<Tool> {
     ]
 }
 
+fn forge_tools(runtime: Option<&ForgeRuntime>) -> Vec<Tool> {
+    let Some(runtime) = runtime else {
+        return Vec::new();
+    };
+    runtime
+        .tools
+        .values()
+        .map(|tool| {
+            Tool::new(
+                tool.exposed_name.clone(),
+                format!(
+                    "Execute forge operation {}",
+                    tool.operation.canonical_name()
+                ),
+                json_object_schema(&tool.input_schema),
+            )
+            .with_raw_output_schema(Arc::new(json_object_schema(&tool.output_schema)))
+        })
+        .collect()
+}
+
+fn append_forge_tools(tools: &mut Vec<Tool>, runtime: Option<&ForgeRuntime>) -> Result<(), String> {
+    let mut names = tools
+        .iter()
+        .map(|tool| tool.name.to_string())
+        .collect::<std::collections::BTreeSet<_>>();
+    for tool in forge_tools(runtime) {
+        let name = tool.name.to_string();
+        if !names.insert(name.clone()) {
+            return Err(format!(
+                "tool name collision while composing MCP surface: {name}"
+            ));
+        }
+        tools.push(tool);
+    }
+    Ok(())
+}
+
+fn json_object_schema(schema: &Value) -> serde_json::Map<String, Value> {
+    schema.as_object().cloned().unwrap_or_else(|| {
+        serde_json::Map::from_iter([("type".to_string(), Value::String("object".to_string()))])
+    })
+}
+
 fn validate_session_step_output_types(
     protocol: Option<&ProtocolDeclaration>,
     store: &ArtifactStore,
@@ -776,43 +851,47 @@ impl ServerHandler for RunaHandler {
         } else {
             ServerCapabilities::builder().enable_tools().build()
         };
-        ServerInfo {
-            protocol_version: ProtocolVersion::default(),
-            capabilities,
-            server_info: Implementation {
-                name: "runa-mcp".into(),
-                version: libagent::version().into(),
-            },
-            instructions: Some(instructions),
-        }
+        ServerInfo::new(capabilities)
+            .with_protocol_version(ProtocolVersion::default())
+            .with_server_info(Implementation::new("runa-mcp", libagent::version()))
+            .with_instructions(instructions)
     }
 
     async fn list_tools(
         &self,
-        _request: Option<PaginatedRequestParam>,
+        _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         if let Some(session) = &self.session {
             let session = session.lock().unwrap();
-            let (tools, _) = session_tools_and_schemas(&session)
+            let (mut tools, _) = session_tools_and_schemas(&session)
                 .map_err(|error| McpError::internal_error(error, None))?;
-            return Ok(ListToolsResult {
-                next_cursor: None,
-                tools,
-            });
+            append_forge_tools(&mut tools, self.forge_runtime.as_ref())
+                .map_err(|error| McpError::internal_error(error, None))?;
+            return Ok(ListToolsResult::with_all_items(tools));
         }
-        Ok(ListToolsResult {
-            next_cursor: None,
-            tools: self.tools.clone(),
-        })
+        let mut tools = self.tools.clone();
+        append_forge_tools(&mut tools, self.forge_runtime.as_ref())
+            .map_err(|error| McpError::internal_error(error, None))?;
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
         &self,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let tool_name = request.name.to_string();
+        if let Some(result) = self.call_forge_tool(
+            &tool_name,
+            request
+                .arguments
+                .as_ref()
+                .map(|arguments| Value::Object(arguments.clone()))
+                .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
+        ) {
+            return result;
+        }
         if let Some(session) = &self.session {
             return self
                 .call_session_tool(session, &tool_name, request, context)
@@ -1090,6 +1169,7 @@ mod tests {
             Some("wu-1".into()),
             store,
             tmp.path().join("workspace"),
+            None,
         );
 
         // Only output types become tools, not requires.
@@ -1152,7 +1232,7 @@ mod tests {
             instructions: None,
         };
 
-        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"));
+        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"), None);
         let tool_names = handler
             .tools
             .iter()
@@ -1187,7 +1267,7 @@ mod tests {
             instructions: None,
         };
 
-        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"));
+        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"), None);
         let info = handler.get_info();
 
         assert_eq!(
@@ -1240,7 +1320,7 @@ mod tests {
             instructions: None,
         };
 
-        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"));
+        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"), None);
 
         // Non-object may_produce schema silently excluded; object produces included.
         assert_eq!(handler.tools.len(), 1);
@@ -1296,6 +1376,7 @@ mod tests {
             Some("wu-1".into()),
             store,
             tmp.path().join("workspace"),
+            None,
         );
 
         // implementation included; composed may_produce silently excluded.
@@ -1341,7 +1422,7 @@ mod tests {
             instructions: None,
         };
 
-        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"));
+        let handler = RunaHandler::new(protocol, None, store, tmp.path().join("workspace"), None);
 
         // All output types use composition → all excluded.
         assert!(handler.tools.is_empty());
@@ -1583,6 +1664,7 @@ mod tests {
             None, // unscoped
             store,
             tmp.path().join("workspace"),
+            None,
         );
 
         // Only "output" should be a tool; "scoped_output" filtered out.

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -61,17 +61,21 @@ impl RunaHandler {
         working_dir: PathBuf,
         config_override: Option<&Path>,
         work_unit: Option<String>,
+        identity: libagent::ResolvedForgeIdentity,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let session = SessionState::open_with_validator(
+        let session = SessionState::open_with_validator_and_identity(
             working_dir.clone(),
             config_override,
             work_unit,
+            identity.clone(),
             validate_session_step_output_types,
         )?;
 
-        let config = libagent::project::read_config(&working_dir, config_override)?;
-        let forge_runtime = runa_forge_compose::runtime_from_config(&config.forge)
-            .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
+        let forge_runtime = runa_forge_compose::runtime_from_config_with_identity(
+            &session.loaded.config.forge,
+            &identity,
+        )
+        .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
 
         Ok(Self {
             protocol: None,
@@ -91,17 +95,21 @@ impl RunaHandler {
         working_dir: PathBuf,
         config_override: Option<&Path>,
         ticket: libagent::TicketRef,
+        identity: libagent::ResolvedForgeIdentity,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let session = SessionState::open_entry(
+        let session = SessionState::open_entry_with_identity(
             working_dir.clone(),
             config_override,
             ticket,
+            identity.clone(),
             validate_session_step_output_types,
         )?;
 
-        let config = libagent::project::read_config(&working_dir, config_override)?;
-        let forge_runtime = runa_forge_compose::runtime_from_config(&config.forge)
-            .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
+        let forge_runtime = runa_forge_compose::runtime_from_config_with_identity(
+            &session.loaded.config.forge,
+            &identity,
+        )
+        .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
 
         Ok(Self {
             protocol: None,

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -493,12 +493,13 @@ fn write_session_advance_receipt(payload: &libagent::AdvanceOutcome) -> std::io:
 fn json_tool_result_with_content(
     payload: &impl serde::Serialize,
 ) -> Result<(CallToolResult, String), McpError> {
-    let json = serde_json::to_string_pretty(payload)
+    let structured_content = serde_json::to_value(payload)
         .map_err(|error| McpError::internal_error(error.to_string(), None))?;
-    Ok((
-        CallToolResult::success(vec![Content::text(json.clone())]),
-        json,
-    ))
+    let json = serde_json::to_string_pretty(&structured_content)
+        .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+    let mut result = CallToolResult::success(vec![Content::text(json.clone())]);
+    result.structured_content = Some(structured_content);
+    Ok((result, json))
 }
 
 async fn complete_session_transition<T: serde::Serialize>(
@@ -1207,6 +1208,27 @@ mod tests {
         assert!(validate_instance_id("path\\traversal").is_err());
         assert!(validate_instance_id("..").is_err());
         assert!(validate_instance_id("").is_err());
+    }
+
+    #[test]
+    fn json_tool_result_with_content_returns_structured_content_for_schema_aware_clients() {
+        let payload = json!({
+            "handle": {
+                "id": "github:tesserine/runa:issue:203",
+                "display": "tesserine/runa#203"
+            },
+            "title": "Structured forge",
+            "body": "Schema-aware client payload",
+            "state": "open"
+        });
+
+        let (result, content) = json_tool_result_with_content(&payload).unwrap();
+
+        assert_eq!(result.structured_content.as_ref(), Some(&payload));
+        assert!(
+            content.contains("Structured forge"),
+            "transcript content should retain JSON text: {content}"
+        );
     }
 
     #[test]

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -126,12 +126,57 @@ impl RunaHandler {
         if !runtime.tools.contains_key(tool_name) {
             return None;
         }
-        Some(match runtime.call_tool(tool_name, input) {
-            Ok(payload) => json_tool_result_with_content(&payload).map(|(result, _)| result),
-            Err(error) => Ok(CallToolResult::error(vec![Content::text(
-                error.to_string(),
-            )])),
-        })
+        let (protocol, work_unit) = self.transcript_context();
+        if let Err(error) = append_tool_event_with_context(
+            "tool_call",
+            protocol.as_deref(),
+            work_unit.as_deref(),
+            tool_name,
+            Some(input.clone()),
+            None,
+        ) {
+            return Some(Err(error));
+        }
+        Some((|| match runtime.call_tool(tool_name, input) {
+            Ok(payload) => {
+                let (result, content) = json_tool_result_with_content(&payload)?;
+                append_tool_event_with_context(
+                    "tool_result",
+                    protocol.as_deref(),
+                    work_unit.as_deref(),
+                    tool_name,
+                    None,
+                    Some(&content),
+                )?;
+                Ok(result)
+            }
+            Err(error) => {
+                let message = error.to_string();
+                append_tool_event_with_context(
+                    "tool_result",
+                    protocol.as_deref(),
+                    work_unit.as_deref(),
+                    tool_name,
+                    None,
+                    Some(&message),
+                )?;
+                Ok(CallToolResult::error(vec![Content::text(message)]))
+            }
+        })())
+    }
+
+    fn transcript_context(&self) -> (Option<String>, Option<String>) {
+        if let Some(session) = &self.session {
+            let current_step = session.lock().unwrap().current_step().cloned();
+            return (
+                current_step.as_ref().map(|step| step.protocol.clone()),
+                current_step.and_then(|step| step.work_unit),
+            );
+        }
+        (
+            self.protocol.as_ref().map(|protocol| protocol.name.clone()),
+            self.work_unit.clone(),
+        )
     }
 
     async fn call_session_tool(

--- a/runa-mcp/src/handler.rs
+++ b/runa-mcp/src/handler.rs
@@ -27,7 +27,7 @@ pub struct RunaHandler {
     /// Maps artifact type name → full JSON Schema (with work_unit intact).
     tool_schemas: HashMap<String, Value>,
     session: Option<Mutex<SessionState>>,
-    forge_runtime: Option<ForgeRuntime>,
+    forge_runtime: Option<Arc<ForgeRuntime>>,
 }
 
 struct HandlerState {
@@ -53,7 +53,7 @@ impl RunaHandler {
             tools,
             tool_schemas,
             session: None,
-            forge_runtime,
+            forge_runtime: forge_runtime.map(Arc::new),
         }
     }
 
@@ -87,7 +87,7 @@ impl RunaHandler {
             tools: Vec::new(),
             tool_schemas: HashMap::new(),
             session: Some(Mutex::new(session)),
-            forge_runtime,
+            forge_runtime: forge_runtime.map(Arc::new),
         })
     }
 
@@ -121,50 +121,67 @@ impl RunaHandler {
             tools: Vec::new(),
             tool_schemas: HashMap::new(),
             session: Some(Mutex::new(session)),
-            forge_runtime,
+            forge_runtime: forge_runtime.map(Arc::new),
         })
     }
 
-    fn call_forge_tool(
+    async fn call_forge_tool(
         &self,
         tool_name: &str,
         input: Value,
     ) -> Option<Result<CallToolResult, McpError>> {
-        let runtime = self.forge_runtime.as_ref()?;
+        let runtime = self.forge_runtime.as_ref()?.clone();
         if !runtime.tools.contains_key(tool_name) {
             return None;
         }
         let (protocol, work_unit) = self.transcript_context();
+        let tool_name = tool_name.to_string();
         if let Err(error) = append_tool_event_with_context(
             "tool_call",
             protocol.as_deref(),
             work_unit.as_deref(),
-            tool_name,
+            &tool_name,
             Some(input.clone()),
             None,
         ) {
             return Some(Err(error));
         }
-        Some((|| match runtime.call_tool(tool_name, input) {
-            Ok(payload) => {
+        let dispatch_tool_name = tool_name.clone();
+        let output =
+            tokio::task::spawn_blocking(move || runtime.call_tool(&dispatch_tool_name, input))
+                .await;
+        Some((|| match output {
+            Err(error) => {
+                let message = format!("forge dispatch task failed: {error}");
+                append_tool_event_with_context(
+                    "tool_result",
+                    protocol.as_deref(),
+                    work_unit.as_deref(),
+                    &tool_name,
+                    None,
+                    Some(&message),
+                )?;
+                Ok(CallToolResult::error(vec![Content::text(message)]))
+            }
+            Ok(Ok(payload)) => {
                 let (result, content) = json_tool_result_with_content(&payload)?;
                 append_tool_event_with_context(
                     "tool_result",
                     protocol.as_deref(),
                     work_unit.as_deref(),
-                    tool_name,
+                    &tool_name,
                     None,
                     Some(&content),
                 )?;
                 Ok(result)
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 let message = error.to_string();
                 append_tool_event_with_context(
                     "tool_result",
                     protocol.as_deref(),
                     work_unit.as_deref(),
-                    tool_name,
+                    &tool_name,
                     None,
                     Some(&message),
                 )?;
@@ -943,12 +960,12 @@ impl ServerHandler for RunaHandler {
             let session = session.lock().unwrap();
             let (mut tools, _) = session_tools_and_schemas(&session)
                 .map_err(|error| McpError::internal_error(error, None))?;
-            append_forge_tools(&mut tools, self.forge_runtime.as_ref())
+            append_forge_tools(&mut tools, self.forge_runtime.as_deref())
                 .map_err(|error| McpError::internal_error(error, None))?;
             return Ok(ListToolsResult::with_all_items(tools));
         }
         let mut tools = self.tools.clone();
-        append_forge_tools(&mut tools, self.forge_runtime.as_ref())
+        append_forge_tools(&mut tools, self.forge_runtime.as_deref())
             .map_err(|error| McpError::internal_error(error, None))?;
         Ok(ListToolsResult::with_all_items(tools))
     }
@@ -962,14 +979,17 @@ impl ServerHandler for RunaHandler {
         if let Some(message) = self.forge_tool_collision_message(&tool_name)? {
             return Ok(CallToolResult::error(vec![Content::text(message)]));
         }
-        if let Some(result) = self.call_forge_tool(
-            &tool_name,
-            request
-                .arguments
-                .as_ref()
-                .map(|arguments| Value::Object(arguments.clone()))
-                .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
-        ) {
+        if let Some(result) = self
+            .call_forge_tool(
+                &tool_name,
+                request
+                    .arguments
+                    .as_ref()
+                    .map(|arguments| Value::Object(arguments.clone()))
+                    .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
+            )
+            .await
+        {
             return result;
         }
         if let Some(session) = &self.session {

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -67,18 +67,27 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let mut loaded = project::load(&working_dir, config_ref)?;
     apply_transcript_settings(&working_dir, &loaded.config);
     libagent::scan(&loaded.workspace_dir, &mut loaded.store)?;
+    let identity = libagent::resolve_forge_identity(&loaded.config.forge);
     if let Some(work_unit) = cli.work_unit.as_deref() {
-        let identity = libagent::resolve_forge_identity(&loaded.config.forge);
         libagent::validate_scoped_work_unit_with_identity(&loaded.store, work_unit, &identity)?;
     }
     if cli.session {
         let handler = match cli.ticket.as_deref() {
             Some(ticket) => {
-                let identity = libagent::resolve_forge_identity(&loaded.config.forge);
                 let ticket_ref = libagent::resolve_ticket_reference(ticket, &identity)?;
-                RunaHandler::new_session_entry(working_dir.clone(), config_ref, ticket_ref)?
+                RunaHandler::new_session_entry(
+                    working_dir.clone(),
+                    config_ref,
+                    ticket_ref,
+                    identity.clone(),
+                )?
             }
-            None => RunaHandler::new_session(working_dir.clone(), config_ref, cli.work_unit)?,
+            None => RunaHandler::new_session(
+                working_dir.clone(),
+                config_ref,
+                cli.work_unit,
+                identity.clone(),
+            )?,
         };
         let (stdin, stdout) = io::stdio();
         let service = handler.serve((stdin, stdout)).await.inspect_err(|e| {
@@ -131,8 +140,9 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         "serving protocol"
     );
 
-    let forge_runtime = runa_forge_compose::runtime_from_config(&loaded.config.forge)
-        .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
+    let forge_runtime =
+        runa_forge_compose::runtime_from_config_with_identity(&loaded.config.forge, &identity)
+            .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
 
     let handler = RunaHandler::new(
         protocol.clone(),

--- a/runa-mcp/src/main.rs
+++ b/runa-mcp/src/main.rs
@@ -131,11 +131,15 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         "serving protocol"
     );
 
+    let forge_runtime = runa_forge_compose::runtime_from_config(&loaded.config.forge)
+        .map_err(|error| format!("failed to compose forge connector tools: {error}"))?;
+
     let handler = RunaHandler::new(
         protocol.clone(),
         cli.work_unit.clone(),
         loaded.store,
         loaded.workspace_dir.clone(),
+        forge_runtime,
     );
 
     let (stdin, stdout) = io::stdio();

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -1985,6 +1985,59 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
 }
 
 #[tokio::test]
+async fn forge_tool_calls_append_transcript_events_when_enabled() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+    let transcript_dir = dir.path().join("transcript");
+    append_github_forge_config(&project_dir, "tesserine", "runa");
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("implement")
+                        .arg("--work-unit")
+                        .arg("wu-1")
+                        .env("RUNA_TRANSCRIPT_DIR", &transcript_dir)
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    service
+        .call_tool(tool_call(
+            "read-ticket",
+            serde_json::json!({ "reference": "tesserine/groundwork#203" }),
+        ))
+        .await
+        .unwrap();
+
+    let events = if transcript_dir.exists() {
+        read_transcript_events(&transcript_dir)
+    } else {
+        String::new()
+    };
+    assert!(
+        events.contains(r#""kind":"tool_call","protocol":"implement","work_unit":"wu-1","tool_name":"read-ticket""#),
+        "missing forge tool_call transcript event: {events}"
+    );
+    assert!(
+        events.contains(r#""kind":"tool_result","protocol":"implement","work_unit":"wu-1","tool_name":"read-ticket""#),
+        "missing forge tool_result transcript event: {events}"
+    );
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn session_driver_calls_append_transcript_events_when_enabled() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_methodology(

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -275,6 +275,23 @@ fn append_github_forge_config(project_dir: &Path, owner: &str, name: &str) {
     .unwrap();
 }
 
+fn append_github_forge_config_with_api(
+    project_dir: &Path,
+    owner: &str,
+    name: &str,
+    api_base: &str,
+) {
+    let config_path = project_dir.join(".runa/config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap();
+    fs::write(
+        config_path,
+        format!(
+            "{existing}\n[forge]\ntype = \"github\"\nowner = \"{owner}\"\nname = \"{name}\"\napi_base = \"{api_base}\"\n",
+        ),
+    )
+    .unwrap();
+}
+
 fn append_transcript_config(project_dir: &Path, transcript_dir: &Path) {
     let config_path = project_dir.join(".runa/config.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
@@ -1797,6 +1814,75 @@ async fn mcp_accepts_tracker_backed_work_unit_with_forge_identity_only_in_config
     assert!(
         read_ticket.output_schema.is_some(),
         "forge connector tools should advertise output schemas"
+    );
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn mcp_forge_connector_uses_resolved_override_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_methodology(
+        dir.path(),
+        scoped_work_unit_manifest_toml(),
+        &scoped_work_unit_schemas(),
+        &["take"],
+    );
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    append_github_forge_config_with_api(
+        &project_dir,
+        "stale-owner",
+        "stale-repo",
+        "http://127.0.0.1:1",
+    );
+
+    let workspace = project_dir.join(".runa/workspace");
+    fs::create_dir_all(workspace.join("work-unit")).unwrap();
+    fs::write(
+        workspace.join("work-unit/work-unit-163.json"),
+        r#"{"title":"Scope","description":"Enforce canonical scope","acceptance_criteria":["Reject aliases"],"handle":{"forge_tag":"github","url":"https://github.com/override-owner/override-repo/issues/163","number":163}}"#,
+    )
+    .unwrap();
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("take")
+                        .arg("--work-unit")
+                        .arg("work-unit-163")
+                        .env("RUNA_FORGE_TYPE", "github")
+                        .env("RUNA_FORGE_OWNER", "override-owner")
+                        .env("RUNA_FORGE_NAME", "override-repo")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let tools = service.list_all_tools().await.unwrap();
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "read-ticket"),
+        "forge connector tools should be advertised"
+    );
+
+    let result = service
+        .call_tool(tool_call(
+            "read-ticket",
+            serde_json::json!({ "reference": "stale-owner/stale-repo#203" }),
+        ))
+        .await
+        .unwrap();
+    let text = tool_result_text(&result);
+    assert!(
+        text.contains("foreign scope") && text.contains("override-owner/override-repo"),
+        "stale file-config identity should not be accepted: {text}"
     );
 
     service.cancel().await.unwrap();

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -1,7 +1,10 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use rmcp::ClientHandler;
@@ -313,6 +316,18 @@ fn append_github_forge_config_with_api(
     .unwrap();
 }
 
+fn append_sourcehut_forge_config_with_api(project_dir: &Path, tracker_id: &str, api_base: &str) {
+    let config_path = project_dir.join(".runa/config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap();
+    fs::write(
+        config_path,
+        format!(
+            "{existing}\n[forge]\ntype = \"sourcehut\"\ntracker_id = \"{tracker_id}\"\napi_base = \"{api_base}\"\n",
+        ),
+    )
+    .unwrap();
+}
+
 fn append_transcript_config(project_dir: &Path, transcript_dir: &Path) {
     let config_path = project_dir.join(".runa/config.toml");
     let existing = fs::read_to_string(&config_path).unwrap();
@@ -389,6 +404,32 @@ fn canonical_forge_tool_names() -> Vec<&'static str> {
         "record-progress",
         "reflect-disposition",
     ]
+}
+
+fn one_shot_json_server<F>(
+    body: &'static str,
+    assert_request: F,
+) -> (String, thread::JoinHandle<()>)
+where
+    F: FnOnce(&str) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let size = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..size]);
+        assert_request(&request);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}"), server)
 }
 
 #[tokio::test]
@@ -1964,6 +2005,116 @@ async fn mcp_forge_connector_uses_resolved_override_identity() {
     );
 
     service.cancel().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mcp_github_forge_tool_dispatches_production_transport_without_blocking_runtime_panic() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+    let (api_base, server) = one_shot_json_server(
+        r#"{"number":203,"title":"MCP GitHub title","body":"MCP body","state":"open"}"#,
+        |request| {
+            assert!(
+                request.starts_with("GET /repos/tesserine/runa/issues/203 "),
+                "unexpected GitHub request: {request}"
+            );
+        },
+    );
+    append_github_forge_config_with_api(&project_dir, "tesserine", "runa", &api_base);
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("implement")
+                        .arg("--work-unit")
+                        .arg("wu-1")
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        service.call_tool(tool_call(
+            "read-ticket",
+            serde_json::json!({ "reference": "203" }),
+        )),
+    )
+    .await
+    .expect("MCP call should return before the timeout")
+    .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&tool_result_text(&result)).unwrap();
+    assert_eq!(payload["title"], "MCP GitHub title");
+    assert_eq!(payload["handle"]["id"], "github:tesserine/runa:issue:203");
+
+    service.cancel().await.unwrap();
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mcp_sourcehut_forge_tool_dispatches_production_transport_without_blocking_runtime_panic() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+    let (api_base, server) = one_shot_json_server(
+        r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"MCP SourceHut title","body":"MCP body","status":"REPORTED"}}}}"#,
+        |request| {
+            assert!(
+                request.starts_with("POST /query "),
+                "unexpected SourceHut request: {request}"
+            );
+            assert!(
+                request.contains(r#""tracker":"4""#),
+                "request should target configured tracker: {request}"
+            );
+        },
+    );
+    append_sourcehut_forge_config_with_api(&project_dir, "4", &format!("{api_base}/query"));
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("implement")
+                        .arg("--work-unit")
+                        .arg("wu-1")
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        service.call_tool(tool_call(
+            "read-ticket",
+            serde_json::json!({ "reference": "203" }),
+        )),
+    )
+    .await
+    .expect("MCP call should return before the timeout")
+    .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&tool_result_text(&result)).unwrap();
+    assert_eq!(payload["title"], "MCP SourceHut title");
+    assert_eq!(payload["handle"]["id"], "sourcehut:tracker:4:ticket:203");
+
+    service.cancel().await.unwrap();
+    server.join().unwrap();
 }
 
 #[tokio::test]

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -2064,19 +2064,55 @@ async fn mcp_github_forge_tool_dispatches_production_transport_without_blocking_
 async fn mcp_sourcehut_forge_tool_dispatches_production_transport_without_blocking_runtime_panic() {
     let dir = setup_project();
     let project_dir = dir.path().join("project");
-    let (api_base, server) = one_shot_json_server(
-        r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"MCP SourceHut title","body":"MCP body","status":"REPORTED"}}}}"#,
-        |request| {
+    let tracker_rid = "06fdktpsb5w8q09e22xy0m6fnr";
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let responses = [
+            (
+                r#"{"data":{"trackers":{"results":[{"id":4,"rid":"06fdktpsb5w8q09e22xy0m6fnr","name":"runa"}],"cursor":null}}}"#,
+                "trackers",
+            ),
+            (
+                r#"{"data":{"tracker":{"ticket":{"id":203,"subject":"MCP SourceHut title","body":"MCP body","status":"REPORTED"}}}}"#,
+                "ticket",
+            ),
+        ];
+        for (body, expected) in responses {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
             assert!(
                 request.starts_with("POST /query "),
                 "unexpected SourceHut request: {request}"
             );
-            assert!(
-                request.contains(r#""tracker":"4""#),
-                "request should target configured tracker: {request}"
-            );
-        },
-    );
+            match expected {
+                "trackers" => {
+                    assert!(request.contains("trackers"), "request: {request}");
+                }
+                "ticket" => {
+                    assert!(
+                        request.contains(&format!(r#""tracker":"{tracker_rid}""#)),
+                        "request should target resolved tracker rid: {request}"
+                    );
+                    assert!(
+                        !request.contains(r#""tracker":"4""#),
+                        "request should not use numeric tracker id as rid: {request}"
+                    );
+                }
+                _ => unreachable!(),
+            }
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
+    });
+    let api_base = format!("http://{address}");
     append_sourcehut_forge_config_with_api(&project_dir, "4", &format!("{api_base}/query"));
 
     let service = ()

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::ClientHandler;
-use rmcp::model::{CallToolRequestParam, CallToolResult};
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::ServiceExt;
 use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
 use tokio::process::Command;
@@ -327,11 +327,30 @@ fn tool_result_text(result: &CallToolResult) -> String {
         .clone()
 }
 
-fn session_call(name: &str) -> CallToolRequestParam {
-    CallToolRequestParam {
-        name: name.to_string().into(),
-        arguments: Some(serde_json::Map::new()),
-    }
+fn session_call(name: &str) -> CallToolRequestParams {
+    CallToolRequestParams::new(name.to_string())
+}
+
+fn tool_call(name: &str, arguments: serde_json::Value) -> CallToolRequestParams {
+    CallToolRequestParams::new(name.to_string()).with_arguments(
+        arguments
+            .as_object()
+            .expect("tool arguments must be an object")
+            .clone(),
+    )
+}
+
+fn canonical_forge_tool_names() -> Vec<&'static str> {
+    vec![
+        "apply-approved-change",
+        "claim-work-unit",
+        "close-out",
+        "create-ticket",
+        "deliver-change-proposal",
+        "read-ticket",
+        "record-progress",
+        "reflect-disposition",
+    ]
 }
 
 fn assert_no_execution_record_for(project_dir: &Path, protocol: &str) {
@@ -577,15 +596,13 @@ async fn session_record_read_advance_records_execution_for_producing_step() {
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -676,15 +693,13 @@ async fn session_advance_records_context_time_input_provenance() {
     .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     service.call_tool(session_call("advance")).await.unwrap();
@@ -761,15 +776,13 @@ async fn session_advance_reopens_current_step_when_context_input_changes() {
     )
     .unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -851,15 +864,13 @@ async fn session_advance_reopens_current_step_when_readiness_consumes_context_in
     .unwrap();
     service.call_tool(session_call("readiness")).await.unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -915,15 +926,13 @@ async fn session_advance_emits_tool_list_changed_when_current_step_changes() {
     .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -976,15 +985,13 @@ async fn session_advance_reconciles_deleted_output_before_recording_execution() 
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     fs::remove_file(workspace.join("claim/claim-1.json")).unwrap();
@@ -1059,15 +1066,13 @@ async fn session_advance_rejects_deleted_required_input_before_downstream_select
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     fs::remove_file(workspace.join("work-unit/work-unit-166.json")).unwrap();
@@ -1340,15 +1345,13 @@ async fn session_advance_error_preserves_current_step_when_next_step_is_unservab
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -1422,15 +1425,13 @@ async fn session_advance_persistence_error_preserves_current_step_and_no_record(
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     let execution_record_path = project_dir.join(".runa/store/execution-records.json");
@@ -1778,8 +1779,25 @@ async fn mcp_accepts_tracker_backed_work_unit_with_forge_identity_only_in_config
         .unwrap();
 
     let tools = service.list_all_tools().await.unwrap();
-    assert_eq!(tools.len(), 1);
-    assert_eq!(tools[0].name.as_ref(), "claim");
+    let mut tool_names = tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+    tool_names.sort_unstable();
+
+    let mut expected_names = vec!["claim"];
+    expected_names.extend(canonical_forge_tool_names());
+    expected_names.sort_unstable();
+    assert_eq!(tool_names, expected_names);
+
+    let read_ticket = tools
+        .iter()
+        .find(|tool| tool.name.as_ref() == "read-ticket")
+        .expect("read-ticket connector tool should be advertised");
+    assert!(
+        read_ticket.output_schema.is_some(),
+        "forge connector tools should advertise output schemas"
+    );
 
     service.cancel().await.unwrap();
 }
@@ -1849,15 +1867,13 @@ async fn scoped_protocol_writes_artifact_with_injected_work_unit() {
     assert_eq!(tools[0].name.as_ref(), "implementation");
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -1894,15 +1910,13 @@ async fn tool_calls_append_transcript_events_when_enabled() {
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -1935,6 +1949,10 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
                         .arg("wu-1")
                         .env_remove("RUNA_TRANSCRIPT_DIR")
                         .env_remove("RUNA_TRANSCRIPT_REDACT_ENV")
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
                         .current_dir(&project_dir);
                 }),
             )
@@ -1944,15 +1962,13 @@ async fn tool_calls_append_transcript_events_from_config_when_environment_is_uns
         .unwrap();
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -2016,15 +2032,13 @@ async fn session_driver_calls_append_transcript_events_when_enabled() {
         .await
         .unwrap();
     service
-        .call_tool(CallToolRequestParam {
-            name: "claim".to_string().into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "claim",
+            serde_json::json!({
                 "instance_id": "claim-1",
                 "scope": "claim this work"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
     service.call_tool(session_call("advance")).await.unwrap();
@@ -2159,15 +2173,13 @@ trigger = { type = "on_change", name = "implementation" }
     assert_eq!(tools[0].name.as_ref(), "implementation");
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 
@@ -2234,15 +2246,13 @@ trigger = { type = "on_change", name = "implementation" }
     assert!(!tool_properties.contains_key("work_unit"));
 
     service
-        .call_tool(CallToolRequestParam {
-            name: "implementation".into(),
-            arguments: serde_json::json!({
+        .call_tool(tool_call(
+            "implementation",
+            serde_json::json!({
                 "instance_id": "impl-1",
                 "title": "ship it"
-            })
-            .as_object()
-            .cloned(),
-        })
+            }),
+        ))
         .await
         .unwrap();
 

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -62,6 +62,27 @@ trigger = { type = "on_change", name = "implementation" }
 "#
 }
 
+fn forge_collision_manifest_toml() -> &'static str {
+    r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "read-ticket"
+
+[[protocols]]
+name = "take"
+produces = ["read-ticket"]
+trigger = { type = "on_change", name = "read-ticket" }
+"#
+}
+
+fn forge_collision_schemas() -> Vec<(&'static str, &'static str)> {
+    vec![(
+        "read-ticket",
+        r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+    )]
+}
+
 fn methodology_schemas() -> Vec<(&'static str, &'static str)> {
     vec![
         (
@@ -368,6 +389,63 @@ fn canonical_forge_tool_names() -> Vec<&'static str> {
         "record-progress",
         "reflect-disposition",
     ]
+}
+
+#[tokio::test]
+async fn call_tool_rejects_forge_artifact_name_collision_before_dispatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_methodology(
+        dir.path(),
+        forge_collision_manifest_toml(),
+        &forge_collision_schemas(),
+        &["take"],
+    );
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    append_github_forge_config(&project_dir, "tesserine", "runa");
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("take")
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let result = service
+        .call_tool(tool_call(
+            "read-ticket",
+            serde_json::json!({
+                "instance_id": "artifact-1",
+                "title": "must not dispatch to forge"
+            }),
+        ))
+        .await
+        .unwrap();
+    let text = tool_result_text(&result);
+    assert!(
+        text.contains("tool name collision") && text.contains("read-ticket"),
+        "colliding tool name should be rejected before forge dispatch: {text}"
+    );
+    assert!(
+        !project_dir
+            .join(".runa/workspace/read-ticket/artifact-1.json")
+            .exists(),
+        "colliding call must not write an artifact"
+    );
+
+    service.cancel().await.unwrap();
 }
 
 fn assert_no_execution_record_for(project_dir: &Path, protocol: &str) {

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -1967,6 +1967,63 @@ async fn mcp_forge_connector_uses_resolved_override_identity() {
 }
 
 #[tokio::test]
+async fn mcp_rejects_forge_input_missing_advertised_required_field_before_dispatch() {
+    let dir = setup_project();
+    let project_dir = dir.path().join("project");
+    append_github_forge_config_with_api(&project_dir, "tesserine", "runa", "http://127.0.0.1:9");
+
+    let service = ()
+        .serve(
+            TokioChildProcess::new(
+                Command::new(env!("CARGO_BIN_EXE_runa-mcp")).configure(|cmd| {
+                    cmd.arg("--protocol")
+                        .arg("implement")
+                        .arg("--work-unit")
+                        .arg("wu-1")
+                        .env_remove("RUNA_FORGE_TYPE")
+                        .env_remove("RUNA_FORGE_OWNER")
+                        .env_remove("RUNA_FORGE_NAME")
+                        .env_remove("RUNA_FORGE_TRACKER_ID")
+                        .current_dir(&project_dir);
+                }),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let result = service
+        .call_tool(tool_call(
+            "apply-approved-change",
+            serde_json::json!({
+                "work_unit": {
+                    "id": "github:tesserine/runa:issue:203",
+                    "display": "tesserine/runa#203"
+                },
+                "change": {
+                    "id": "github:tesserine/runa:pull:12:version:1",
+                    "display": "tesserine/runa#12"
+                },
+                "approved_commit": "abc123",
+                "base": "main"
+            }),
+        ))
+        .await
+        .unwrap();
+    let text = tool_result_text(&result);
+    assert!(
+        text.contains("approved_version") && text.contains("advertised schema"),
+        "missing required field should be rejected by the MCP surface schema guard: {text}"
+    );
+    assert!(
+        !text.contains("transport error"),
+        "schema rejection must happen before provider transport dispatch: {text}"
+    );
+
+    service.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn mcp_rejects_exact_tracker_backed_work_unit_with_number_disagreement() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_methodology(


### PR DESCRIPTION
## Summary
- adds provider-neutral forge contract and composition crates for the canonical work-unit lifecycle tools
- implements GitHub and SourceHut forge connectors with scoped request construction, credential resolution, and local HTTP harness coverage
- fixes SourceHut ticket lifecycle operations to use the published todo.sr.ht GraphQL schema: `tracker(...).ticket(...)`, `submitTicket(trackerId:, input:)`, `submitComment`, and `updateTicketStatus`
- adds non-gated SourceHut GraphQL proof by validating harness requests against vendored SourceHut SDL and rejecting fields/mutations the real provider does not expose
- rejects forge/methodology output tool-name collisions before MCP call dispatch reaches a forge provider
- documents connector configuration, including GitHub claim assignee configuration

## Verification
- cargo test --workspace
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings

## Remaining Land Gate
- AC8 real-provider round-trip against real WeForge/SourceHut on babbie-dev remains separate, per issue guidance
