### PR TITLE
chore(adr): withdraw ADR-0002 (runa wish unsound); re-home request→intent rename to commons#94

### DIFF
--- a/docs/architecture/decisions/0001-single-state-assess-and-route-operation.md
+++ b/docs/architecture/decisions/0001-single-state-assess-and-route-operation.md
@@ -1,6 +1,6 @@
 # ADR-0001 — The single state-assess-and-route operation (request as entry-state)
 
-- **Status:** Accepted — 2026-06-30; all six decisions settled. Implementation decomposes from this ADR. **Decisions 3 and 5 superseded in part by [ADR-0002](0002-operator-intent-seeding-wish.md).**
+- **Status:** Accepted — 2026-06-30; all six decisions settled. Implementation decomposes from this ADR. (ADR-0002 was withdrawn 2026-06-30; it claimed to supersede Decisions 3 and 5, but that supersession is void. **Decision 3 stands in full.** Decision 5's v2 *shape* stands; only the artifact *name* changes, under the `request` → `intent` rename re-homed to `tesserine/commons#94` and sequenced after `babbie-ops#67`.)
 - **Date:** 2026-06-28
 - **Deciders:** Robbie and the governance station.
 - **Spike:** [#210](https://github.com/tesserine/runa/issues/210) · **Epic:** [#167](https://github.com/tesserine/runa/issues/167) (dual-mode).

--- a/docs/architecture/decisions/0002-operator-intent-seeding-wish.md
+++ b/docs/architecture/decisions/0002-operator-intent-seeding-wish.md
@@ -1,7 +1,49 @@
 # ADR-0002 — Operator intent seeding: `wish` authors, `go` advances
 
-**Status:** Proposed
-**Supersedes (in part):** [ADR-0001](0001-single-state-assess-and-route-operation.md) — Decision 3 (command structure) and Decision 5 (request artifact shape), on the points named below.
+**Status:** Withdrawn — 2026-06-30. Decision A (`runa wish`) is unsound and never reached Accepted; see the withdrawal note below.
+**Supersedes:** nothing. The supersession this ADR claimed over ADR-0001 Decisions 3 and 5 is void — Decision 3 stands in full; Decision 5's shape stands and its rename is carried elsewhere (below).
+
+## Withdrawal note (2026-06-30)
+
+This ADR is withdrawn. Its organizing decision — **Decision A**, that the operator
+`wish` gesture is a **`runa` verb** — is unsound against the substrate, and the ADR
+has no remaining reason to exist as a runa decision once that falls.
+
+**Why Decision A is void.** `runa`'s entire command surface (`Init`, `List`,
+`Doctor`, `Scan`, `State`, `Step`, `Run`, `Go`) operates only on artifacts that
+*already exist*: it scans, validates, computes readiness, and advances. It carries
+no model and authors no content; even its cold-start path (`go --ticket`) performs
+no forge read of its own and hands materialization to the methodology. A verb that
+greets an operator, elicits prose intent, and authors a `{description, source}`
+seed is the one capability runa's architecture defines it as *not* having. This
+ADR's own Context conceded runa "validates artifacts, it doesn't author intent" —
+and then had it author intent. That is the contradiction.
+
+**Where the work actually lives.** The operator `wish` gesture belongs to
+**`agentd`** — the session launcher, which already lowers operator intent into a
+conforming seed (`agentd-runner` `resolve_invocation_input`, arm
+`InvocationInput::RequestText`: takes `description`, stamps `source: operator`,
+validates against the methodology's request schema, seeds the session). It is
+tracked by **`tesserine/agentd#152`** (`agentd wish`).
+
+**The one sound thing this ADR identified — the rename — is carried forward, not
+lost.** Decision B (rename the entry artifact `request` → `intent`) is a real and
+necessary change, but it is an artifact decision **owned by `tesserine/commons`**
+(the artifact's home), not a runa ADR concern. It is re-homed to **`tesserine/commons#94`**
+and sequenced *after* the `babbie-ops#67` integration test (it does not gate it).
+
+**Effect on ADR-0001.** Nothing is superseded. Decision 3 (single outer verb
+`go`; seeding is data) stands in full — the matured-surface framing that would have
+superseded it is void. Decision 5's v2 *shape* stands; only the artifact *name*
+changes, under the commons rename above.
+
+The body below is retained as the historical record of the withdrawn proposal. It
+does not govern.
+
+---
+
+**Original status (superseded by this withdrawal):** Proposed
+**Originally claimed to supersede (in part):** [ADR-0001](0001-single-state-assess-and-route-operation.md) — Decision 3 (command structure) and Decision 5 (request artifact shape). *Both claims void; see withdrawal note above.*
 
 ## Lineage
 

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -14,13 +14,17 @@ canonical home, `pentaxis93/principles`. An ADR **cites** those sources as what
 it realizes; it does not restate them (Single Home).
 
 Records are numbered sequentially (`NNNN-kebab-title.md`) and never renumbered.
-Status is one of **Proposed**, **Accepted**, or **Superseded** (naming the ADR
-that supersedes it).
+Status is one of **Proposed**, **Accepted**, **Superseded** (naming the ADR
+that supersedes it), or **Withdrawn** (a proposal found unsound before it was
+accepted — nothing supersedes it; the withdrawal note states why).
 
 ## Index
 
 - [ADR-0001](0001-single-state-assess-and-route-operation.md) — The single
   state-assess-and-route operation (request as entry-state) — *Accepted*
-  (Decisions 3 & 5 superseded in part by ADR-0002)
+  (Decision 3 stands in full; Decision 5's shape stands, its artifact name changing
+  under the `request` → `intent` rename re-homed to `tesserine/commons#94`)
 - [ADR-0002](0002-operator-intent-seeding-wish.md) — Operator intent seeding:
-  `wish` authors, `go` advances — *Proposed*
+  `wish` authors, `go` advances — *Withdrawn* (Decision A unsound: `wish` is an
+  `agentd` verb, not runa — `tesserine/agentd#152`; the `request` → `intent` rename
+  it identified is re-homed to `tesserine/commons#94`)


### PR DESCRIPTION
Records a governance decision already made and grounded against both components' code.

**Finding.** ADR-0002 Decision A placed the operator `wish` gesture as a **runa** verb. Grounding runa's actual command surface (`Init, List, Doctor, Scan, State, Step, Run, Go` — every verb operates on already-existing artifacts; no model, no authoring) shows this is unsound: authoring operator intent is the one capability runa's architecture defines it as *not* having. The `wish` gesture belongs to **agentd** (the session launcher, whose `resolve_invocation_input` already synthesizes a conforming seed from operator text) — tracked by `tesserine/agentd#152`.

**Changes (docs only):**
- **ADR-0002** → *Withdrawn* (a proposal found unsound before acceptance). A withdrawal note records why Decision A is void, where the work actually lives (agentd#152), and that the body is retained only as historical record.
- **ADR-0001** → supersession annotation corrected: the claimed supersession of Decisions 3 & 5 is void. **Decision 3 stands in full**; Decision 5's v2 *shape* stands, only the artifact *name* changes.
- **Decision B (the one sound part of ADR-0002 — `request`→`intent` rename)** is re-homed to its owning repo as **`tesserine/commons#94`**, sequenced *after* `babbie-ops#67` (it does not gate the integration test).
- **ADR README** status enum extended with *Withdrawn*.

Context: closes the loop on `tesserine/runa#214` (closed superseded-by-grounding) and the `babbie-ops#67` full-stack reframe.