### PR TITLE
[codex] align entry seed references with intent

### DIFF
--- a/docs/session-surface-contract.md
+++ b/docs/session-surface-contract.md
@@ -170,7 +170,7 @@ remove a gate.
 
 The operator holds intent authority. Operator intent enters once at the session
 seed through the canonical commons
-[request artifact](https://github.com/tesserine/commons/blob/main/REQUEST.md)
+[intent artifact](https://github.com/tesserine/commons/blob/main/INTENT.md)
 and the direction declared from it, such as Groundwork `take` session direction.
 The operator may alter or withdraw that intent, and the session must regenerate
 from the changed seed. The operator is not inserted as an approver of each

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -985,15 +985,15 @@ trigger = { type = "on_artifact", name = "work-unit" }
         write_entry_project_with_acquisition_requires(dir, materialize, false)
     }
 
-    /// `acquisition_requires_request` declares an unmet `requires` on the
+    /// `acquisition_requires_intent` declares an unmet `requires` on the
     /// acquisition surface so its preconditions block at cold-start entry.
     fn write_entry_project_with_acquisition_requires(
         dir: &Path,
         materialize: bool,
-        acquisition_requires_request: bool,
+        acquisition_requires_intent: bool,
     ) -> PathBuf {
-        let decompose_requires = if acquisition_requires_request {
-            "requires = [\"request\"]\n"
+        let decompose_requires = if acquisition_requires_intent {
+            "requires = [\"intent\"]\n"
         } else {
             ""
         };
@@ -1005,7 +1005,7 @@ name = "groundwork"
 name = "work-unit"
 
 [[artifact_types]]
-name = "request"
+name = "intent"
 
 [[artifact_types]]
 name = "claim"
@@ -1014,7 +1014,7 @@ name = "claim"
 name = "decompose"
 {decompose_requires}produces = ["work-unit"]
 scoped = false
-trigger = {{ type = "on_artifact", name = "request" }}
+trigger = {{ type = "on_artifact", name = "intent" }}
 
 [[protocols]]
 name = "take"
@@ -1033,7 +1033,7 @@ trigger = {{ type = "on_artifact", name = "work-unit" }}
                     r#"{"type":"object","required":["title","handle"],"properties":{"title":{"type":"string"},"handle":{"type":"object"}}}"#,
                 ),
                 (
-                    "request",
+                    "intent",
                     r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
                 ),
                 (
@@ -1128,8 +1128,18 @@ trigger = { type = "on_artifact", name = "work-unit" }
         }
     }
 
+    fn unset_forge_env() -> crate::test_helpers::EnvGuard {
+        crate::test_helpers::EnvGuard::unset(&[
+            "RUNA_FORGE_TYPE",
+            "RUNA_FORGE_OWNER",
+            "RUNA_FORGE_NAME",
+            "RUNA_FORGE_TRACKER_ID",
+        ])
+    }
+
     #[test]
     fn open_entry_cold_pins_acquisition_step() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         let project_dir = write_entry_project(dir.path(), false);
 
@@ -1144,6 +1154,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn open_entry_re_entry_binds_without_acquisition_surface() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         // No unscoped work-unit producer exists, but the work-unit is already
         // recorded: re-entry must degrade to a bound session rather than fail on
@@ -1160,6 +1171,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn open_entry_cold_without_acquisition_surface_is_error() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         // No work-unit recorded and no acquisition surface: a cold start has no
         // way to acquire, so discovery fails.
@@ -1177,6 +1189,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn open_entry_blocks_when_acquisition_preconditions_unmet() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         // decompose requires an absent `request`; entry substitutes only the
         // trigger, so the unmet precondition must still block.
@@ -1189,6 +1202,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn open_entry_binds_immediately_when_work_unit_exists() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         let project_dir = write_entry_project(dir.path(), true);
 
@@ -1203,6 +1217,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn advance_from_acquisition_binds_and_selects_take() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         let project_dir = write_entry_project(dir.path(), false);
         let mut session =
@@ -1230,6 +1245,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn advance_restores_promised_scope_when_post_bind_commit_fails() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         let project_dir = write_entry_project(dir.path(), false);
         let mut session =
@@ -1269,6 +1285,7 @@ trigger = { type = "on_artifact", name = "work-unit" }
 
     #[test]
     fn advance_without_materialized_work_unit_is_unresolved() {
+        let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
         let project_dir = write_entry_project(dir.path(), false);
         let mut session =

--- a/runa-cli/tests/entry.rs
+++ b/runa-cli/tests/entry.rs
@@ -610,13 +610,13 @@ fn run_ticket_reports_success_when_acquisition_is_the_only_work() {
     assert!(stdout.contains("Run outcome: success"), "stdout: {stdout}");
 }
 
-/// The acquisition triggers on `request` (which it does not require); the ticket
+/// The acquisition triggers on `intent` (which it does not require); the ticket
 /// substitutes that trigger.
 const TRIGGER_ONLY_ENTRY_MANIFEST: &str = r#"
 name = "groundwork"
 
 [[artifact_types]]
-name = "request"
+name = "intent"
 
 [[artifact_types]]
 name = "work-unit"
@@ -628,7 +628,7 @@ name = "claim"
 name = "decompose"
 produces = ["work-unit"]
 scoped = false
-trigger = { type = "on_artifact", name = "request" }
+trigger = { type = "on_artifact", name = "intent" }
 
 [[protocols]]
 name = "take"
@@ -644,7 +644,7 @@ fn setup_trigger_only_entry_project(dir: &Path) -> PathBuf {
         TRIGGER_ONLY_ENTRY_MANIFEST,
         &[
             (
-                "request",
+                "intent",
                 r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
             ),
             (
@@ -669,11 +669,11 @@ fn setup_trigger_only_entry_project(dir: &Path) -> PathBuf {
 fn run_ticket_admits_acquisition_when_only_trigger_type_partially_scanned() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = setup_trigger_only_entry_project(dir.path());
-    // An unreadable `request` (the substituted trigger type, not a required
+    // An unreadable `intent` (the substituted trigger type, not a required
     // input) leaves it only partially scanned.
-    let request_dir = project_dir.join(".runa/workspace/request");
-    fs::create_dir_all(&request_dir).unwrap();
-    let unreadable = request_dir.join("hidden.json");
+    let intent_dir = project_dir.join(".runa/workspace/intent");
+    fs::create_dir_all(&intent_dir).unwrap();
+    let unreadable = intent_dir.join("hidden.json");
     fs::write(&unreadable, r#"{"title":"hidden"}"#).unwrap();
     fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
 


### PR DESCRIPTION
## Summary

- Update runa canonical session entry-seed references from the commons request artifact to the intent artifact.
- Adjust ticket-entry fixtures that model the substituted canonical trigger.
- Isolate libagent entry tests from ambient RUNA_FORGE_* overrides while preserving config-backed identity checks.

## Validation

- cargo test -p libagent session::tests::open_entry
- cargo test -p libagent session::tests::advance
- cargo test -p runa-cli --test entry ticket
- cargo test -p runa-cli --test entry run_ticket_admits_acquisition_when_only_trigger_type_partially_scanned
- cargo test -p runa-cli --test state state_marks_trigger_and_requires_ready_when_a_valid_sibling_exists
- cargo test -p runa-cli --test doctor doctor_reports_mixed_validity_artifacts_without_blocking_readiness

Refs tesserine/commons#94.
