### PR TITLE
feat(forge): read-ticket returns the ticket comment log — v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- **`read-ticket` returns the ticket comment log** per forge-capability
+  `1.2.0` (tesserine/commons#100; contract constants re-pinned to
+  `commons@b229fb1`): the ticket snapshot carries an optional ordered
+  `comments` log — entries `{body, author?, created_at?}`, oldest first —
+  declared in the contract crate's emitted operation schemas
+  (`comment-entry` `$def`), mapped from GitHub issue comments and SourceHut
+  comment-kind ticket events with per-provider normalization to ascending
+  timestamp order, inherited absent-or-empty by `create-ticket`'s output,
+  and gated by provider conformance tests that validate returned snapshots
+  against the emitted `read-ticket` output schema with and without
+  comments (a zero-comment ticket yields an empty or absent log, never an
+  error).
+
 ### Changed
 
 - Transcript capture now treats `[transcript].dir` and `RUNA_TRANSCRIPT_DIR`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,7 @@ dependencies = [
 name = "runa-forge-github"
 version = "0.2.0-rc.1"
 dependencies = [
+ "jsonschema",
  "reqwest",
  "runa-forge-contract",
  "serde",
@@ -1742,6 +1743,7 @@ name = "runa-forge-sourcehut"
 version = "0.2.0-rc.1"
 dependencies = [
  "apollo-compiler",
+ "jsonschema",
  "reqwest",
  "runa-forge-contract",
  "serde",

--- a/runa-forge-compose/tests/compose.rs
+++ b/runa-forge-compose/tests/compose.rs
@@ -99,8 +99,10 @@ fn github_connector_coordinates_follow_resolved_env_identity() {
         ("RUNA_FORGE_OWNER", "override-owner"),
         ("RUNA_FORGE_NAME", "override-repo"),
     ]);
-    let (api_base, request_capture, server) =
-        http_json_server(r#"{"number":203,"title":"Override","body":"body","state":"open"}"#);
+    let (api_base, request_capture, server) = http_json_sequence_server(&[
+        r#"{"number":203,"title":"Override","body":"body","state":"open"}"#,
+        r#"[]"#,
+    ]);
 
     let runtime = runtime_from_config(&ForgeConfig {
         forge_type: Some("github".to_string()),
@@ -120,6 +122,8 @@ fn github_connector_coordinates_follow_resolved_env_identity() {
         request_capture
             .lock()
             .unwrap()
+            .first()
+            .expect("issue request should be captured")
             .starts_with("GET /repos/override-owner/override-repo/issues/203 ")
     );
     assert_eq!(

--- a/runa-forge-contract/src/lib.rs
+++ b/runa-forge-contract/src/lib.rs
@@ -4,8 +4,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 pub const CAPABILITY_NAME: &str = "forge";
-pub const CAPABILITY_VERSION: &str = "1.1.0";
-pub const COMMONS_PROVENANCE: &str = "commons@6924159fc4ff58745f0e2c68ed16849ffd9b4086";
+pub const CAPABILITY_VERSION: &str = "1.2.0";
+pub const COMMONS_PROVENANCE: &str = "commons@b229fb1a840c27ced31d582b40d766f4f441dcf6";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -227,6 +227,16 @@ fn schema_document((required, properties): (Vec<&str>, BTreeMap<&str, Value>)) -
         "additionalProperties": false,
         "properties": properties,
         "$defs": {
+            "comment-entry": {
+                "type": "object",
+                "required": ["body"],
+                "additionalProperties": false,
+                "properties": {
+                    "body": { "type": "string", "minLength": 1 },
+                    "author": { "type": "string", "minLength": 1 },
+                    "created_at": { "type": "string", "minLength": 1 }
+                }
+            },
             "handle": {
                 "type": "object",
                 "required": ["id", "display"],
@@ -371,6 +381,13 @@ fn operation_output_properties(
             properties.insert("title", string_schema());
             properties.insert("body", serde_json::json!({ "type": ["string", "null"] }));
             properties.insert("state", string_schema());
+            properties.insert(
+                "comments",
+                serde_json::json!({
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/comment-entry" }
+                }),
+            );
             (vec!["handle", "title", "state"], properties)
         }
         Operation::ClaimWorkUnit | Operation::RecordProgress | Operation::CloseOut => {

--- a/runa-forge-contract/tests/contract.rs
+++ b/runa-forge-contract/tests/contract.rs
@@ -1,13 +1,13 @@
 use jsonschema::Validator;
 use runa_forge_contract::{
-    CompositionError, Operation, canonical_forge_tool_set, compose_tool_sets,
-    operation_input_schema, operation_output_schema, validate_tool_set,
+    CAPABILITY_VERSION, COMMONS_PROVENANCE, CompositionError, Operation, canonical_forge_tool_set,
+    compose_tool_sets, operation_input_schema, operation_output_schema, validate_tool_set,
 };
 use serde_json::json;
 use std::collections::HashMap;
 
 #[test]
-fn canonical_tool_set_exposes_all_v1_1_operations() {
+fn canonical_tool_set_exposes_all_v1_operations() {
     let set = canonical_forge_tool_set("github");
 
     validate_tool_set(&set).unwrap();
@@ -89,6 +89,55 @@ fn composition_accepts_role_qualified_aliases() {
     assert!(composed.contains_key("read-ticket"));
     assert!(composed.contains_key("work-unit-read-ticket"));
     assert_eq!(composed.len(), 16);
+}
+
+#[test]
+fn capability_constants_pin_the_canonical_version() {
+    assert_eq!(CAPABILITY_VERSION, "1.2.0");
+    assert_eq!(
+        COMMONS_PROVENANCE,
+        "commons@b229fb1a840c27ced31d582b40d766f4f441dcf6"
+    );
+}
+
+#[test]
+fn read_ticket_output_schema_admits_and_bounds_the_comment_log() {
+    let schema = operation_output_schema(Operation::ReadTicket);
+    let validator = Validator::options().build(&schema).unwrap();
+    let handle = json!({"id": "github:tesserine/runa:issue:228", "display": "tesserine/runa#228"});
+
+    let without_log = json!({
+        "handle": handle, "title": "unit", "body": "spec", "state": "open"
+    });
+    let empty_log = json!({
+        "handle": handle, "title": "unit", "body": null, "state": "open", "comments": []
+    });
+    let with_log = json!({
+        "handle": handle, "title": "unit", "body": "spec", "state": "open",
+        "comments": [
+            {"body": "freshen record"},
+            {"body": "review directive", "author": "operator", "created_at": "2026-07-02T10:53:26Z"}
+        ]
+    });
+    for snapshot in [&without_log, &empty_log, &with_log] {
+        assert!(
+            validator.is_valid(snapshot),
+            "snapshot should validate: {snapshot}"
+        );
+    }
+
+    let rejected = [
+        json!({"handle": handle, "title": "unit", "state": "open", "comments": "first!"}),
+        json!({"handle": handle, "title": "unit", "state": "open", "comments": [{"author": "operator"}]}),
+        json!({"handle": handle, "title": "unit", "state": "open", "comments": [{"body": ""}]}),
+        json!({"handle": handle, "title": "unit", "state": "open", "comments": [{"body": "x", "reactions": 3}]}),
+    ];
+    for snapshot in &rejected {
+        assert!(
+            !validator.is_valid(snapshot),
+            "snapshot should be rejected: {snapshot}"
+        );
+    }
 }
 
 #[test]

--- a/runa-forge-github/Cargo.toml
+++ b/runa-forge-github/Cargo.toml
@@ -9,3 +9,6 @@ runa-forge-contract.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
+
+[dev-dependencies]
+jsonschema.workspace = true

--- a/runa-forge-github/src/lib.rs
+++ b/runa-forge-github/src/lib.rs
@@ -90,6 +90,10 @@ impl GithubRecordingTransport {
         transport
     }
 
+    pub fn push_response(&self, response: Value) {
+        self.responses.lock().unwrap().push_back(response);
+    }
+
     pub fn requests(&self) -> Vec<ProviderRequest> {
         self.requests.lock().unwrap().clone()
     }
@@ -232,7 +236,17 @@ impl<T: GithubTransport> GithubConnector<T> {
             ),
             None,
         )?;
-        self.ticket_snapshot(number, &response)
+        let comments = self.send(
+            "GET",
+            format!(
+                "/repos/{}/{}/issues/{number}/comments",
+                self.config.owner, self.config.repo
+            ),
+            None,
+        )?;
+        let mut snapshot = self.ticket_snapshot(number, &response)?;
+        snapshot["comments"] = Value::Array(comment_entries(&comments)?);
+        Ok(snapshot)
     }
 
     fn create_ticket(&self, input: Value) -> Result<Value, ForgeError> {
@@ -505,6 +519,47 @@ impl<T: GithubTransport> GithubConnector<T> {
             "handle '{handle}' is not a GitHub pull handle"
         )))
     }
+}
+
+fn comment_entries(response: &Value) -> Result<Vec<Value>, ForgeError> {
+    let Some(items) = response.as_array() else {
+        return Err(ForgeError::ProviderResponse(
+            "issue comments response is not an array".into(),
+        ));
+    };
+    let mut entries: Vec<(String, Value)> = Vec::new();
+    for item in items {
+        let Some(body) = item
+            .get("body")
+            .and_then(Value::as_str)
+            .filter(|body| !body.is_empty())
+        else {
+            continue;
+        };
+        let mut entry = serde_json::Map::new();
+        entry.insert("body".into(), Value::String(body.to_string()));
+        if let Some(author) = item
+            .get("user")
+            .and_then(|user| user.get("login"))
+            .and_then(Value::as_str)
+            .filter(|login| !login.is_empty())
+        {
+            entry.insert("author".into(), Value::String(author.to_string()));
+        }
+        let created_at = item
+            .get("created_at")
+            .and_then(Value::as_str)
+            .filter(|created| !created.is_empty());
+        if let Some(created) = created_at {
+            entry.insert("created_at".into(), Value::String(created.to_string()));
+        }
+        entries.push((
+            created_at.unwrap_or_default().to_string(),
+            Value::Object(entry),
+        ));
+    }
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    Ok(entries.into_iter().map(|(_, entry)| entry).collect())
 }
 
 fn required_string<'a>(input: &'a Value, field: &str) -> Result<&'a str, ForgeError> {

--- a/runa-forge-github/tests/github.rs
+++ b/runa-forge-github/tests/github.rs
@@ -1,4 +1,5 @@
-use runa_forge_contract::Operation;
+use jsonschema::Validator;
+use runa_forge_contract::{Operation, operation_output_schema};
 use runa_forge_github::{
     GithubConfig, GithubConnector, GithubHttpTransport, GithubRecordingTransport, ProviderRequest,
 };
@@ -85,6 +86,118 @@ fn assert_github_user_agent(request: &str) {
 
 #[test]
 fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
+    for reference in [
+        "github:tesserine/runa#203",
+        "tesserine/runa#203",
+        "#203",
+        "203",
+    ] {
+        let transport = GithubRecordingTransport::default();
+        transport.push_response(json!({
+            "number": 203,
+            "title": "Forge connectors",
+            "body": "body",
+            "state": "open"
+        }));
+        transport.push_response(json!([]));
+        let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+        let output = connector
+            .call(Operation::ReadTicket, json!({ "reference": reference }))
+            .unwrap();
+
+        assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
+        assert_eq!(output["title"], "Forge connectors");
+    }
+}
+
+#[test]
+fn read_ticket_returns_the_comment_log_ordered_oldest_first_and_schema_valid() {
+    let transport = GithubRecordingTransport::default();
+    transport.push_response(json!({
+        "number": 203,
+        "title": "Forge connectors",
+        "body": "body",
+        "state": "open"
+    }));
+    transport.push_response(json!([
+        {
+            "body": "Review round 2: required correction.",
+            "user": { "login": "operator" },
+            "created_at": "2026-07-02T12:00:00Z"
+        },
+        {
+            "body": "Freshen pass — grounded at head.",
+            "user": { "login": "governance" },
+            "created_at": "2026-07-02T10:00:00Z"
+        },
+        {
+            "body": "Plan approved.",
+            "user": { "login": "operator" },
+            "created_at": "2026-07-02T11:00:00Z"
+        }
+    ]));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert_eq!(
+        output["comments"],
+        json!([
+            {
+                "body": "Freshen pass — grounded at head.",
+                "author": "governance",
+                "created_at": "2026-07-02T10:00:00Z"
+            },
+            {
+                "body": "Plan approved.",
+                "author": "operator",
+                "created_at": "2026-07-02T11:00:00Z"
+            },
+            {
+                "body": "Review round 2: required correction.",
+                "author": "operator",
+                "created_at": "2026-07-02T12:00:00Z"
+            }
+        ])
+    );
+    let schema = operation_output_schema(Operation::ReadTicket);
+    let validator = Validator::options().build(&schema).unwrap();
+    assert!(
+        validator.is_valid(&output),
+        "snapshot should validate: {output}"
+    );
+}
+
+#[test]
+fn read_ticket_with_zero_provider_comments_yields_an_empty_log() {
+    let transport = GithubRecordingTransport::default();
+    transport.push_response(json!({
+        "number": 203,
+        "title": "Forge connectors",
+        "body": "body",
+        "state": "open"
+    }));
+    transport.push_response(json!([]));
+    let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
+
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert_eq!(output["comments"], json!([]));
+    let schema = operation_output_schema(Operation::ReadTicket);
+    let validator = Validator::options().build(&schema).unwrap();
+    assert!(
+        validator.is_valid(&output),
+        "snapshot should validate: {output}"
+    );
+}
+
+#[test]
+fn create_ticket_snapshot_carries_no_comment_log() {
     let transport = GithubRecordingTransport::with_repeating_response(json!({
         "number": 203,
         "title": "Forge connectors",
@@ -93,19 +206,14 @@ fn read_ticket_accepts_deployment_reference_forms_and_issues_scoped_handles() {
     }));
     let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
 
-    for reference in [
-        "github:tesserine/runa#203",
-        "tesserine/runa#203",
-        "#203",
-        "203",
-    ] {
-        let output = connector
-            .call(Operation::ReadTicket, json!({ "reference": reference }))
-            .unwrap();
+    let output = connector
+        .call(
+            Operation::CreateTicket,
+            json!({ "title": "title", "body": "body" }),
+        )
+        .unwrap();
 
-        assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
-        assert_eq!(output["title"], "Forge connectors");
-    }
+    assert!(output.get("comments").is_none());
 }
 
 #[test]
@@ -145,6 +253,13 @@ fn every_operation_constructs_the_expected_provider_request() {
     }));
     let connector = GithubConnector::new(config("https://api.github.test"), transport.clone());
 
+    transport.push_response(json!({
+        "number": 203,
+        "title": "Forge connectors",
+        "body": "body",
+        "state": "open"
+    }));
+    transport.push_response(json!([]));
     let cases = [
         (Operation::ReadTicket, json!({"reference": "203"})),
         (
@@ -180,6 +295,7 @@ fn every_operation_constructs_the_expected_provider_request() {
 
     let expected_requests = [
         ("GET", "/repos/tesserine/runa/issues/203"),
+        ("GET", "/repos/tesserine/runa/issues/203/comments"),
         ("POST", "/repos/tesserine/runa/issues"),
         ("POST", "/repos/tesserine/runa/issues/203/assignees"),
         ("POST", "/repos/tesserine/runa/issues/203/comments"),
@@ -196,7 +312,7 @@ fn every_operation_constructs_the_expected_provider_request() {
         assert_eq!(request.method, method);
         assert_eq!(request.path, path);
     }
-    assert_eq!(requests[9].body, Some(json!({ "state": "closed" })));
+    assert_eq!(requests[10].body, Some(json!({ "state": "closed" })));
 }
 
 #[test]
@@ -382,20 +498,31 @@ fn production_http_transport_executes_and_parses_read_ticket() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
     let server = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
-        let mut request = [0_u8; 2048];
-        let size = stream.read(&mut request).unwrap();
-        let request = String::from_utf8_lossy(&request[..size]);
-        assert!(request.starts_with("GET /repos/tesserine/runa/issues/203 "));
-        assert_github_user_agent(&request);
-        let body = r#"{"number":203,"title":"Harness title","body":"Harness body","state":"open"}"#;
-        write!(
-            stream,
-            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
-            body.len(),
-            body
-        )
-        .unwrap();
+        let responses = [
+            (
+                "GET /repos/tesserine/runa/issues/203 ",
+                r#"{"number":203,"title":"Harness title","body":"Harness body","state":"open"}"#,
+            ),
+            (
+                "GET /repos/tesserine/runa/issues/203/comments ",
+                r#"[{"body":"Harness comment","user":{"login":"operator"},"created_at":"2026-07-02T10:00:00Z"}]"#,
+            ),
+        ];
+        for (prefix, body) in responses {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let size = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
+            assert!(request.starts_with(prefix), "unexpected request: {request}");
+            assert_github_user_agent(&request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
     });
 
     let connector = GithubConnector::new(config(&format!("http://{address}")), GithubHttpTransport);
@@ -405,6 +532,14 @@ fn production_http_transport_executes_and_parses_read_ticket() {
 
     assert_eq!(output["title"], "Harness title");
     assert_eq!(output["handle"]["id"], "github:tesserine/runa:issue:203");
+    assert_eq!(
+        output["comments"],
+        json!([{
+            "body": "Harness comment",
+            "author": "operator",
+            "created_at": "2026-07-02T10:00:00Z"
+        }])
+    );
     server.join().unwrap();
 }
 
@@ -418,6 +553,7 @@ fn production_http_transport_executes_and_parses_every_operation() {
             "/repos/tesserine/runa/issues/203",
             r#"{"number":203,"title":"Harness read","body":"Harness body","state":"open"}"#,
         ),
+        ("GET", "/repos/tesserine/runa/issues/203/comments", r#"[]"#),
         (
             "POST",
             "/repos/tesserine/runa/issues",

--- a/runa-forge-sourcehut/Cargo.toml
+++ b/runa-forge-sourcehut/Cargo.toml
@@ -12,4 +12,5 @@ reqwest.workspace = true
 
 [dev-dependencies]
 apollo-compiler.workspace = true
+jsonschema.workspace = true
 tempfile.workspace = true

--- a/runa-forge-sourcehut/src/lib.rs
+++ b/runa-forge-sourcehut/src/lib.rs
@@ -313,13 +313,15 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
         let tracker_rid = self.tracker_rid()?;
         let response = self.graphql(
             "ticket",
-            "query ticket($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { id rid name ticket(id: $id) { id subject body status } } }",
+            "query ticket($tracker: ID!, $id: Int!) { tracker(rid: $tracker) { id rid name ticket(id: $id) { id subject body status events { results { created changes { ... on Comment { text author { canonicalName } } } } } } } }",
             json!({ "id": number, "tracker": tracker_rid }),
         )?;
-        self.ticket_snapshot(
-            number,
-            required_provider_object(&response, "/data/tracker/ticket", "ticket")?,
-        )
+        let ticket = required_provider_object(&response, "/data/tracker/ticket", "ticket")?;
+        let mut snapshot = self.ticket_snapshot(number, ticket)?;
+        if let Some(entries) = comment_entries(ticket) {
+            snapshot["comments"] = Value::Array(entries);
+        }
+        Ok(snapshot)
     }
 
     fn create_ticket(&self, input: Value) -> Result<Value, ForgeError> {
@@ -587,6 +589,48 @@ impl<T: SourcehutTransport> SourcehutConnector<T> {
             "handle '{handle}' is not a SourceHut change handle"
         )))
     }
+}
+
+fn comment_entries(ticket: &Value) -> Option<Vec<Value>> {
+    let results = ticket.get("events")?.get("results")?.as_array()?;
+    let mut entries: Vec<(String, Value)> = Vec::new();
+    for event in results {
+        let created = event
+            .get("created")
+            .and_then(Value::as_str)
+            .filter(|created| !created.is_empty());
+        let Some(changes) = event.get("changes").and_then(Value::as_array) else {
+            continue;
+        };
+        for change in changes {
+            let Some(text) = change
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            else {
+                continue;
+            };
+            let author = change
+                .get("author")
+                .and_then(|author| author.get("canonicalName"))
+                .and_then(Value::as_str)
+                .filter(|name| !name.is_empty());
+            let mut entry = serde_json::Map::new();
+            entry.insert("body".into(), Value::String(text.to_string()));
+            if let Some(author) = author {
+                entry.insert("author".into(), Value::String(author.to_string()));
+            }
+            if let Some(created) = created {
+                entry.insert("created_at".into(), Value::String(created.to_string()));
+            }
+            entries.push((
+                created.unwrap_or_default().to_string(),
+                Value::Object(entry),
+            ));
+        }
+    }
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    Some(entries.into_iter().map(|(_, entry)| entry).collect())
 }
 
 fn required_string<'a>(input: &'a Value, field: &str) -> Result<&'a str, ForgeError> {

--- a/runa-forge-sourcehut/tests/sourcehut.rs
+++ b/runa-forge-sourcehut/tests/sourcehut.rs
@@ -1,5 +1,6 @@
 use apollo_compiler::{ExecutableDocument, Schema};
-use runa_forge_contract::{ForgeError, Operation};
+use jsonschema::Validator;
+use runa_forge_contract::{ForgeError, Operation, operation_output_schema};
 use runa_forge_sourcehut::{
     ProviderRequest, SourcehutConfig, SourcehutConnector, SourcehutHttpTransport,
     SourcehutRecordingTransport, SourcehutTransport,
@@ -125,9 +126,16 @@ fn assert_graphql_request_validates(request: &str, expected_field: &str) {
 #[derive(Debug, Clone, Default)]
 struct SourcehutTrackerFakeTransport {
     requests: Arc<Mutex<Vec<ProviderRequest>>>,
+    ticket_events: Arc<Mutex<Option<Value>>>,
 }
 
 impl SourcehutTrackerFakeTransport {
+    fn with_ticket_events(events: Value) -> Self {
+        let transport = Self::default();
+        *transport.ticket_events.lock().unwrap() = Some(events);
+        transport
+    }
+
     fn requests(&self) -> Vec<ProviderRequest> {
         self.requests.lock().unwrap().clone()
     }
@@ -191,18 +199,22 @@ impl SourcehutTransport for SourcehutTrackerFakeTransport {
                         "errors": [{ "message": "tracker(rid:) requires an opaque resource id" }]
                     }));
                 }
+                let mut ticket = json!({
+                    "id": 203,
+                    "subject": "Forge connectors",
+                    "body": "body",
+                    "status": "REPORTED"
+                });
+                if let Some(events) = self.ticket_events.lock().unwrap().clone() {
+                    ticket["events"] = events;
+                }
                 Ok(json!({
                     "data": {
                         "tracker": {
                             "id": 4,
                             "rid": TRACKER_RID,
                             "name": "runa",
-                            "ticket": {
-                                "id": 203,
-                                "subject": "Forge connectors",
-                                "body": "body",
-                                "status": "REPORTED"
-                            }
+                            "ticket": ticket
                         }
                     }
                 }))
@@ -287,6 +299,98 @@ fn sourcehut_fake_rejects_numeric_tracker_id_as_tracker_rid() {
         .unwrap();
 
     assert!(response.get("errors").is_some(), "{response}");
+}
+
+#[test]
+fn read_ticket_returns_the_comment_log_ordered_oldest_first_and_schema_valid() {
+    let transport = SourcehutTrackerFakeTransport::with_ticket_events(json!({
+        "results": [
+            {
+                "created": "2026-07-02T12:00:00Z",
+                "changes": [ { "text": "Review round 2: required correction.", "author": { "canonicalName": "~operator" } } ]
+            },
+            {
+                "created": "2026-07-02T09:00:00Z",
+                "changes": [ {} ]
+            },
+            {
+                "created": "2026-07-02T10:00:00Z",
+                "changes": [ { "text": "Freshen pass — grounded at head.", "author": { "canonicalName": "~governance" } } ]
+            }
+        ]
+    }));
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert_eq!(
+        output["comments"],
+        json!([
+            {
+                "body": "Freshen pass — grounded at head.",
+                "author": "~governance",
+                "created_at": "2026-07-02T10:00:00Z"
+            },
+            {
+                "body": "Review round 2: required correction.",
+                "author": "~operator",
+                "created_at": "2026-07-02T12:00:00Z"
+            }
+        ])
+    );
+    let schema = operation_output_schema(Operation::ReadTicket);
+    let validator = Validator::options().build(&schema).unwrap();
+    assert!(
+        validator.is_valid(&output),
+        "snapshot should validate: {output}"
+    );
+}
+
+#[test]
+fn read_ticket_with_zero_comment_events_yields_an_empty_log() {
+    let transport = SourcehutTrackerFakeTransport::with_ticket_events(json!({ "results": [] }));
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert_eq!(output["comments"], json!([]));
+    let schema = operation_output_schema(Operation::ReadTicket);
+    let validator = Validator::options().build(&schema).unwrap();
+    assert!(
+        validator.is_valid(&output),
+        "snapshot should validate: {output}"
+    );
+}
+
+#[test]
+fn read_ticket_without_an_events_node_omits_the_log() {
+    let transport = SourcehutTrackerFakeTransport::default();
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let output = connector
+        .call(Operation::ReadTicket, json!({ "reference": "203" }))
+        .unwrap();
+
+    assert!(output.get("comments").is_none());
+}
+
+#[test]
+fn create_ticket_snapshot_carries_no_comment_log() {
+    let transport = SourcehutTrackerFakeTransport::default();
+    let connector = SourcehutConnector::new(config("https://todo.test/query"), transport.clone());
+
+    let output = connector
+        .call(
+            Operation::CreateTicket,
+            json!({ "title": "title", "body": "body" }),
+        )
+        .unwrap();
+
+    assert!(output.get("comments").is_none());
 }
 
 #[test]

--- a/runa-mcp/tests/stdio.rs
+++ b/runa-mcp/tests/stdio.rs
@@ -453,6 +453,37 @@ where
     (format!("http://{address}"), server)
 }
 
+fn json_sequence_server<F>(
+    bodies: &'static [&'static str],
+    assert_first_request: F,
+) -> (String, thread::JoinHandle<()>)
+where
+    F: FnOnce(&str) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let mut assert_first_request = Some(assert_first_request);
+        for body in bodies {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
+            if let Some(assert_request) = assert_first_request.take() {
+                assert_request(&request);
+            }
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
+    });
+    (format!("http://{address}"), server)
+}
+
 #[tokio::test]
 async fn call_tool_rejects_forge_artifact_name_collision_before_dispatch() {
     let dir = tempfile::tempdir().unwrap();
@@ -2032,8 +2063,11 @@ async fn mcp_forge_connector_uses_resolved_override_identity() {
 async fn mcp_github_forge_tool_dispatches_production_transport_without_blocking_runtime_panic() {
     let dir = setup_project();
     let project_dir = dir.path().join("project");
-    let (api_base, server) = one_shot_json_server(
-        r#"{"number":203,"title":"MCP GitHub title","body":"MCP body","state":"open"}"#,
+    let (api_base, server) = json_sequence_server(
+        &[
+            r#"{"number":203,"title":"MCP GitHub title","body":"MCP body","state":"open"}"#,
+            r#"[{"body":"MCP comment","user":{"login":"operator"},"created_at":"2026-07-02T10:00:00Z"}]"#,
+        ],
         |request| {
             assert!(
                 request.starts_with("GET /repos/tesserine/runa/issues/203 "),
@@ -2076,6 +2110,14 @@ async fn mcp_github_forge_tool_dispatches_production_transport_without_blocking_
     let payload: serde_json::Value = serde_json::from_str(&tool_result_text(&result)).unwrap();
     assert_eq!(payload["title"], "MCP GitHub title");
     assert_eq!(payload["handle"]["id"], "github:tesserine/runa:issue:203");
+    assert_eq!(
+        payload["comments"],
+        serde_json::json!([{
+            "body": "MCP comment",
+            "author": "operator",
+            "created_at": "2026-07-02T10:00:00Z"
+        }])
+    );
 
     service.cancel().await.unwrap();
     server.join().unwrap();


### PR DESCRIPTION
Implements tesserine/runa#228 — the final node of the comment-log set (commons#100 landed at `b229fb1`, groundwork#516 landed at `5af9a2d`).

The ticket body is the work-unit's spec; the comment log is its running record — review state, dispositions, and directives. `read-ticket` now returns that log per forge-capability `1.2.0`.

**Surfaces**
- **Contract crate** — constants re-pinned to `commons@b229fb1` (`CAPABILITY_VERSION` `1.2.0`); the emitted `read-ticket`/`create-ticket` output schema gains an optional `comments` array and a `comment-entry` `$def` (`body` required; `author`/`created_at` optional, each min-length 1).
- **GitHub connector** — `read_ticket` fetches issue comments and returns them oldest-first (`user.login` → `author`, `created_at` verbatim, empty bodies skipped); `create-ticket` carries no log.
- **SourceHut connector** — the ticket query gains comment-kind events (`changes { ... on Comment { text author { canonicalName } } }`); the snapshot carries the normalized log oldest-first; an absent `events` node omits the log. The query is validated against the vendored `todo.sr.ht` schema — the schema is the authority (author lives on `Comment`, not the event).
- **Tests** — returned snapshots validate against the emitted `read-ticket` output schema, with and without comments; a zero-comment ticket yields an empty or absent log, never an error; `capability_constants_pin_the_canonical_version` guards the pin.

**Blast radius** — extending the operation's provider round-trips broke every harness that pinned the old request sequence; all swept in one pass: recording-transport sequencing, both production HTTP harnesses, compose env-identity, and the MCP dispatch harness (now proving the log crosses the MCP boundary).

**Evidence** — at `c6e9371`: the merge gate `./scripts/release-check metadata` passes; `cargo fmt --check` clean; `cargo clippy --workspace` clean (0 diagnostics); every touched crate's suite green in isolation (`runa-forge-contract`, `-github`, `-sourcehut`, `-compose`, `runa-mcp`). Full-workspace `cargo test` has a 55-test failure set **identical to unmodified `main`** — all sandbox-environmental (network-binding, subprocess, and filesystem-preflight tests, none of which run on `pull_request`); this branch introduces zero new failures (verified by named-failure diff).

**Substrate note (not in this PR):** the init tests write scratch under `runa-cli/target/`, which the root `.gitignore` rule `/target` does not cover (it is anchored to root). Harmless to the repo and CI, but it dirties a local tree; a one-line ignore fix is worth its own micro-issue.