### PR TITLE
chore: ignore nested crate/test target dirs, not just workspace root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Rust build artifacts
-/target
+# Rust build artifacts (workspace root and any crate/test scratch dir)
+target/
 
 # Local runa project state (this repo is a Rust project, not a runa-managed one)
 /.runa/


### PR DESCRIPTION
Closes the hygiene gap noted in tesserine/runa#229: the root-anchored `/target` rule matched only the workspace build dir, so test scratch written under `runa-cli/target/` (the init tests' `init-relative-preflight-*` fixtures, created when they run with a relative working dir) escaped the ignore and showed up as untracked tree noise.

**Change** — one line: `/target` → `target/`. The unanchored form is the idiomatic cargo spelling; it matches a `target` directory at any depth (workspace root included) as a single rule, rather than accreting a second `runa-cli/target/` line.

**Verified** (via `git check-ignore`): root `target/` still ignored; `runa-cli/target/...` now ignored; a real source path (`runa-forge-github/src/lib.rs`) and a `target`-substring directory (`some_target/`) are both unaffected — the rule matches the exact path component only, files named `target` are not caught. No tracked file lives under any `target/` dir, so nothing currently in the repo is masked.

Pure hygiene, no behaviour or program-line change; not a roadmap node.