### PR TITLE
fix(exit-codes): classify agent-startup failure as infrastructure_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ Semantic Versioning.
 
 ### Fixed
 
+- `run` now reports a session whose agent **fails to start** — the agent
+  process exits without executing any protocol work or delivering any artifact
+  — as `infrastructure_failure` (6) rather than `work_failed` (5). The outcome
+  classification distinguishes the two from observable run state: a run that
+  recorded failures but attempted no work (no protocol reached `Succeeded` and
+  none ran to a postcondition check) is an infrastructure failure, while
+  `work_failed` remains reserved for work that ran and failed its completion
+  checks. Honest-Signal fix for the commons/EXIT-CODES.md contract, surfaced by
+  a session whose agent never authenticated (tesserine/runa#232).
 - Invariant-bearing modules now document their invariants at the code:
   `session.rs` opens with the session state-machine contract (state derives
   from artifacts, single current step, transactional `advance`,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -331,8 +331,8 @@ Without `--dry-run`, requires a Linux host plus an effective agent command. `run
 | 2 | Usage error, currently `--json` without `--dry-run`. |
 | 3 | Quiescent but work remains blocked, waiting, or trapped in a cycle. |
 | 4 | Nothing ready — live `run` did not dispatch any protocol because none were READY. |
-| 5 | Work was attempted, but one or more protocols failed or violated postconditions during the invocation. |
-| 6 | Infrastructure failure: project/config/load/scan/serialization/bootstrap/runtime failure prevented completion from being established. |
+| 5 | Work was attempted, but one or more protocols ran and failed or violated postconditions during the invocation. |
+| 6 | Infrastructure failure: an agent that failed to start (exited without executing any protocol work or delivering any artifact), or a project/config/load/scan/serialization/bootstrap/runtime failure, prevented completion from being established. |
 | 130 | Interrupted — `Ctrl-C` prevented the next candidate from starting. |
 
 ### `runa go`

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -26,6 +26,13 @@ pub enum RunOutcome {
     NothingReady,
     QuiescentFailures,
     QuiescentBlocked,
+    /// The run recorded failures but attempted no protocol work: every failure
+    /// was an agent that could not start (no `Succeeded`, no
+    /// `PostconditionFailure`). The execution substrate failed before any
+    /// completion could be established, so this is an infrastructure failure —
+    /// distinct from `QuiescentFailures`, which is work that ran and failed its
+    /// completion checks. See commons/EXIT-CODES.md and tesserine/runa#232.
+    AgentStartupFailure,
     Interrupted,
 }
 
@@ -43,6 +50,7 @@ impl RunOutcome {
             RunOutcome::NothingReady => ExitCode::NothingReady,
             RunOutcome::QuiescentFailures => ExitCode::WorkFailed,
             RunOutcome::QuiescentBlocked => ExitCode::Blocked,
+            RunOutcome::AgentStartupFailure => ExitCode::InfrastructureFailure,
             RunOutcome::Interrupted => ExitCode::Success,
         }
     }
@@ -53,6 +61,7 @@ impl RunOutcome {
             RunOutcome::NothingReady => "nothing_ready",
             RunOutcome::QuiescentFailures => "work_failed",
             RunOutcome::QuiescentBlocked => "blocked",
+            RunOutcome::AgentStartupFailure => "infrastructure_failure",
             RunOutcome::Interrupted => "interrupted",
         }
     }
@@ -248,7 +257,19 @@ fn classify_live_outcome(
     evaluated: &protocol_eval::EvaluatedProtocols,
     had_failures: bool,
     executed_any: bool,
+    had_postcondition_failure: bool,
 ) -> RunOutcome {
+    // Work was attempted iff a protocol executed to reconciliation (`Succeeded`)
+    // or ran and failed its postconditions (`PostconditionFailure`). A run that
+    // recorded failures but attempted no work — every failure an agent that
+    // could not start — is an infrastructure failure, not a work failure:
+    // `work_failed` (5) is reserved for work that ran and failed its completion
+    // checks. See commons/EXIT-CODES.md and tesserine/runa#232.
+    let work_attempted = executed_any || had_postcondition_failure;
+    if had_failures && !work_attempted {
+        return RunOutcome::AgentStartupFailure;
+    }
+
     match classify_outcome(evaluated, had_failures) {
         RunOutcome::AllComplete if !executed_any => RunOutcome::NothingReady,
         outcome => outcome,
@@ -685,7 +706,7 @@ fn run_with_scope(
     )?;
     let mut state = initial_state;
     if state.planned_entries.is_empty() {
-        let outcome = classify_live_outcome(&state.evaluated, false, prior_execution);
+        let outcome = classify_live_outcome(&state.evaluated, false, prior_execution, false);
         println!("Run outcome: {}", outcome.label());
         return Ok(outcome);
     }
@@ -699,6 +720,7 @@ fn run_with_scope(
     let mut exhausted = HashSet::new();
     let mut failed = HashSet::new();
     let mut executed_any = prior_execution;
+    let mut had_postcondition_failure = false;
 
     loop {
         let next_entry = state.planned_entries.clone().into_iter().find(|entry| {
@@ -706,7 +728,12 @@ fn run_with_scope(
             !exhausted.contains(&key) && !failed.contains(&key)
         });
         let Some(next_entry) = next_entry else {
-            let outcome = classify_live_outcome(&state.evaluated, !failed.is_empty(), executed_any);
+            let outcome = classify_live_outcome(
+                &state.evaluated,
+                !failed.is_empty(),
+                executed_any,
+                had_postcondition_failure,
+            );
             println!("Run outcome: {}", outcome.label());
             return Ok(outcome);
         };
@@ -754,6 +781,7 @@ fn run_with_scope(
             }
             Ok(ReconcileOutcome::PostconditionFailure { scan_result }) => {
                 failed.insert(key);
+                had_postcondition_failure = true;
                 state = refresh_state_after_scan(
                     &loaded,
                     working_dir,
@@ -1092,6 +1120,60 @@ mod tests {
         assert_eq!(
             classify_outcome(&evaluated, false),
             RunOutcome::QuiescentBlocked
+        );
+    }
+
+    fn evaluated_all_complete() -> EvaluatedProtocols {
+        EvaluatedProtocols {
+            topology: libagent::EvaluationTopology {
+                status_order: Vec::new(),
+                execution_order: Vec::new(),
+                cycle: None,
+            },
+            cycle: None,
+            ready: Vec::new(),
+            blocked: Vec::new(),
+            waiting: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn classify_live_outcome_reports_agent_startup_failure_when_no_work_attempted() {
+        // Failures occurred, but every one was an agent that could not start:
+        // nothing executed, no postcondition ever ran. This is infrastructure
+        // failure (6), not work_failed (5).
+        let evaluated = evaluated_all_complete();
+        assert_eq!(
+            classify_live_outcome(&evaluated, true, false, false),
+            RunOutcome::AgentStartupFailure
+        );
+        assert_eq!(
+            RunOutcome::AgentStartupFailure.as_exit_code(),
+            ExitCode::InfrastructureFailure
+        );
+    }
+
+    #[test]
+    fn classify_live_outcome_reports_work_failed_when_postconditions_failed_without_execution() {
+        // The agent ran and produced output, but its postconditions failed. Work
+        // was attempted, so this stays work_failed (5) even though nothing
+        // reconciled to `Succeeded`.
+        let evaluated = evaluated_all_complete();
+        assert_eq!(
+            classify_live_outcome(&evaluated, true, false, true),
+            RunOutcome::QuiescentFailures
+        );
+    }
+
+    #[test]
+    fn classify_live_outcome_reports_work_failed_when_work_executed_then_a_step_failed() {
+        // At least one protocol executed successfully before a later failure.
+        // Meaningful work was established, so this is work_failed (5), not an
+        // infrastructure failure.
+        let evaluated = evaluated_all_complete();
+        assert_eq!(
+            classify_live_outcome(&evaluated, true, true, false),
+            RunOutcome::QuiescentFailures
         );
     }
 

--- a/runa-cli/tests/run.rs
+++ b/runa-cli/tests/run.rs
@@ -483,6 +483,20 @@ fn write_single_protocol_agent(dir: &Path) -> PathBuf {
     fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
     script_path
 }
+/// An agent that always fails to start: it consumes the payload, logs its
+/// invocation, emits a startup-style message, and exits non-zero without
+/// executing any protocol work or writing any workspace artifact — the shape of
+/// an agent that cannot authenticate (e.g. "Not logged in").
+fn write_always_failing_agent(dir: &Path) -> PathBuf {
+    let script_path = dir.join("always-failing-agent.sh");
+    fs::write(
+        &script_path,
+        "#!/bin/sh\nlog_file=\"$1\"\npayload=$(cat)\nprintf 'startup-failure\\n' >> \"$log_file\"\nprintf 'Not logged in\\n'\nexit 1\n",
+    )
+    .unwrap();
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+    script_path
+}
 fn write_arg_logging_single_protocol_agent(dir: &Path) -> PathBuf {
     let script_path = dir.join("arg-logging-single-protocol-agent.sh");
     fs::write(
@@ -670,6 +684,77 @@ trigger = { type = "on_artifact", name = "constraints" }
     let executed = fs::read_to_string(&log_path).unwrap();
     assert_eq!(executed, "implement\n");
     assert!(workspace.join("implementation/impl-1.json").is_file());
+}
+#[test]
+fn run_without_dry_run_reports_agent_startup_failure_as_infrastructure_failure() {
+    // AC1 (tesserine/runa#232): a session whose agent exits non-zero having
+    // executed no protocol work and delivered no artifact is infrastructure_failure
+    // (6), not work_failed (5).
+    let dir = tempfile::tempdir().unwrap();
+    let bool_schema =
+        r#"{"type":"object","required":["done"],"properties":{"done":{"type":"boolean"}}}"#;
+    let manifest_path = common::write_methodology(
+        dir.path(),
+        r#"
+name = "groundwork"
+
+[[artifact_types]]
+name = "constraints"
+
+[[artifact_types]]
+name = "implementation"
+
+[[protocols]]
+name = "implement"
+requires = ["constraints"]
+produces = ["implementation"]
+trigger = { type = "on_artifact", name = "constraints" }
+"#,
+        &[
+            (
+                "constraints",
+                r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+            ),
+            ("implementation", bool_schema),
+        ],
+        &["implement"],
+    );
+
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+
+    let workspace = project_dir.join(".runa/workspace");
+    fs::create_dir_all(workspace.join("constraints")).unwrap();
+    fs::write(
+        workspace.join("constraints/spec-1.json"),
+        r#"{"title":"ship run"}"#,
+    )
+    .unwrap();
+
+    let log_path = dir.path().join("startup-failure.log");
+    let agent_path = write_always_failing_agent(dir.path());
+    append_agent_command_config(&project_dir, &[agent_path.as_path(), log_path.as_path()]);
+
+    let output = runa_bin()
+        .arg("run")
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6), "{output:?}");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Run outcome: infrastructure_failure"),
+        "stdout: {stdout}"
+    );
+
+    // The agent was actually dispatched and failed — this is a failure to start,
+    // not a "nothing ready" outcome — yet it produced no workspace artifact.
+    let executed = fs::read_to_string(&log_path).unwrap();
+    assert_eq!(executed, "startup-failure\n");
+    assert!(!workspace.join("implementation").exists());
 }
 #[test]
 fn run_without_dry_run_cli_agent_command_overrides_configured_agent_command() {


### PR DESCRIPTION
## What this does

`runa run` now reports a session whose agent **fails to start** — the agent process exits without executing any protocol work or delivering any artifact (it cannot launch or authenticate) — as `infrastructure_failure` (6) instead of `work_failed` (5).

The session-outcome classification distinguishes the two from **observable run state**, not agent stdout: a run that recorded failures but attempted no work is an infrastructure failure, while `work_failed` (5) stays reserved for work that ran and failed its completion checks.

- `work_attempted = executed_any || had_postcondition_failure` — a protocol reached `Succeeded`, or ran and failed its postconditions.
- `had_failures && !work_attempted` → new `RunOutcome::AgentStartupFailure` → `infrastructure_failure` (6). Every other path is unchanged.

Closes #232. (`commons/EXIT-CODES.md`; surfaced during the pentaxis93/babbie-ops#67 acceptance run.)

## Acceptance criteria

- **AC1** — agent exits non-zero, no protocol work executed, no artifact delivered → `infrastructure_failure` (6). *(new integration test + `classify_live_outcome` unit test)*
- **AC2** — agent attempted work, completion checks failed → `work_failed` (5), preserved. *(existing postcondition tests stay green; unit test for the no-prior-success postcondition case)*
- **AC3** — distinction derives from observable run state (`Succeeded` / `PostconditionFailure` / `AgentCommandFailed`), robust to the agent, not a stdout match.
- **AC4** — `docs/cli-reference.md` `run` exit-code table updated; CHANGELOG entry added.

## Test evidence

- `cargo fmt --check` — clean.
- `cargo clippy -p runa-cli --all-targets -- -D warnings` — clean.
- `cargo test -p runa-cli --bin runa classify_live_outcome` — **3/3 pass** (the classification logic — startup-failure, postcondition-without-execution, and executed-then-failed cases).

**Integration-test note (honest signal).** The end-to-end integration tests that spawn an agent subprocess (my new AC1 test and the four pre-existing `work_failed` tests) do **not** execute in the review sandbox: it pipes child stdio, which the agent-execution path's fd/process-group isolation cannot inherit, so `runa run` produces no output before the assertion. Verified this is **environmental, not a regression** — on a clean checkout of head (`dc02f9d`, changes stashed) the same four pre-existing agent-spawning tests and the two `commands::step` fd tests fail identically. The added integration test mirrors the established harness and passes where those sibling tests do (a real Linux host / the project's dev environment). The passing `classify_live_outcome` unit tests are the non-gated proxy for the same behavior.

## Scope

Touches only `runa-cli`'s session-outcome classification. The commons vocabulary (`exit_codes.rs`) is unchanged. The parallel defect on the `runa step` / `runa go` surfaces (`StepError::AgentCommandFailed → work_failed`) is filed as sibling **#233**, not folded here.
