### PR TITLE
fix(exit-codes): runa step/go classify agent-startup failure as infrastructure_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ Semantic Versioning.
   `work_failed` remains reserved for work that ran and failed its completion
   checks. Honest-Signal fix for the commons/EXIT-CODES.md contract, surfaced by
   a session whose agent never authenticated (tesserine/runa#232).
+- `step` and `go` now report an agent that **fails to start** — the agent
+  process exits without executing any protocol work or delivering any artifact
+  — as `infrastructure_failure` (6) rather than `work_failed` (5), on their own
+  command surfaces. The `StepError::exit_code` mapping distinguishes the agent
+  process failing (`AgentCommandFailed`, reached before any postcondition
+  assessment) from work that ran and failed its completion checks
+  (`PostExecutionEnforcement` / a session that did not advance), which remain
+  `work_failed` (5). The sibling of the `run` fix above on the `step`/`go`
+  surfaces (tesserine/runa#233).
 - Invariant-bearing modules now document their invariants at the code:
   `session.rs` opens with the session state-machine contract (state derives
   from artifacts, single current step, transactional `advance`,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -274,8 +274,8 @@ Without `--dry-run`, `step` requires `[agent].command` in the config and a Linux
 | 2 | Usage error, currently `--json` without `--dry-run`. |
 | 3 | No READY candidate and work remains blocked, waiting on prerequisites, or trapped in a cycle. |
 | 4 | No READY candidate and no actionable work remains because the in-scope outputs are already current. |
-| 5 | Work was attempted, but the agent failed or postconditions were not satisfied. |
-| 6 | Infrastructure failure: project/config/load/scan/serialization/bootstrap/MCP lookup/runtime I/O failure prevented completion from being established. |
+| 5 | Work was attempted, but its postconditions or completion checks were not satisfied. |
+| 6 | Infrastructure failure: an agent that failed to start (exited without executing any protocol work or delivering any artifact), or a project/config/load/scan/serialization/bootstrap/MCP lookup/runtime I/O failure, prevented completion from being established. |
 
 ### `runa run`
 
@@ -385,8 +385,8 @@ fails with exit `5`.
 | 2 | Usage error, or a ticket reference that is unparseable or disagrees with the active deployment. |
 | 3 | No READY candidate and work remains blocked, waiting on prerequisites, or trapped in a cycle. |
 | 4 | No READY candidate and no actionable work remains because the in-scope outputs are already current. |
-| 5 | Work was attempted, but the agent failed or did not advance the selected session step. |
-| 6 | Infrastructure failure: project/config/load/scan/serialization/bootstrap/MCP lookup/runtime I/O failure prevented completion from being established. |
+| 5 | Work was attempted, but the agent did not advance the selected session step. |
+| 6 | Infrastructure failure: an agent that failed to start (exited without executing any protocol work or delivering any artifact), or a project/config/load/scan/serialization/bootstrap/MCP lookup/runtime I/O failure, prevented completion from being established. |
 
 ## MCP Server
 

--- a/runa-cli/src/commands/step.rs
+++ b/runa-cli/src/commands/step.rs
@@ -204,9 +204,14 @@ impl StepError {
     pub(crate) fn exit_code(&self) -> ExitCode {
         match self {
             StepError::JsonRequiresDryRun => ExitCode::UsageError,
-            StepError::AgentCommandFailed { .. } | StepError::PostExecutionEnforcement { .. } => {
-                ExitCode::WorkFailed
-            }
+            // The agent process exited non-zero before postconditions were ever
+            // assessed: no work completion was established, so this is an
+            // infrastructure failure, not a work failure. `work_failed` (5) is
+            // reserved for work that ran and failed its completion checks — the
+            // `PostExecutionEnforcement` path below, reached only after a clean
+            // agent exit. See commons/EXIT-CODES.md and tesserine/runa#232.
+            StepError::AgentCommandFailed { .. } => ExitCode::InfrastructureFailure,
+            StepError::PostExecutionEnforcement { .. } => ExitCode::WorkFailed,
             StepError::SessionDidNotAdvance { .. } => ExitCode::WorkFailed,
             StepError::TicketReference(err) => match err {
                 libagent::EntryError::InvalidReference { .. }
@@ -2013,5 +2018,49 @@ cat >/dev/null
         let decision = decide_live_fallback_after_refresh(refreshed);
 
         assert_eq!(decision, Err(StepOutcome::NothingReady));
+    }
+
+    #[test]
+    fn agent_startup_failure_maps_to_infrastructure_failure() {
+        // The agent process exited non-zero having reached no postcondition
+        // enforcement: no work completion was established, so this is an
+        // infrastructure failure, not a work failure (tesserine/runa#233).
+        let err = StepError::AgentCommandFailed {
+            command: "agent".to_string(),
+            protocol: "protocol".to_string(),
+            work_unit: None,
+            status: "exit status: 1".to_string(),
+        };
+
+        assert_eq!(err.exit_code(), ExitCode::InfrastructureFailure);
+    }
+
+    #[test]
+    fn postcondition_enforcement_failure_stays_work_failed() {
+        // The agent ran and exited cleanly; its postconditions failed. Work was
+        // attempted and failed its completion checks — `work_failed` (5).
+        let err = StepError::PostExecutionEnforcement {
+            protocol: "protocol".to_string(),
+            work_unit: None,
+            source: libagent::EnforcementError {
+                protocol_name: "protocol".to_string(),
+                phase: libagent::Phase::Post,
+                failures: Vec::new(),
+            },
+        };
+
+        assert_eq!(err.exit_code(), ExitCode::WorkFailed);
+    }
+
+    #[test]
+    fn session_did_not_advance_stays_work_failed() {
+        // The agent exited successfully but did not advance the session step:
+        // work was attempted and did not complete — `work_failed` (5), unchanged.
+        let err = StepError::SessionDidNotAdvance {
+            protocol: "protocol".to_string(),
+            work_unit: None,
+        };
+
+        assert_eq!(err.exit_code(), ExitCode::WorkFailed);
     }
 }


### PR DESCRIPTION
Closes #233.

## What

`runa step` and `runa go` mapped `StepError::AgentCommandFailed` — returned whenever the agent process exits non-zero, including a failure to start or authenticate before any protocol work — to `work_failed` (5). This is the same Honest-Signal defect corrected for `runa run` in #232, on a different command surface with a different mapping (`StepError::exit_code`, not `RunOutcome`). Both `step` and `go` route their errors through `StepError::exit_code` (`main.rs`), and `go` reaches the same `execute_entry` that emits `AgentCommandFailed`.

## The fix

Split the merged `StepError::exit_code` arm:

- `AgentCommandFailed` → `infrastructure_failure` (6). The agent process exited non-zero before postconditions were ever assessed, so no work completion was established. Consistent with the landed #232 treatment, where `AgentCommandFailed` is not counted as work-attempted.
- `PostExecutionEnforcement` → `work_failed` (5), unchanged. Reached only after a clean agent exit; work ran and failed its completion checks.
- `SessionDidNotAdvance` → `work_failed` (5), untouched.

The distinction derives from the observable `StepError` variant (process exit / which phase runa reached), not a match on agent stdout (AC3).

## Acceptance criteria

- **AC1** — agent-startup non-zero exit on `step`/`go` → `infrastructure_failure` (6). Covered by `agent_startup_failure_maps_to_infrastructure_failure`.
- **AC2** — `PostExecutionEnforcement` stays `work_failed` (5). Covered by `postcondition_enforcement_failure_stays_work_failed` (and `session_did_not_advance_stays_work_failed` for the boundary).
- **AC3** — distinction from observable run state, not stdout. The mapping keys on the error variant.
- **AC4** — `docs/cli-reference.md` step and go exit-code tables corrected to match the #232 `run` language.

## Evidence

- `cargo fmt --check` clean; `cargo clippy -p runa-cli --all-targets -- -D warnings` clean.
- 3 new `StepError::exit_code` unit tests pass (startup → 6; postcondition → 5; no-advance → 5); 41 pre-existing `runa-cli` unit tests pass.
- Three pre-existing `runa-cli` tests (`init` preflight and the two `execute_entry` fd/stdio tests) fail in this sandbox because it pipes child stdio, which the agent-execution fd path cannot inherit. Proven **environmental, not a regression** by baseline parity: with these changes stashed, the same three fail identically on clean head `41ca83e`. runa has no PR-CI (release-only workflows), so local fmt/clippy/unit is the standing gate.