### PR TITLE
feat(entry): re-entry to a recorded work-unit serves the acquisition surface unless its record is current

### DIFF
--- a/libagent/src/entry.rs
+++ b/libagent/src/entry.rs
@@ -451,6 +451,35 @@ pub fn check_acquisition_admissible(
     Ok(())
 }
 
+/// Whether the acquisition surface's persisted execution record is current:
+/// a record exists for the unscoped acquisition and its recorded input
+/// snapshot equals the present one — the same input-freshness comparison
+/// canonical selection applies to every protocol.
+///
+/// This is the re-entry routing gate. A ticket entry that resolves to a
+/// recorded work-unit opens bound only when the acquisition surface has
+/// already executed against the present input set; otherwise the entry
+/// serves the acquisition surface, so the methodology's own re-grounding
+/// discipline fires before the scoped pipeline proceeds. The runtime
+/// consults only its own store state here — what re-grounding means is the
+/// methodology's, delivered by the acquisition protocol it already owns.
+pub fn acquisition_record_current(
+    acquisition: &ProtocolDeclaration,
+    store: &ArtifactStore,
+) -> bool {
+    match store.execution_record(&acquisition.name, None) {
+        Some(record) => {
+            let current_inputs = crate::selection::execution_input_snapshot_for_freshness_inputs(
+                store,
+                record.input_modes.iter(),
+                None,
+            );
+            record.inputs == current_inputs
+        }
+        None => false,
+    }
+}
+
 /// Resolve a ticket reference to the materialized `work-unit` instance.
 ///
 /// Returns the instance id whose tracker handle identity equals the reference,
@@ -678,6 +707,73 @@ mod tests {
             },
             instructions: None,
         }
+    }
+
+    #[test]
+    fn acquisition_record_current_is_false_without_a_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::test_helpers::make_store(&tmp.path().join("store"), vec!["work-unit"]);
+        let acquisition = acquisition_protocol(&[]);
+
+        assert!(!acquisition_record_current(&acquisition, &store));
+    }
+
+    #[test]
+    fn acquisition_record_current_is_true_when_snapshot_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = crate::test_helpers::make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit"],
+        );
+        store
+            .record(
+                "request",
+                "good",
+                std::path::Path::new("good.json"),
+                &serde_json::json!({"title": "good"}),
+            )
+            .unwrap();
+        let acquisition = acquisition_protocol(&["request"]);
+        let record = crate::protocol_entry_execution_record(&acquisition, &store, None);
+        store
+            .record_execution(&acquisition.name, None, record)
+            .unwrap();
+
+        assert!(acquisition_record_current(&acquisition, &store));
+    }
+
+    #[test]
+    fn acquisition_record_current_is_false_when_a_recorded_input_changes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = crate::test_helpers::make_store(
+            &tmp.path().join("store"),
+            vec!["request", "work-unit"],
+        );
+        store
+            .record(
+                "request",
+                "good",
+                std::path::Path::new("good.json"),
+                &serde_json::json!({"title": "good"}),
+            )
+            .unwrap();
+        let acquisition = acquisition_protocol(&["request"]);
+        let record = crate::protocol_entry_execution_record(&acquisition, &store, None);
+        store
+            .record_execution(&acquisition.name, None, record)
+            .unwrap();
+
+        // The recorded input changes after the record was taken.
+        store
+            .record(
+                "request",
+                "good",
+                std::path::Path::new("good.json"),
+                &serde_json::json!({"title": "changed"}),
+            )
+            .unwrap();
+
+        assert!(!acquisition_record_current(&acquisition, &store));
     }
 
     #[test]

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -45,8 +45,8 @@ pub use enforcement::{
 };
 pub use entry::{
     AcquisitionBlock, EntryError, RUNA_ENTRY_TICKET, SeedTicketRef, TicketRef,
-    check_acquisition_admissible, discover_acquisition_surface, resolve_promise,
-    resolve_seed_ticket_reference, resolve_ticket_reference,
+    acquisition_record_current, check_acquisition_admissible, discover_acquisition_surface,
+    resolve_promise, resolve_seed_ticket_reference, resolve_ticket_reference,
 };
 pub use graph::{CycleError, DependencyGraph, GraphError};
 pub use logging::{LoggingError, ResolvedLoggingConfig, configure_tracing, resolve_logging_config};

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -394,10 +394,21 @@ impl SessionState {
         let scan_result = crate::scan(&loaded.workspace_dir, &mut loaded.store)?;
         let scan_findings = crate::collect_scan_findings(&scan_result, &loaded.workspace_dir);
 
-        // Resolve the promise first. Re-entry (the work-unit already exists)
-        // degrades to an ordinary bound session and needs no acquisition surface;
-        // only a cold start requires one.
-        if let Some(work_unit) = crate::resolve_promise(&loaded.store, &identity, &ticket)? {
+        // Resolve the promise first — resolution stays fail-closed. Re-entry
+        // (the work-unit already exists) opens as an ordinary bound session
+        // only when the acquisition surface's persisted execution record is
+        // current; a stale or absent record routes the entry through the
+        // acquisition surface exactly as a cold start, so the methodology's
+        // re-grounding discipline fires before the scoped pipeline proceeds.
+        // A methodology with no acquisition surface has no re-grounding to
+        // serve, so its re-entry stays bound.
+        let resolved = crate::resolve_promise(&loaded.store, &identity, &ticket)?;
+        let reentry_bound = resolved.is_some()
+            && match crate::discover_acquisition_surface(&loaded.manifest.protocols) {
+                Ok(acquisition) => crate::acquisition_record_current(acquisition, &loaded.store),
+                Err(_) => true,
+            };
+        if let Some(work_unit) = resolved.filter(|_| reentry_bound) {
             crate::validate_scoped_work_unit_with_identity(&loaded.store, &work_unit, &identity)?;
             let mut session = Self {
                 working_dir,
@@ -414,7 +425,10 @@ impl SessionState {
             return Ok(session);
         }
 
-        // Cold start: the acquisition surface is required.
+        // Cold start, or re-entry whose acquisition record is stale or absent:
+        // the acquisition surface is required, and the session opens promised
+        // and pinned to it. On re-entry the work-unit is already recorded, so
+        // `advance`'s bind resolves it once the acquisition step delivers.
         crate::validate_tracker_consistency(&loaded.store, &identity)?;
         let acquisition_name = crate::discover_acquisition_surface(&loaded.manifest.protocols)?
             .name
@@ -1361,14 +1375,65 @@ trigger = { type = "on_artifact", name = "work-unit" }
     }
 
     #[test]
-    fn open_entry_binds_immediately_when_work_unit_exists() {
+    fn open_entry_reentry_without_acquisition_record_serves_acquisition() {
         let _env = unset_forge_env();
         let dir = tempfile::tempdir().unwrap();
+        // The work-unit is already recorded, but the acquisition surface has no
+        // persisted execution record: the entry serves the acquisition surface
+        // so the methodology's re-grounding fires before the scoped pipeline.
         let project_dir = write_entry_project(dir.path(), true);
 
         let session =
             SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(())).unwrap();
 
+        let step = session
+            .current_step()
+            .expect("re-entry with a stale acquisition record serves acquisition");
+        assert_eq!(step.protocol, "decompose");
+        assert_eq!(step.work_unit, None);
+        assert!(matches!(
+            session.scope,
+            SessionScope::Promised { ticket: Some(_) }
+        ));
+    }
+
+    #[test]
+    fn reentry_acquisition_advance_binds_recorded_unit_and_next_entry_opens_bound() {
+        let _env = unset_forge_env();
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_entry_project(dir.path(), true);
+
+        // First entry on the recorded work-unit serves the acquisition surface.
+        let mut session =
+            SessionState::open_entry(project_dir.clone(), None, ticket_14(), |_, _| Ok(()))
+                .unwrap();
+        assert_eq!(
+            session.current_step().map(|s| s.protocol.as_str()),
+            Some("decompose")
+        );
+
+        // The acquisition step advances (the delivered work-unit is the
+        // recorded one), binds the recorded instance — no second work-unit —
+        // and persists the acquisition's execution record.
+        let advance = session
+            .advance_with_validator(|_, _| Ok(()))
+            .expect("re-entry acquisition advances and binds");
+        assert_eq!(advance.payload.completed_step.protocol, "decompose");
+        assert_eq!(
+            advance
+                .payload
+                .next_step
+                .as_ref()
+                .map(|s| s.protocol.as_str()),
+            Some("take")
+        );
+        assert!(
+            matches!(&session.scope, SessionScope::Bound(work_unit) if work_unit == "work-unit-14-cold-start")
+        );
+
+        // The persisted record makes the immediately following entry open bound.
+        let session =
+            SessionState::open_entry(project_dir, None, ticket_14(), |_, _| Ok(())).unwrap();
         let step = session.current_step().expect("bound session selects take");
         assert_eq!(step.protocol, "take");
         assert_eq!(step.work_unit.as_deref(), Some("work-unit-14-cold-start"));

--- a/runa-cli/src/commands/go.rs
+++ b/runa-cli/src/commands/go.rs
@@ -219,14 +219,29 @@ fn run_ticket_resolved(
     loaded: crate::project::LoadedProject,
     scan_result: libagent::ScanResult,
 ) -> Result<StepOutcome, StepError> {
-    // Re-entry (the work-unit already exists) degrades to a bound session and
-    // needs no acquisition surface — resolve before discovering it.
+    // Re-entry (the work-unit already exists) degrades to a bound session only
+    // when the acquisition surface's persisted execution record is current; a
+    // stale or absent record routes the entry through the acquisition surface
+    // below, so the methodology's re-grounding discipline fires before the
+    // scoped pipeline proceeds. A methodology with no acquisition surface has
+    // no re-grounding to serve, so its re-entry stays bound. Resolution runs
+    // first and stays fail-closed.
     if let Some(work_unit) = entry::resolve_existing(&loaded, &identity, &ticket_ref)? {
+        let record_current = match entry::acquisition_surface(&loaded) {
+            Ok(acquisition) => libagent::acquisition_record_current(&acquisition, &loaded.store),
+            Err(_) => true,
+        };
+        if record_current {
+            println!(
+                "Ticket {} resolves to recorded work-unit {work_unit}",
+                ticket_ref.display
+            );
+            return run_bound(working_dir, config_override, &work_unit);
+        }
         println!(
-            "Ticket {} resolves to recorded work-unit {work_unit}",
+            "Ticket {} resolves to recorded work-unit {work_unit}; serving the acquisition surface to re-ground it",
             ticket_ref.display
         );
-        return run_bound(working_dir, config_override, &work_unit);
     }
 
     let acquisition = entry::acquisition_surface(&loaded)?;

--- a/runa-cli/src/commands/run.rs
+++ b/runa-cli/src/commands/run.rs
@@ -541,22 +541,34 @@ fn run_resolved_entry(
     cli_agent_command_present: bool,
     cli_agent_command_argv: &[String],
 ) -> Result<RunOutcome, RunError> {
-    // Re-entry: the work-unit already exists — behave as `--work-unit <id>`.
+    // Re-entry: the work-unit already exists — behave as `--work-unit <id>`
+    // only when the acquisition surface's persisted execution record is
+    // current; a stale or absent record routes the entry through the
+    // acquisition path below, so the methodology's re-grounding discipline
+    // fires before the scoped pipeline proceeds. A methodology with no
+    // acquisition surface has no re-grounding to serve, so its re-entry stays
+    // bound. Resolution runs first and stays fail-closed.
     if let Some(work_unit) =
         entry::resolve_existing(&loaded, &identity, &ticket_ref).map_err(RunError::from)?
     {
-        return run_with_scope(
-            working_dir,
-            config_override,
-            dry_run,
-            json_output,
-            loaded,
-            scan_result,
-            Some(work_unit),
-            false,
-            cli_agent_command_present,
-            cli_agent_command_argv,
-        );
+        let record_current = match entry::acquisition_surface(&loaded) {
+            Ok(acquisition) => libagent::acquisition_record_current(&acquisition, &loaded.store),
+            Err(_) => true,
+        };
+        if record_current {
+            return run_with_scope(
+                working_dir,
+                config_override,
+                dry_run,
+                json_output,
+                loaded,
+                scan_result,
+                Some(work_unit),
+                false,
+                cli_agent_command_present,
+                cli_agent_command_argv,
+            );
+        }
     }
 
     // Cold: project the entry cascade, or execute acquisition then cascade.


### PR DESCRIPTION
Closes #243.

## What

Re-entry to a recorded work-unit no longer degrades unconditionally to a bound session. It opens bound **only when the acquisition surface's persisted execution record is current** — the same input-freshness comparison canonical selection applies (`store.execution_record` + recorded-vs-present snapshot). A stale or absent record routes the entry through the acquisition surface exactly as a cold start, so the methodology's re-grounding (freshen) discipline fires before the scoped pipeline proceeds.

Sites: `libagent::entry::acquisition_record_current` (the single home of the routing gate), `SessionState::open_entry_loaded`, `go.rs::run_ticket_resolved`, `run.rs::run_resolved_entry`.

## Contract mapping (issue #243 contract, comment of 2026-07-10)

- Stale/absent record → acquisition served at entry: `open_entry_reentry_without_acquisition_record_serves_acquisition`; the CLI sites share the exported gate.
- Current record → bound as today: second half of `reentry_acquisition_advance_binds_recorded_unit_and_next_entry_opens_bound`.
- Promised scope pins the acquisition step, so no scoped protocol (`define` included) is selectable until it advances; a non-advancing acquisition surfaces the existing did-not-advance error — existing machinery, unchanged.
- Bind lands on the *recorded* instance and the persisted record makes the next entry open bound (no re-freshen loop): `reentry_acquisition_advance_binds_recorded_unit_and_next_entry_opens_bound`.
- `resolve_promise` untouched; fail-closed (`WorkUnitScanIncomplete`) precedes the gate at every site.
- No freshen logic in runa: the gate consults only runa-native store state; the discipline stays at its groundwork home. Cross-repo seam filed as tesserine/groundwork#595.
- No acquisition surface in the manifest → re-entry stays bound (`open_entry_re_entry_binds_without_acquisition_surface`, unchanged).

## Evidence

- `cargo test -p libagent`: **396 passed, 0 failed** (includes 3 new gate unit tests + 2 re-derived/new session tests).
- `cargo test -p runa-cli --test go --test e2e`: green. `--test entry` / `--test run`: green except 7 failures in partial-scan fixtures that build unreadability from `chmod 0o000` — this container runs as **root**, which bypasses permission bits, so the scan gap never forms; the class is environmental, reproduced independent of this diff (root reads a `0o000` file). The 3 `--bin runa` unit failures are the same class plus runa#231's relative-CWD init test, all present on pristine `main`.
- `cargo clippy --workspace --all-targets`: no warnings in changed files (two pre-existing dead-code warnings in unrelated test helpers, per runa#242's class).
- `cargo fmt` applied.

No PR CI exists on this repo (runa#241), so the suite evidence above is the land gate's record.