### PR TITLE
feat(planning): a rejected current output can be invalidated and regenerated without changing its inputs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ These are library capabilities exposed by libagent and consumed by both the CLI 
 
 5. **Context injection construction.** `context::build_context` converts a ready `ProtocolDeclaration` plus the current artifact store into the stable agent-facing context used by `runa step`: protocol name, optional `work_unit`, available required/accepted artifact refs, and expected outputs. Store scoping still includes unpartitioned artifacts as shared inputs when a work unit is active. `context::render_context_prompt` turns that context into the prose prompt delivered on stdin during live execution.
 
-6. **Protocol selection.** `selection::discover_ready_candidates` evaluates protocols in topological order under an explicit `EvaluationScope`. `EvaluationScope::Unscoped` evaluates only protocols with `scoped = false` and always uses `work_unit = None`. `EvaluationScope::Scoped(id)` evaluates only protocols with `scoped = true` for that exact delegated work unit. Readiness no longer discovers sibling work units from artifact instances. Current work is suppressed only when outputs are valid and trusted plus either: the current freshness-relevant input snapshot matches the last successful execution record for that `(protocol, work_unit)` pair, or no execution record exists and the timestamp fallback still shows outputs newer than all relevant inputs. Execution-record snapshots are mode-aware: `on_change`/`on_invalid` preserve any recorded matching instance, while `on_artifact` and `requires` compare only valid instances. The timestamp fallback still considers the latest recorded modification across relevant inputs.
+6. **Protocol selection.** `selection::discover_ready_candidates` evaluates protocols in topological order under an explicit `EvaluationScope`. `EvaluationScope::Unscoped` evaluates only protocols with `scoped = false` and always uses `work_unit = None`. `EvaluationScope::Scoped(id)` evaluates only protocols with `scoped = true` for that exact delegated work unit. Readiness no longer discovers sibling work units from artifact instances. Current work is suppressed only when outputs are valid and trusted plus either: the current freshness-relevant input snapshot matches the last successful execution record for that `(protocol, work_unit)` pair, or no execution record exists and the timestamp fallback still shows outputs newer than all relevant inputs. A pending supersession overrides both paths: the pair is not current — the producer regenerates against its unchanged inputs and the timestamp fallback is not consulted — and an execution record whose input snapshot contains a pending-rejected revision is not current regardless of snapshot equality. Execution-record snapshots are mode-aware: `on_change`/`on_invalid` preserve any recorded matching instance, while `on_artifact` and `requires` compare only valid instances. The timestamp fallback still considers the latest recorded modification across relevant inputs.
 
 7. **Scoped work-unit identity validation.** After workspace scan and before scoped readiness evaluation, `runa state`, `runa step`, `runa run`, and `runa go` validate that the supplied `--work-unit` exactly matches a recorded `work-unit` instance id when any are recorded. Invalid and malformed recorded roots still establish canonical ids. Valid tracker-backed roots also enforce instance-id/handle number agreement, duplicate tracker-root rejection, and agreement with the active forge deployment identity resolved from `.runa/config.toml` with `RUNA_FORGE_*` env overrides. With no recorded `work-unit` roots, scoped evaluation remains inert.
 
@@ -92,7 +92,7 @@ Stable agent-facing context injection contract plus prompt rendering. `build_con
 
 ### `store.rs`
 
-Artifact state tracking keyed by `(type_name, instance_id)`. Each `ArtifactState` records the filesystem path, `ValidationStatus` (Valid, Invalid with violations, Malformed with a parse error, or Stale), millisecond-precision modification timestamp, a `sha256:<hex>` content hash, a `schema_hash` for the artifact type schema used during validation, and an optional `work_unit` string extracted from artifact JSON at record time. Parsed JSON uses canonical JSON hashing (recursively sorted keys); malformed files hash raw bytes. Persists artifact state as JSON files under `.runa/store/{type_name}/{instance_id}.json` using a byte-preserving path encoding (`unix_bytes` on Unix, `windows_wide` on Windows) plus a lossy `display_path` for inspection, and still accepts legacy string-path store records on load. Separately persists execution metadata in `.runa/store/execution-records.json`: a manifest-contract hash plus per-`(protocol, work_unit)` records of the freshness-relevant input snapshot from the last successful execution, including invalid or malformed instances only for inputs whose freshness mode is `AnyRecorded`. Uses atomic write (tmp + rename). Separately, the store keeps non-persisted scan-gap metadata for the current process so completion/freshness checks can distinguish whole-type scan failures from unreadable specific instances.
+Artifact state tracking keyed by `(type_name, instance_id)`. Each `ArtifactState` records the filesystem path, `ValidationStatus` (Valid, Invalid with violations, Malformed with a parse error, or Stale), millisecond-precision modification timestamp, a `sha256:<hex>` content hash, a `schema_hash` for the artifact type schema used during validation, and an optional `work_unit` string extracted from artifact JSON at record time. Parsed JSON uses canonical JSON hashing (recursively sorted keys); malformed files hash raw bytes. Persists artifact state as JSON files under `.runa/store/{type_name}/{instance_id}.json` using a byte-preserving path encoding (`unix_bytes` on Unix, `windows_wide` on Windows) plus a lossy `display_path` for inspection, and still accepts legacy string-path store records on load. Separately persists execution metadata in `.runa/store/execution-records.json`: a manifest-contract hash plus per-`(protocol, work_unit)` records of the freshness-relevant input snapshot from the last successful execution, including invalid or malformed instances only for inputs whose freshness mode is `AnyRecorded`, and an append-only supersession lineage — each entry the target `(protocol, work_unit)`, an auditable reason, the rejected output revisions with their preserved content, and the execution record the disposition displaced. A supersession is pending while its pair has no current record; pendingness is computed from that relation, never stored, so any recording path resolves it. Uses atomic write (tmp + rename). Separately, the store keeps non-persisted scan-gap metadata for the current process so completion/freshness checks can distinguish whole-type scan failures from unreadable specific instances.
 
 Query methods (`is_valid`, `has_any_invalid`, `instances_of`, `latest_modification_ms`) accept an `Option<&str>` work unit filter. `None` returns all instances (unscoped). `Some(wu)` returns instances matching that work unit plus unpartitioned instances (those with no `work_unit` field). This scoping threads through trigger evaluation, enforcement, and context injection.
 
@@ -190,7 +190,7 @@ surface.
     {type_name}/
       {instance_id}.json        # Agent-produced artifact file
   store/                        # Internal runtime state store (not configurable)
-    execution-records.json      # Execution contract hash + last successful valid-input snapshots per (protocol, work_unit)
+    execution-records.json      # Execution contract hash + last successful valid-input snapshots per (protocol, work_unit) + supersession lineage
     {type_name}/
       {instance_id}.json        # ArtifactState: encoded path + display_path, status, last_modified_ms, content_hash, schema_hash, work_unit
 ```
@@ -265,6 +265,33 @@ selected session step produced a successful `advance` transition receipt from
 the session surface, then reloads the store to print refreshed readiness. A
 successful process exit without a session advance is treated as attempted-work
 failure.
+
+### `runa supersede --protocol <NAME> [--work-unit <ID>] --output <type>/<instance>@<revision> --reason <TEXT>`
+
+Applies a supersession disposition to a recorded protocol execution: the
+sanctioned operation by which a conforming-but-rejected output re-enters the
+graph for regeneration against unchanged inputs. Runs the implicit workspace
+scan first, then validates the disposition against current reality — the
+protocol must be declared, an execution record must exist for the scope, each
+`--output` (repeatable) must name an output artifact type the protocol
+declares, a recorded instance for the scope, and that instance's current
+content hash — and rejects each mismatch with a diagnostic naming it (a stale
+revision diagnostic names the current one). Scoped invocations run the same
+canonical work-unit identity validation as the other scope-taking commands.
+
+On success, the current execution record moves into an append-only
+supersession lineage entry in `execution-records.json` together with the
+auditable reason and the rejected revisions' content (read back from the
+workspace and verified against the supplied hash), leaving the pair with no
+current record. Readiness evaluation treats that pending state as
+not-current: the producer becomes READY for its unchanged inputs, the
+timestamp fallback is not consulted, and any execution record whose input
+snapshot contains a pending-rejected revision is likewise not current, so
+downstream state derived from the rejected output reopens. The pending state
+resolves when the next execution is recorded for the pair through any normal
+path (`step`, `run`, `go`, or the session surface); the lineage entry
+remains. Exit codes: `0` applied, `1` disposition rejected against current
+reality, `2` malformed invocation, `6` infrastructure failure.
 
 ## Key Design Patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ Semantic Versioning.
   through unchanged and never invokes `create-work-unit`. Operator contract:
   `docs/session-surface-contract.md` §Required-Forge-Mutation Contract.
 
+- **Supersession disposition — a rejected conforming output regenerates
+  against unchanged inputs** (tesserine/runa#248): `runa supersede
+  --protocol <NAME> [--work-unit <ID>] --output <type>/<instance>@<revision>
+  --reason <TEXT>` marks a recorded protocol execution superseded, guarded
+  against current reality (declared protocol, existing record, declared
+  output type, recorded instance, current revision — each mismatch rejected
+  with a diagnostic naming it). The superseded record, the auditable reason,
+  and the rejected revisions' preserved content persist as append-only
+  lineage in `execution-records.json`; readiness treats the pending pair as
+  not-current (timestamp fallback bypassed) and treats any execution record
+  whose input snapshot contains a pending-rejected revision as not-current,
+  so the producer becomes READY and downstream state derived from the
+  rejected output reopens. Regeneration flows only through the normal
+  `step`/`run`/`go`/session paths; recording the regenerated execution
+  resolves the pending state.
+
 - **`read-work-unit` returns the work-unit comment log** per forge-capability
   `2.0.0` (tesserine/commons#106; contract constants re-pinned to
   `e75e211`'s immutable v2 schema URL): the work-unit snapshot carries an

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -395,6 +395,59 @@ fails with exit `5`.
 | 5 | Work was attempted, but the agent did not advance the selected session step. |
 | 6 | Infrastructure failure: an agent that failed to start (exited without executing any protocol work or delivering any artifact), or a project/config/load/scan/serialization/bootstrap/MCP lookup/runtime I/O failure, prevented completion from being established. |
 
+### `runa supersede`
+
+```bash
+runa supersede --protocol <NAME> [--work-unit <ID>] \
+  --output <type>/<instance>@<revision> [--output ...] \
+  --reason <TEXT> [--config <PATH>]
+```
+
+Applies a supersession disposition to a recorded protocol execution. A
+protocol output can be schema-valid and current by input identity while
+governance judges its content defective; this operation is the sanctioned
+way that judgment re-enters the graph. It marks the recorded execution
+superseded so the producing protocol becomes READY against its unchanged
+inputs, while the rejected execution and output revisions are preserved as
+inspectable lineage in `.runa/store/execution-records.json`.
+
+The disposition is guarded against current reality. `supersede` runs the
+implicit workspace scan first, then rejects — each with a diagnostic naming
+the mismatch — a protocol the methodology does not declare, a target with no
+execution record for the scope, an output artifact type the protocol does
+not declare, an instance not recorded for the scope, and a revision that is
+not the instance's current content hash (the diagnostic names the current
+revision). The reason is required and recorded verbatim in the lineage
+entry. Scoped invocations validate `--work-unit` against canonical recorded
+work-unit identity exactly as other scope-taking commands do.
+
+After the disposition, readiness reflects it everywhere the shared
+evaluation runs (`state`, `step`, `run`, `go`, and the session surface): the
+producer is READY, and any execution record whose recorded inputs contain a
+rejected revision is no longer current, so downstream state derived from the
+rejected output reopens. Regeneration itself flows only through the normal
+execution paths; recording the regenerated execution resolves the pending
+supersession. No workspace deletion, output editing, or direct
+execution-record mutation is part of the supported path.
+
+**Flags:**
+
+- `--protocol <NAME>` — Protocol whose recorded execution is superseded.
+- `--work-unit <ID>` — Delegated work unit of the recorded execution.
+- `--output <type>/<instance>@<revision>` — Rejected output revision;
+  repeatable. The revision is the instance's `sha256:<hex>` content hash as
+  reported in `.runa/store/<type>/<instance>.json`.
+- `--reason <TEXT>` — Auditable reason for rejecting the conforming output.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | The disposition was applied; the producer regenerates against unchanged inputs. |
+| 1 | The disposition was rejected against current reality (wrong protocol, output identity, or stale revision; empty reason or outputs). |
+| 2 | Usage error, including a malformed `--output` token. |
+| 6 | Infrastructure failure: project/config/load/scan or store I/O prevented the disposition. |
+
 ## MCP Server
 
 `runa-mcp` is a stdio MCP server with two modes.

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -162,7 +162,7 @@ materialized work-unit id are indistinguishable downstream of acquisition.
 
 runa is an event-driven runtime. The CLI commands (init, scan, list, state, step, doctor) are windows into its state. The runtime itself is the monitoring loop.
 
-Given the declarations above, runa provides five runtime capabilities:
+Given the declarations above, runa provides six runtime capabilities:
 
 **Monitoring.** runa watches artifact state and evaluates trigger conditions on relevant state changes within the caller's evaluation scope. When a protocol's trigger condition becomes satisfied, runa activates the protocol.
 
@@ -173,6 +173,8 @@ Given the declarations above, runa provides five runtime capabilities:
 **Enforcement.** A protocol cannot execute if any `requires` artifact type lacks a valid instance. A protocol's execution is incomplete if its `produces` artifacts are missing or invalid, or if a required output choice has zero or multiple produced member types. These are hard constraints the runtime enforces regardless of what the methodology intends.
 
 **Context injection.** When a protocol is ready to execute, runa resolves which artifact instances the protocol needs — all valid `requires` instances and all available valid `accepts` instances within the active scope — and delivers them as the protocol's input context alongside the protocol's instruction content and expected outputs, including any required output choices. The protocol receives its inputs without querying the store directly.
+
+**Supersession.** A protocol output can conform to its schema and be current by input identity while an authorized disposition judges its content defective. runa provides one sanctioned, auditable operation for that judgment: a supersession disposition targets a recorded execution by exact protocol, output identity, and current revision, carries a required reason, preserves the rejected execution and revisions as lineage, and returns the producing protocol to readiness against its unchanged inputs while state derived from the rejected output is no longer current. Regeneration flows only through the ordinary execution paths, which resolve the pending supersession by recording the new execution. The methodology's artifacts and declarations are never mutated by the disposition.
 
 ## What runa Does Not Do
 

--- a/docs/session-surface-contract.md
+++ b/docs/session-surface-contract.md
@@ -189,6 +189,19 @@ protocol, schema, validator, or contract failed to encode what good required.
 The repair belongs at that source, not in an ad hoc override of a conforming
 transition.
 
+That judgment re-enters the graph through one sanctioned, auditable runtime
+operation: the supersession disposition (`runa supersede`). It marks the
+recorded execution of the producing protocol superseded — targeting the exact
+protocol, output identity, and current revision, and carrying a required
+reason — so the protocol becomes READY against its unchanged inputs, while
+the rejected execution and output revisions are preserved as lineage and
+downstream state derived from them is no longer current. The disposition does
+not execute anything: regeneration flows only through the same session
+surface as any other work, and recording the regenerated execution resolves
+the pending supersession. Deleting outputs, mutating inputs to force
+freshness, hand-spawning fixed-protocol servers, or editing execution records
+directly are outside this contract.
+
 ## Lifecycle-Reachability Contract
 
 The session lifecycle is expressed as methodology protocols and driven by

--- a/libagent/src/lib.rs
+++ b/libagent/src/lib.rs
@@ -92,7 +92,8 @@ pub use status::{
 };
 pub use store::{
     ArtifactState, ArtifactStore, ExecutionInput, ExecutionInputMode, ExecutionInputSnapshot,
-    ExecutionRecord, StoreError, ValidationStatus, execution_contract_hash,
+    ExecutionRecord, RejectedOutput, StoreError, SupersedeError, SupersededExecution,
+    ValidationStatus, execution_contract_hash,
 };
 pub use trigger::{TriggerContext, TriggerResult, evaluate as evaluate_trigger};
 pub use validation::{ValidationError, Violation};

--- a/libagent/src/projection.rs
+++ b/libagent/src/projection.rs
@@ -350,9 +350,21 @@ fn protocol_is_current(
         return false;
     };
 
+    // Mirror of the live rule: a supersession pending in this projection —
+    // no store record and no projected re-run yet — keeps the producer
+    // non-current, and a record whose inputs contain a revision rejected by
+    // such a supersession is non-current. A projected re-run of the
+    // producer resolves both within the projection.
+    if projection.pending_supersession(&protocol.name, work_unit) {
+        return false;
+    }
+
     let freshness_inputs = protocol_freshness_inputs(protocol);
 
     if let Some(record) = projection.execution_record(&protocol.name, work_unit) {
+        if projection.record_contains_pending_rejected(record) {
+            return false;
+        }
         let current_inputs =
             projection.execution_input_snapshot(record.input_modes.iter(), work_unit);
         return record.inputs == current_inputs;
@@ -706,6 +718,42 @@ impl<'a> ProjectionState<'a> {
         self.projected_execution_records
             .get(&key)
             .or_else(|| self.store.execution_record(protocol, work_unit))
+    }
+
+    /// Projection view of pending supersession: pending in the store and not
+    /// yet resolved by a projected re-run of the pair within this cascade.
+    fn pending_supersession(&self, protocol: &str, work_unit: Option<&str>) -> bool {
+        self.execution_record(protocol, work_unit).is_none()
+            && self
+                .store
+                .supersessions()
+                .iter()
+                .any(|entry| entry.protocol == protocol && entry.work_unit.as_deref() == work_unit)
+    }
+
+    /// Whether the record's input snapshot contains a revision rejected by a
+    /// supersession still pending in this projection.
+    fn record_contains_pending_rejected(&self, record: &ExecutionRecord) -> bool {
+        record
+            .inputs
+            .artifact_types
+            .iter()
+            .any(|(artifact_type, inputs)| {
+                inputs.iter().any(|input| {
+                    self.store
+                        .supersessions()
+                        .iter()
+                        .filter(|entry| {
+                            self.pending_supersession(&entry.protocol, entry.work_unit.as_deref())
+                        })
+                        .flat_map(|entry| entry.rejected_outputs.iter())
+                        .any(|rejected| {
+                            rejected.artifact_type == *artifact_type
+                                && rejected.instance_id == input.instance_id
+                                && rejected.content_hash == input.content_hash
+                        })
+                })
+            })
     }
 
     fn execution_input_snapshot<'b, I>(
@@ -1682,5 +1730,92 @@ mod tests {
                 projection: ProjectionClass::Current,
             }]
         );
+    }
+
+    /// A pending supersession keeps the producer ready in the projection —
+    /// and the projected cascade resolves it: after the producer's projected
+    /// re-run, the pair is no longer pending within the projection.
+    #[test]
+    fn pending_supersession_reopens_the_producer_in_projection() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join("ws");
+        let mut store = make_store(&tmp.path().join("store"), vec!["intent", "requirements"]);
+        for (artifact_type, instance_id, data, ts) in [
+            ("intent", "seed", json!({"title": "seed"}), 1000u64),
+            ("requirements", "reqs", json!({"title": "reqs"}), 2000u64),
+        ] {
+            let type_dir = ws.join(artifact_type);
+            std::fs::create_dir_all(&type_dir).unwrap();
+            let path = type_dir.join(format!("{instance_id}.json"));
+            std::fs::write(&path, serde_json::to_string_pretty(&data).unwrap()).unwrap();
+            store
+                .record_with_timestamp(artifact_type, instance_id, &path, &data, ts)
+                .unwrap();
+        }
+        let req_hash = store
+            .instances_of("requirements", None)
+            .into_iter()
+            .find(|(id, _)| *id == "reqs")
+            .map(|(_, state)| state.content_hash.clone())
+            .unwrap();
+        let survey = protocol(
+            "survey",
+            &["intent"],
+            &["requirements"],
+            TriggerCondition::OnArtifact {
+                name: "intent".into(),
+            },
+        );
+        store
+            .record_execution(
+                "survey",
+                None,
+                ExecutionRecord {
+                    input_modes: [("intent".to_string(), FreshnessInputMode::ValidOnly)]
+                        .into_iter()
+                        .collect(),
+                    inputs: store.execution_input_snapshot(["intent"], None),
+                },
+            )
+            .unwrap();
+
+        // Suppressed before the disposition.
+        let partials = HashSet::new();
+        let projection = ProjectionState::new(&store, &partials);
+        let ready = discover_ready_candidates_projection(
+            std::slice::from_ref(&survey),
+            &projection,
+            &["survey"],
+            EvaluationScope::Unscoped,
+        );
+        assert!(ready.is_empty());
+
+        store
+            .supersede_execution(
+                &survey,
+                None,
+                &[("requirements".to_string(), "reqs".to_string(), req_hash)],
+                "defective",
+            )
+            .unwrap();
+
+        // Ready in the projection after the disposition; the projected
+        // cascade runs the producer to quiescence.
+        let projected = project_cascade(
+            &[survey],
+            &store,
+            &["survey"],
+            &[Candidate {
+                protocol_name: "survey".into(),
+                work_unit: None,
+            }],
+            &partials,
+            EvaluationScope::Unscoped,
+        );
+        let executed: Vec<&str> = projected
+            .iter()
+            .map(|entry| entry.protocol_name.as_str())
+            .collect();
+        assert_eq!(executed, ["survey"]);
     }
 }

--- a/libagent/src/selection.rs
+++ b/libagent/src/selection.rs
@@ -385,7 +385,21 @@ fn protocol_is_current(
         return false;
     };
 
+    // A pending supersession is an operator judgment that the recorded
+    // execution's output is defective against these very inputs: the
+    // protocol is not current until it regenerates, and the timestamp
+    // fallback below is never consulted for it.
+    if store.pending_supersession(&protocol.name, work_unit) {
+        return false;
+    }
+
     if let Some(record) = store.execution_record(&protocol.name, work_unit) {
+        // A record whose input snapshot contains a pending-rejected revision
+        // derived its outputs from a rejected output upstream: it is not
+        // current regardless of snapshot equality.
+        if record_contains_pending_rejected(store, record) {
+            return false;
+        }
         let current_inputs = execution_input_snapshot_for_freshness_inputs(
             store,
             record.input_modes.iter(),
@@ -406,6 +420,28 @@ fn protocol_is_current(
         })
         .max()
         .is_none_or(|latest_input| latest_input <= output_timestamp)
+}
+
+/// Whether the recorded input snapshot contains a revision rejected by a
+/// still-pending supersession — the recorded execution consumed an output
+/// that governance has judged defective and that has not yet regenerated.
+pub(crate) fn record_contains_pending_rejected(
+    store: &ArtifactStore,
+    record: &ExecutionRecord,
+) -> bool {
+    record
+        .inputs
+        .artifact_types
+        .iter()
+        .any(|(artifact_type, inputs)| {
+            inputs.iter().any(|input| {
+                store.revision_is_pending_rejected(
+                    artifact_type,
+                    &input.instance_id,
+                    &input.content_hash,
+                )
+            })
+        })
 }
 
 /// Merge a freshness mode for an artifact type that may appear under
@@ -3372,5 +3408,276 @@ mod tests {
             .collect();
 
         assert_eq!(ready_from_classify, ready_from_discover);
+    }
+
+    /// Write an artifact file to disk and record it with a timestamp,
+    /// returning its content hash. Supersession tests need real files
+    /// because the disposition preserves the rejected content from disk.
+    fn record_file_with_timestamp(
+        store: &mut ArtifactStore,
+        dir: &std::path::Path,
+        artifact_type: &str,
+        instance_id: &str,
+        data: &serde_json::Value,
+        timestamp_ms: u64,
+    ) -> String {
+        let type_dir = dir.join(artifact_type);
+        std::fs::create_dir_all(&type_dir).unwrap();
+        let path = type_dir.join(format!("{instance_id}.json"));
+        std::fs::write(&path, serde_json::to_string_pretty(data).unwrap()).unwrap();
+        store
+            .record_with_timestamp(artifact_type, instance_id, &path, data, timestamp_ms)
+            .unwrap();
+        store
+            .instances_of(artifact_type, None)
+            .into_iter()
+            .find(|(id, _)| *id == instance_id)
+            .map(|(_, state)| state.content_hash.clone())
+            .unwrap()
+    }
+
+    fn valid_only_record(store: &ArtifactStore, input_type: &str) -> ExecutionRecord {
+        ExecutionRecord {
+            input_modes: [(input_type.to_string(), FreshnessInputMode::ValidOnly)]
+                .into_iter()
+                .collect(),
+            inputs: store.execution_input_snapshot([input_type], None),
+        }
+    }
+
+    fn status_of<'a>(classified: &'a [ClassifiedCandidate], name: &str) -> &'a CandidateStatus {
+        &classified
+            .iter()
+            .find(|candidate| candidate.protocol_name == name)
+            .unwrap_or_else(|| panic!("no candidate '{name}'"))
+            .status
+    }
+
+    /// The complete planning case from tesserine/runa#248:
+    /// `intent → survey → requirements → decompose`, a byte-identical intent,
+    /// suppression via execution records, supersession of the rejected
+    /// requirements, regeneration of survey against the unchanged intent, and
+    /// correct downstream invalidation.
+    #[test]
+    fn supersession_regenerates_the_planning_case_against_unchanged_inputs() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join("ws");
+        let mut store = make_store(
+            &tmp.path().join("s"),
+            vec!["intent", "requirements", "work-units"],
+        );
+        record_file_with_timestamp(
+            &mut store,
+            &ws,
+            "intent",
+            "replace-forge-connectors",
+            &json!({"title": "replace forge connectors with native radicle"}),
+            1000,
+        );
+        let rejected_hash = record_file_with_timestamp(
+            &mut store,
+            &ws,
+            "requirements",
+            "radicle-native-collaboration",
+            &json!({"title": "requirements v1"}),
+            2000,
+        );
+        record_file_with_timestamp(
+            &mut store,
+            &ws,
+            "work-units",
+            "wu-plan",
+            &json!({"title": "decomposed work"}),
+            3000,
+        );
+        store
+            .record_execution("survey", None, valid_only_record(&store, "intent"))
+            .unwrap();
+        store
+            .record_execution("decompose", None, valid_only_record(&store, "requirements"))
+            .unwrap();
+
+        let survey = make_protocol(
+            "survey",
+            &["intent"],
+            &[],
+            &["requirements"],
+            &[],
+            TriggerCondition::OnArtifact {
+                name: "intent".into(),
+            },
+        );
+        let decompose = make_protocol(
+            "decompose",
+            &["requirements"],
+            &[],
+            &["work-units"],
+            &[],
+            TriggerCondition::OnArtifact {
+                name: "requirements".into(),
+            },
+        );
+        let protocols = [survey.clone(), decompose];
+        let order = ["survey", "decompose"];
+
+        // Baseline: both executions recorded against current inputs — the
+        // whole pipeline is suppressed as outputs-current.
+        let classified = classify_candidates(
+            &protocols,
+            &store,
+            &order,
+            &HashSet::new(),
+            EvaluationScope::Unscoped,
+        );
+        for name in ["survey", "decompose"] {
+            assert!(
+                matches!(
+                    status_of(&classified, name),
+                    CandidateStatus::Waiting {
+                        waiting_reason: WaitingReason::OutputsCurrent,
+                        ..
+                    }
+                ),
+                "expected '{name}' suppressed as outputs-current"
+            );
+        }
+
+        // Governance rejects the conforming requirements: the disposition
+        // supersedes survey's execution, targeting the exact revision.
+        store
+            .supersede_execution(
+                &survey,
+                None,
+                &[(
+                    "requirements".to_string(),
+                    "radicle-native-collaboration".to_string(),
+                    rejected_hash.clone(),
+                )],
+                "requirements found substantively defective by governance",
+            )
+            .unwrap();
+
+        // The producer is READY against the unchanged intent; downstream
+        // state derived from the rejected output is no longer current.
+        let classified = classify_candidates(
+            &protocols,
+            &store,
+            &order,
+            &HashSet::new(),
+            EvaluationScope::Unscoped,
+        );
+        assert!(
+            matches!(status_of(&classified, "survey"), CandidateStatus::Ready),
+            "survey must regenerate against unchanged inputs"
+        );
+        assert!(
+            matches!(status_of(&classified, "decompose"), CandidateStatus::Ready),
+            "decompose derived from the rejected revision must not be current"
+        );
+
+        // Regeneration: survey re-executes against the byte-identical intent
+        // and produces a corrected requirements revision; the new execution
+        // is recorded through the normal path.
+        let regenerated_hash = record_file_with_timestamp(
+            &mut store,
+            &ws,
+            "requirements",
+            "radicle-native-collaboration",
+            &json!({"title": "requirements v2 — corrected"}),
+            4000,
+        );
+        assert_ne!(regenerated_hash, rejected_hash);
+        store
+            .record_execution("survey", None, valid_only_record(&store, "intent"))
+            .unwrap();
+
+        // Survey is current again; decompose reopens by the ordinary
+        // snapshot rule because its recorded input revision changed.
+        let classified = classify_candidates(
+            &protocols,
+            &store,
+            &order,
+            &HashSet::new(),
+            EvaluationScope::Unscoped,
+        );
+        assert!(matches!(
+            status_of(&classified, "survey"),
+            CandidateStatus::Waiting {
+                waiting_reason: WaitingReason::OutputsCurrent,
+                ..
+            }
+        ));
+        assert!(matches!(
+            status_of(&classified, "decompose"),
+            CandidateStatus::Ready
+        ));
+
+        // The rejected execution and output remain inspectable as lineage.
+        let lineage = store.supersessions();
+        assert_eq!(lineage.len(), 1);
+        assert_eq!(lineage[0].protocol, "survey");
+        assert_eq!(lineage[0].rejected_outputs[0].content_hash, rejected_hash);
+        assert_eq!(
+            lineage[0].rejected_outputs[0].content,
+            json!({"title": "requirements v1"})
+        );
+    }
+
+    #[test]
+    fn pending_supersession_bypasses_the_timestamp_fallback() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join("ws");
+        let mut store = make_store(&tmp.path().join("s"), vec!["intent", "requirements"]);
+        // Output strictly newer than the input: the fallback alone would
+        // report the protocol current.
+        record_file_with_timestamp(
+            &mut store,
+            &ws,
+            "intent",
+            "seed",
+            &json!({"title": "seed"}),
+            1000,
+        );
+        let req_hash = record_file_with_timestamp(
+            &mut store,
+            &ws,
+            "requirements",
+            "reqs",
+            &json!({"title": "reqs"}),
+            2000,
+        );
+        let survey = make_protocol(
+            "survey",
+            &["intent"],
+            &[],
+            &["requirements"],
+            &[],
+            TriggerCondition::OnArtifact {
+                name: "intent".into(),
+            },
+        );
+        store
+            .record_execution("survey", None, valid_only_record(&store, "intent"))
+            .unwrap();
+        store
+            .supersede_execution(
+                &survey,
+                None,
+                &[("requirements".to_string(), "reqs".to_string(), req_hash)],
+                "defective",
+            )
+            .unwrap();
+
+        let classified = classify_candidates(
+            &[survey],
+            &store,
+            &["survey"],
+            &HashSet::new(),
+            EvaluationScope::Unscoped,
+        );
+        assert!(matches!(
+            status_of(&classified, "survey"),
+            CandidateStatus::Ready
+        ));
     }
 }

--- a/libagent/src/session.rs
+++ b/libagent/src/session.rs
@@ -1338,6 +1338,81 @@ trigger = { type = "on_artifact", name = "work-unit" }
         assert!(session.store().execution_record("survey", None).is_some());
     }
 
+    /// AC4 of tesserine/runa#248 at the session layer: after a supersession,
+    /// the ordinary session surface serves the superseded protocol as the
+    /// current step, and its `advance` records the regenerated execution,
+    /// resolving the pending supersession.
+    #[test]
+    fn session_serves_and_records_the_superseded_step() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = write_unscoped_session_project(dir.path());
+
+        // First pass: the session executes survey and records it — the
+        // pipeline is then suppressed as outputs-current.
+        let mut session = SessionState::open(project_dir.clone(), None, None).unwrap();
+        let workspace = project_dir.join(".runa/workspace");
+        fs::create_dir_all(workspace.join("requirements")).unwrap();
+        fs::write(
+            workspace.join("requirements/requirements-1.json"),
+            r#"{"scope":"v1","functional_requirements":["defective"]}"#,
+        )
+        .unwrap();
+        session.advance_with_validator(|_, _| Ok(())).unwrap();
+        drop(session);
+        let suppressed = SessionState::open(project_dir.clone(), None, None).unwrap();
+        assert!(suppressed.current_step().is_none());
+        drop(suppressed);
+
+        // Governance supersedes the recorded execution, targeting the exact
+        // current revision, through the store the session persists into.
+        let mut loaded = crate::project::load(&project_dir, None).unwrap();
+        crate::scan(&loaded.workspace_dir, &mut loaded.store).unwrap();
+        let survey = loaded
+            .manifest
+            .protocols
+            .iter()
+            .find(|protocol| protocol.name == "survey")
+            .cloned()
+            .unwrap();
+        let rejected_hash = loaded
+            .store
+            .instances_of("requirements", None)
+            .into_iter()
+            .find(|(id, _)| *id == "requirements-1")
+            .map(|(_, state)| state.content_hash.clone())
+            .unwrap();
+        loaded
+            .store
+            .supersede_execution(
+                &survey,
+                None,
+                &[(
+                    "requirements".to_string(),
+                    "requirements-1".to_string(),
+                    rejected_hash,
+                )],
+                "governance judged the conforming requirements defective",
+            )
+            .unwrap();
+        drop(loaded);
+
+        // The normal session path serves the superseded step again and its
+        // advance records the regenerated execution.
+        let mut session = SessionState::open(project_dir.clone(), None, None).unwrap();
+        let step = session.current_step().expect("superseded step is served");
+        assert_eq!(step.protocol, "survey");
+        fs::write(
+            workspace.join("requirements/requirements-1.json"),
+            r#"{"scope":"v2","functional_requirements":["corrected"]}"#,
+        )
+        .unwrap();
+        let advance = session.advance_with_validator(|_, _| Ok(())).unwrap();
+        assert_eq!(advance.payload.completed_step.protocol, "survey");
+        assert!(session.store().execution_record("survey", None).is_some());
+        assert!(!session.store().pending_supersession("survey", None));
+        assert_eq!(session.store().supersessions().len(), 1);
+    }
+
     #[test]
     fn open_entry_re_entry_binds_without_acquisition_surface() {
         let _env = unset_forge_env();

--- a/libagent/src/store.rs
+++ b/libagent/src/store.rs
@@ -2608,6 +2608,7 @@ mod tests {
                 name: produces[0].into(),
             },
             instructions: None,
+            workflow_mechanics: None,
         }
     }
 

--- a/libagent/src/store.rs
+++ b/libagent/src/store.rs
@@ -24,6 +24,7 @@ pub struct ArtifactStore {
     artifact_types: HashMap<String, ArtifactType>,
     artifacts: HashMap<(String, String), ArtifactState>,
     execution_records: HashMap<(String, Option<String>), ExecutionRecord>,
+    supersessions: Vec<SupersededExecution>,
     execution_contract_hash: Option<String>,
     store_dir: PathBuf,
     // Populated by scan() for the current process only. These observations are
@@ -78,6 +79,156 @@ pub struct ExecutionRecord {
     #[serde(default)]
     pub input_modes: BTreeMap<String, ExecutionInputMode>,
     pub inputs: ExecutionInputSnapshot,
+}
+
+/// One output revision rejected by a supersession disposition. Carries the
+/// exact identity (`artifact_type`, `instance_id`, `content_hash`) the
+/// disposition targeted, plus the rejected artifact content itself so the
+/// revision stays inspectable after regeneration overwrites the workspace
+/// instance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RejectedOutput {
+    pub artifact_type: String,
+    pub instance_id: String,
+    pub content_hash: String,
+    pub content: Value,
+}
+
+/// A superseded protocol execution retained as lineage. Created by
+/// [`ArtifactStore::supersede_execution`]: the disposition's target, its
+/// auditable reason, the output revisions it rejected, and the execution
+/// record it displaced.
+///
+/// A supersession is **pending** while its `(protocol, work_unit)` pair has
+/// no current execution record — pendingness is computed from that relation,
+/// never stored. Recording a new execution for the pair (through any
+/// recording path, including the session surface's staged commit) resolves
+/// the pending state; the entry itself is append-only lineage.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SupersededExecution {
+    pub protocol: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_unit: Option<String>,
+    pub reason: String,
+    pub rejected_outputs: Vec<RejectedOutput>,
+    pub superseded_record: ExecutionRecord,
+}
+
+/// Rejections of a supersession disposition, each naming the exact mismatch
+/// between the disposition and current reality.
+#[derive(Debug)]
+pub enum SupersedeError {
+    /// The disposition names no rejected output.
+    EmptyOutputs,
+    /// The disposition carries no reason; the judgment must be auditable.
+    EmptyReason,
+    /// No execution record exists for the targeted `(protocol, work_unit)`.
+    NoExecutionRecord {
+        protocol: String,
+        work_unit: Option<String>,
+    },
+    /// The named artifact type is not an output the protocol declares.
+    UndeclaredOutputType {
+        protocol: String,
+        artifact_type: String,
+    },
+    /// The named instance is not recorded for the targeted scope.
+    UnknownInstance {
+        artifact_type: String,
+        instance_id: String,
+        work_unit: Option<String>,
+    },
+    /// The supplied revision does not match the instance's current content.
+    StaleRevision {
+        artifact_type: String,
+        instance_id: String,
+        supplied: String,
+        current: String,
+    },
+    /// The rejected artifact's workspace file could not be read for
+    /// preservation as lineage evidence.
+    UnreadableArtifact {
+        artifact_type: String,
+        instance_id: String,
+        path: PathBuf,
+        detail: String,
+    },
+    /// The underlying store operation failed.
+    Store(StoreError),
+}
+
+impl fmt::Display for SupersedeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn scope(work_unit: &Option<String>) -> String {
+            match work_unit {
+                Some(id) => format!(" (work unit '{id}')"),
+                None => String::new(),
+            }
+        }
+        match self {
+            SupersedeError::EmptyOutputs => {
+                write!(f, "a supersession must name at least one rejected output")
+            }
+            SupersedeError::EmptyReason => {
+                write!(f, "a supersession must carry a non-empty reason")
+            }
+            SupersedeError::NoExecutionRecord {
+                protocol,
+                work_unit,
+            } => write!(
+                f,
+                "no recorded execution exists for protocol '{protocol}'{}",
+                scope(work_unit)
+            ),
+            SupersedeError::UndeclaredOutputType {
+                protocol,
+                artifact_type,
+            } => write!(
+                f,
+                "protocol '{protocol}' does not declare output artifact type '{artifact_type}'"
+            ),
+            SupersedeError::UnknownInstance {
+                artifact_type,
+                instance_id,
+                work_unit,
+            } => write!(
+                f,
+                "no recorded instance '{artifact_type}/{instance_id}'{}",
+                scope(work_unit)
+            ),
+            SupersedeError::StaleRevision {
+                artifact_type,
+                instance_id,
+                supplied,
+                current,
+            } => write!(
+                f,
+                "revision '{supplied}' is not the current revision of \
+                 '{artifact_type}/{instance_id}'; the current revision is '{current}'"
+            ),
+            SupersedeError::UnreadableArtifact {
+                artifact_type,
+                instance_id,
+                path,
+                detail,
+            } => write!(
+                f,
+                "cannot preserve rejected artifact '{artifact_type}/{instance_id}' \
+                 from '{}': {detail}",
+                path.display()
+            ),
+            SupersedeError::Store(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for SupersedeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SupersedeError::Store(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 /// Validation status of an artifact instance.
@@ -202,12 +353,14 @@ struct PersistedArtifactState {
     work_unit: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct PersistedExecutionRecords {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     contract_hash: Option<String>,
     #[serde(default)]
     records: Vec<PersistedExecutionRecord>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    supersessions: Vec<SupersededExecution>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -353,7 +506,7 @@ fn serialize_artifact_state(state: &ArtifactState) -> Result<String, StoreError>
 
 fn deserialize_execution_records(
     content: &str,
-) -> Result<(Option<String>, ExecutionRecordMap), StoreError> {
+) -> Result<(Option<String>, ExecutionRecordMap, Vec<SupersededExecution>), StoreError> {
     let persisted: PersistedExecutionRecords =
         serde_json::from_str(content).map_err(|e| StoreError::Serialization(e.to_string()))?;
     let records = persisted
@@ -373,12 +526,13 @@ fn deserialize_execution_records(
             ))
         })
         .collect();
-    Ok((persisted.contract_hash, records))
+    Ok((persisted.contract_hash, records, persisted.supersessions))
 }
 
 fn serialize_execution_records(
     contract_hash: Option<&str>,
     records: &ExecutionRecordMap,
+    supersessions: &[SupersededExecution],
 ) -> Result<String, StoreError> {
     let mut persisted_records: Vec<_> = records
         .iter()
@@ -397,6 +551,7 @@ fn serialize_execution_records(
     serde_json::to_string_pretty(&PersistedExecutionRecords {
         contract_hash: contract_hash.map(str::to_owned),
         records: persisted_records,
+        supersessions: supersessions.to_vec(),
     })
     .map_err(|e| StoreError::Serialization(e.to_string()))
 }
@@ -473,10 +628,12 @@ impl ArtifactStore {
         }
 
         let execution_records_path = store_dir.join("execution-records.json");
-        let (execution_contract_hash, execution_records) =
+        let (execution_contract_hash, execution_records, supersessions) =
             match std::fs::read_to_string(&execution_records_path) {
                 Ok(content) => deserialize_execution_records(&content)?,
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => (None, HashMap::new()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    (None, HashMap::new(), Vec::new())
+                }
                 Err(err) => return Err(StoreError::Io(err)),
             };
 
@@ -484,6 +641,7 @@ impl ArtifactStore {
             artifact_types: type_map,
             artifacts,
             execution_records,
+            supersessions,
             execution_contract_hash,
             store_dir,
             type_level_scan_gaps: HashSet::new(),
@@ -603,6 +761,154 @@ impl ArtifactStore {
         self.execution_records
             .remove(&(protocol.to_string(), work_unit.map(str::to_owned)));
         self.persist_execution_records()
+    }
+
+    /// Apply a supersession disposition: mark the recorded execution of
+    /// `protocol` for `work_unit` as superseded, rejecting the named output
+    /// revisions, so the protocol regenerates against its unchanged inputs.
+    ///
+    /// The disposition is guarded against current reality: an execution
+    /// record must exist for the pair, every named output must be an output
+    /// the protocol declares, its instance must be recorded for the scope,
+    /// and the supplied revision must equal the instance's current content
+    /// hash — each mismatch is rejected with a diagnostic naming it. On
+    /// success the current record moves into an append-only
+    /// [`SupersededExecution`] lineage entry together with the rejected
+    /// artifact content (read back from the workspace file and verified
+    /// against the supplied revision), and the pair is left with no current
+    /// record: the pending state that [`Self::pending_supersession`]
+    /// reports, resolved by the next recorded execution.
+    pub fn supersede_execution(
+        &mut self,
+        protocol: &crate::model::ProtocolDeclaration,
+        work_unit: Option<&str>,
+        rejected_outputs: &[(String, String, String)],
+        reason: &str,
+    ) -> Result<(), SupersedeError> {
+        if reason.trim().is_empty() {
+            return Err(SupersedeError::EmptyReason);
+        }
+        if rejected_outputs.is_empty() {
+            return Err(SupersedeError::EmptyOutputs);
+        }
+        let record = self
+            .execution_record(&protocol.name, work_unit)
+            .cloned()
+            .ok_or_else(|| SupersedeError::NoExecutionRecord {
+                protocol: protocol.name.clone(),
+                work_unit: work_unit.map(str::to_owned),
+            })?;
+
+        let mut preserved = Vec::with_capacity(rejected_outputs.len());
+        for (artifact_type, instance_id, supplied_hash) in rejected_outputs {
+            let declared = protocol
+                .produces
+                .iter()
+                .chain(protocol.may_produce.iter())
+                .chain(protocol.required_choice_members())
+                .any(|declared| declared == artifact_type);
+            if !declared {
+                return Err(SupersedeError::UndeclaredOutputType {
+                    protocol: protocol.name.clone(),
+                    artifact_type: artifact_type.clone(),
+                });
+            }
+
+            let state = self
+                .instances_of(artifact_type, work_unit)
+                .into_iter()
+                .find(|(id, _)| id == instance_id)
+                .map(|(_, state)| state.clone())
+                .ok_or_else(|| SupersedeError::UnknownInstance {
+                    artifact_type: artifact_type.clone(),
+                    instance_id: instance_id.clone(),
+                    work_unit: work_unit.map(str::to_owned),
+                })?;
+            if state.content_hash != *supplied_hash {
+                return Err(SupersedeError::StaleRevision {
+                    artifact_type: artifact_type.clone(),
+                    instance_id: instance_id.clone(),
+                    supplied: supplied_hash.clone(),
+                    current: state.content_hash.clone(),
+                });
+            }
+
+            let unreadable = |detail: String| SupersedeError::UnreadableArtifact {
+                artifact_type: artifact_type.clone(),
+                instance_id: instance_id.clone(),
+                path: state.path.clone(),
+                detail,
+            };
+            let raw =
+                std::fs::read_to_string(&state.path).map_err(|err| unreadable(err.to_string()))?;
+            let content: Value =
+                serde_json::from_str(&raw).map_err(|err| unreadable(err.to_string()))?;
+            let file_hash = content_hash(&content);
+            if file_hash != *supplied_hash {
+                return Err(SupersedeError::StaleRevision {
+                    artifact_type: artifact_type.clone(),
+                    instance_id: instance_id.clone(),
+                    supplied: supplied_hash.clone(),
+                    current: file_hash,
+                });
+            }
+
+            preserved.push(RejectedOutput {
+                artifact_type: artifact_type.clone(),
+                instance_id: instance_id.clone(),
+                content_hash: supplied_hash.clone(),
+                content,
+            });
+        }
+
+        self.execution_records
+            .remove(&(protocol.name.clone(), work_unit.map(str::to_owned)));
+        self.supersessions.push(SupersededExecution {
+            protocol: protocol.name.clone(),
+            work_unit: work_unit.map(str::to_owned),
+            reason: reason.to_string(),
+            rejected_outputs: preserved,
+            superseded_record: record,
+        });
+        self.persist_execution_records()
+            .map_err(SupersedeError::Store)
+    }
+
+    /// All supersession lineage entries, in disposition order.
+    pub fn supersessions(&self) -> &[SupersededExecution] {
+        &self.supersessions
+    }
+
+    /// Whether `(protocol, work_unit)` has a superseded execution and no
+    /// current execution record — the state in which the protocol must
+    /// regenerate against its unchanged inputs.
+    pub fn pending_supersession(&self, protocol: &str, work_unit: Option<&str>) -> bool {
+        self.execution_record(protocol, work_unit).is_none()
+            && self
+                .supersessions
+                .iter()
+                .any(|entry| entry.protocol == protocol && entry.work_unit.as_deref() == work_unit)
+    }
+
+    /// Whether the exact revision `(artifact_type, instance_id,
+    /// content_hash)` is rejected by a supersession that is still pending.
+    /// Execution records whose input snapshots contain such a revision are
+    /// not current: their recorded inputs derive from a rejected output.
+    pub fn revision_is_pending_rejected(
+        &self,
+        artifact_type: &str,
+        instance_id: &str,
+        content_hash: &str,
+    ) -> bool {
+        self.supersessions
+            .iter()
+            .filter(|entry| self.pending_supersession(&entry.protocol, entry.work_unit.as_deref()))
+            .flat_map(|entry| entry.rejected_outputs.iter())
+            .any(|rejected| {
+                rejected.artifact_type == artifact_type
+                    && rejected.instance_id == instance_id
+                    && rejected.content_hash == content_hash
+            })
     }
 
     pub(crate) fn stage_execution_record(
@@ -1004,6 +1310,7 @@ impl ArtifactStore {
         let json = serialize_execution_records(
             self.execution_contract_hash.as_deref(),
             &self.execution_records,
+            &self.supersessions,
         )?;
         std::fs::write(&tmp_path, json).map_err(StoreError::Io)?;
         std::fs::rename(&tmp_path, &file_path).map_err(StoreError::Io)?;
@@ -2286,5 +2593,292 @@ mod tests {
         let persisted = std::fs::read_to_string(type_dir.join("spec.json")).unwrap();
         assert!(persisted.contains("\"display_path\": \"reports/spec.json\""));
         assert!(persisted.contains("\"unix_bytes\""), "{persisted}");
+    }
+
+    fn supersede_test_protocol(name: &str, produces: &[&str]) -> crate::model::ProtocolDeclaration {
+        crate::model::ProtocolDeclaration {
+            name: name.into(),
+            requires: Vec::new(),
+            accepts: Vec::new(),
+            produces: produces.iter().map(|s| s.to_string()).collect(),
+            may_produce: Vec::new(),
+            required_output_choices: Vec::new(),
+            scoped: false,
+            trigger: crate::model::TriggerCondition::OnChange {
+                name: produces[0].into(),
+            },
+            instructions: None,
+        }
+    }
+
+    /// Write an artifact file to disk and record it, returning its content hash.
+    fn record_file(
+        store: &mut ArtifactStore,
+        dir: &Path,
+        artifact_type: &str,
+        instance_id: &str,
+        data: &Value,
+    ) -> String {
+        let type_dir = dir.join(artifact_type);
+        std::fs::create_dir_all(&type_dir).unwrap();
+        let path = type_dir.join(format!("{instance_id}.json"));
+        std::fs::write(&path, serde_json::to_string_pretty(data).unwrap()).unwrap();
+        store
+            .record(artifact_type, instance_id, &path, data)
+            .unwrap();
+        store
+            .get(artifact_type, instance_id)
+            .unwrap()
+            .content_hash
+            .clone()
+    }
+
+    fn simple_record(store: &ArtifactStore, input_type: &str) -> ExecutionRecord {
+        ExecutionRecord {
+            input_modes: BTreeMap::from([(input_type.to_string(), ExecutionInputMode::ValidOnly)]),
+            inputs: store.execution_input_snapshot([input_type], None),
+        }
+    }
+
+    #[test]
+    fn supersede_moves_record_to_pending_lineage_and_persists() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join("ws");
+        let store_dir = tmp.path().join("store");
+        let mut store = make_store(&store_dir, vec!["intent", "requirements"]);
+        record_file(&mut store, &ws, "intent", "seed", &json!({"title": "seed"}));
+        let req_hash = record_file(
+            &mut store,
+            &ws,
+            "requirements",
+            "reqs",
+            &json!({"title": "reqs"}),
+        );
+
+        let protocol = supersede_test_protocol("survey", &["requirements"]);
+        let record = simple_record(&store, "intent");
+        store
+            .record_execution("survey", None, record.clone())
+            .unwrap();
+
+        store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "reqs".into(), req_hash.clone())],
+                "governance found the requirements defective",
+            )
+            .unwrap();
+
+        assert!(store.execution_record("survey", None).is_none());
+        assert!(store.pending_supersession("survey", None));
+        assert!(store.revision_is_pending_rejected("requirements", "reqs", &req_hash));
+        let lineage = store.supersessions();
+        assert_eq!(lineage.len(), 1);
+        assert_eq!(lineage[0].superseded_record, record);
+        assert_eq!(
+            lineage[0].rejected_outputs[0].content,
+            json!({"title": "reqs"})
+        );
+        assert_eq!(
+            lineage[0].reason,
+            "governance found the requirements defective"
+        );
+
+        // The lineage and the pending state survive a store reload.
+        drop(store);
+        let reloaded = make_store(&store_dir, vec!["intent", "requirements"]);
+        assert!(reloaded.pending_supersession("survey", None));
+        assert!(reloaded.revision_is_pending_rejected("requirements", "reqs", &req_hash));
+        assert_eq!(reloaded.supersessions().len(), 1);
+        assert_eq!(
+            reloaded.supersessions()[0].rejected_outputs[0].content,
+            json!({"title": "reqs"})
+        );
+    }
+
+    #[test]
+    fn recording_a_new_execution_resolves_the_pending_supersession() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join("ws");
+        let mut store = make_store(&tmp.path().join("store"), vec!["intent", "requirements"]);
+        record_file(&mut store, &ws, "intent", "seed", &json!({"title": "seed"}));
+        let req_hash = record_file(
+            &mut store,
+            &ws,
+            "requirements",
+            "reqs",
+            &json!({"title": "reqs"}),
+        );
+
+        let protocol = supersede_test_protocol("survey", &["requirements"]);
+        store
+            .record_execution("survey", None, simple_record(&store, "intent"))
+            .unwrap();
+        store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "reqs".into(), req_hash.clone())],
+                "defective",
+            )
+            .unwrap();
+        assert!(store.pending_supersession("survey", None));
+
+        store
+            .record_execution("survey", None, simple_record(&store, "intent"))
+            .unwrap();
+        assert!(!store.pending_supersession("survey", None));
+        assert!(!store.revision_is_pending_rejected("requirements", "reqs", &req_hash));
+        // The lineage entry stays, resolved.
+        assert_eq!(store.supersessions().len(), 1);
+    }
+
+    #[test]
+    fn supersede_rejects_each_mismatch_with_an_accurate_diagnostic() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join("ws");
+        let mut store = make_store(&tmp.path().join("store"), vec!["intent", "requirements"]);
+        record_file(&mut store, &ws, "intent", "seed", &json!({"title": "seed"}));
+        let req_hash = record_file(
+            &mut store,
+            &ws,
+            "requirements",
+            "reqs",
+            &json!({"title": "reqs"}),
+        );
+        let protocol = supersede_test_protocol("survey", &["requirements"]);
+
+        // No execution record for the target.
+        let err = store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "reqs".into(), req_hash.clone())],
+                "reason",
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, SupersedeError::NoExecutionRecord { .. }),
+            "{err}"
+        );
+
+        store
+            .record_execution("survey", None, simple_record(&store, "intent"))
+            .unwrap();
+
+        // Empty reason.
+        let err = store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "reqs".into(), req_hash.clone())],
+                "  ",
+            )
+            .unwrap_err();
+        assert!(matches!(err, SupersedeError::EmptyReason), "{err}");
+
+        // No outputs named.
+        let err = store
+            .supersede_execution(&protocol, None, &[], "reason")
+            .unwrap_err();
+        assert!(matches!(err, SupersedeError::EmptyOutputs), "{err}");
+
+        // Output type the protocol does not declare.
+        let err = store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("intent".into(), "seed".into(), "sha256:x".into())],
+                "reason",
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, SupersedeError::UndeclaredOutputType { .. }),
+            "{err}"
+        );
+
+        // Instance not recorded.
+        let err = store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "absent".into(), req_hash.clone())],
+                "reason",
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, SupersedeError::UnknownInstance { .. }),
+            "{err}"
+        );
+
+        // Stale revision: diagnostic names the current hash.
+        let err = store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "reqs".into(), "sha256:stale".into())],
+                "reason",
+            )
+            .unwrap_err();
+        match &err {
+            SupersedeError::StaleRevision {
+                current, supplied, ..
+            } => {
+                assert_eq!(current, &req_hash);
+                assert_eq!(supplied, "sha256:stale");
+            }
+            other => panic!("expected StaleRevision, got: {other:?}"),
+        }
+
+        // Every rejection left the record and lineage untouched.
+        assert!(store.execution_record("survey", None).is_some());
+        assert!(store.supersessions().is_empty());
+        assert!(!store.pending_supersession("survey", None));
+    }
+
+    #[test]
+    fn supersede_rejects_an_unreadable_workspace_artifact() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = make_store(&tmp.path().join("store"), vec!["intent", "requirements"]);
+        // Recorded state with no backing file on disk.
+        store
+            .record(
+                "requirements",
+                "reqs",
+                &tmp.path().join("ws/requirements/reqs.json"),
+                &json!({"title": "reqs"}),
+            )
+            .unwrap();
+        let req_hash = store
+            .get("requirements", "reqs")
+            .unwrap()
+            .content_hash
+            .clone();
+        let protocol = supersede_test_protocol("survey", &["requirements"]);
+        store
+            .record_execution(
+                "survey",
+                None,
+                ExecutionRecord {
+                    input_modes: BTreeMap::new(),
+                    inputs: ExecutionInputSnapshot::default(),
+                },
+            )
+            .unwrap();
+
+        let err = store
+            .supersede_execution(
+                &protocol,
+                None,
+                &[("requirements".into(), "reqs".into(), req_hash)],
+                "reason",
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, SupersedeError::UnreadableArtifact { .. }),
+            "{err}"
+        );
+        assert!(store.execution_record("survey", None).is_some());
     }
 }

--- a/runa-cli/src/commands/mod.rs
+++ b/runa-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod run;
 pub mod scan;
 pub mod state;
 pub mod step;
+pub mod supersede;
 
 #[derive(Debug)]
 pub enum CommandError {

--- a/runa-cli/src/commands/supersede.rs
+++ b/runa-cli/src/commands/supersede.rs
@@ -1,0 +1,183 @@
+//! `runa supersede` — apply a supersession disposition to a recorded
+//! protocol execution.
+//!
+//! The disposition marks a conforming-but-rejected execution result as
+//! superseded so the producing protocol regenerates against its unchanged
+//! inputs. It is guarded against current reality: the targeted protocol,
+//! output identity, and revision must all match what is recorded now, and
+//! the judgment must carry an auditable reason. The rejected revision is
+//! preserved in the supersession lineage; regeneration itself flows only
+//! through the normal `step`/`run`/`go`/session paths.
+
+use std::fmt;
+use std::path::Path;
+
+use super::CommandError;
+
+#[derive(Debug)]
+pub enum SupersedeCommandError {
+    Command(CommandError),
+    /// An `--output` token does not parse as `<type>/<instance>@<revision>`.
+    MalformedOutput(String),
+    /// The named protocol is not declared by the methodology.
+    UnknownProtocol(String),
+    /// The store rejected the disposition.
+    Disposition(libagent::SupersedeError),
+}
+
+impl fmt::Display for SupersedeCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SupersedeCommandError::Command(err) => write!(f, "{err}"),
+            SupersedeCommandError::MalformedOutput(token) => write!(
+                f,
+                "malformed --output '{token}': expected <type>/<instance>@<revision>, \
+                 for example 'requirements/radicle-native-collaboration@sha256:abc123'"
+            ),
+            SupersedeCommandError::UnknownProtocol(name) => {
+                write!(f, "unknown protocol: '{name}'")
+            }
+            SupersedeCommandError::Disposition(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for SupersedeCommandError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SupersedeCommandError::Command(err) => Some(err),
+            SupersedeCommandError::Disposition(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<CommandError> for SupersedeCommandError {
+    fn from(err: CommandError) -> Self {
+        SupersedeCommandError::Command(err)
+    }
+}
+
+impl SupersedeCommandError {
+    /// Exit-code mapping: malformed invocation is a usage error; a
+    /// disposition rejected against current reality is a generic failure;
+    /// project-load, scan, and store I/O failures are infrastructure.
+    pub fn exit_code(&self) -> crate::exit_codes::ExitCode {
+        match self {
+            SupersedeCommandError::MalformedOutput(_) => crate::exit_codes::ExitCode::UsageError,
+            SupersedeCommandError::UnknownProtocol(_) => {
+                crate::exit_codes::ExitCode::GenericFailure
+            }
+            SupersedeCommandError::Disposition(libagent::SupersedeError::Store(_)) => {
+                crate::exit_codes::ExitCode::InfrastructureFailure
+            }
+            SupersedeCommandError::Disposition(_) => crate::exit_codes::ExitCode::GenericFailure,
+            SupersedeCommandError::Command(_) => crate::exit_codes::ExitCode::InfrastructureFailure,
+        }
+    }
+}
+
+/// Parse one `--output` token of the form `<type>/<instance>@<revision>`
+/// into its `(artifact_type, instance_id, content_hash)` identity.
+fn parse_output_token(token: &str) -> Option<(String, String, String)> {
+    let (identity, revision) = token.split_once('@')?;
+    let (artifact_type, instance_id) = identity.split_once('/')?;
+    if artifact_type.is_empty() || instance_id.is_empty() || revision.is_empty() {
+        return None;
+    }
+    Some((
+        artifact_type.to_string(),
+        instance_id.to_string(),
+        revision.to_string(),
+    ))
+}
+
+pub fn run(
+    working_dir: &Path,
+    config_override: Option<&Path>,
+    protocol: &str,
+    work_unit: Option<&str>,
+    outputs: &[String],
+    reason: &str,
+) -> Result<(), SupersedeCommandError> {
+    let parsed: Vec<(String, String, String)> = outputs
+        .iter()
+        .map(|token| {
+            parse_output_token(token)
+                .ok_or_else(|| SupersedeCommandError::MalformedOutput(token.clone()))
+        })
+        .collect::<Result<_, _>>()?;
+
+    // Scan first so the revision guard checks current reality, and validate
+    // scoped identity exactly as the other scope-taking commands do.
+    let (mut loaded, _scan_result) = super::load_and_scan(working_dir, config_override)?;
+    super::validate_scoped_work_unit(&loaded, work_unit)?;
+
+    let declaration = loaded
+        .manifest
+        .protocols
+        .iter()
+        .find(|candidate| candidate.name == protocol)
+        .cloned()
+        .ok_or_else(|| SupersedeCommandError::UnknownProtocol(protocol.to_string()))?;
+
+    loaded
+        .store
+        .supersede_execution(&declaration, work_unit, &parsed, reason)
+        .map_err(SupersedeCommandError::Disposition)?;
+
+    println!(
+        "Superseded execution of '{protocol}'{}; the protocol regenerates against its unchanged inputs.",
+        match work_unit {
+            Some(id) => format!(" for work unit '{id}'"),
+            None => String::new(),
+        }
+    );
+    for (artifact_type, instance_id, revision) in &parsed {
+        println!("  rejected: {artifact_type}/{instance_id}@{revision}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_output_token;
+
+    #[test]
+    fn parses_well_formed_output_token() {
+        let parsed = parse_output_token("requirements/radicle-native@sha256:abc123").unwrap();
+        assert_eq!(
+            parsed,
+            (
+                "requirements".to_string(),
+                "radicle-native".to_string(),
+                "sha256:abc123".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_tokens_missing_a_component() {
+        for token in [
+            "requirements/radicle-native",
+            "requirements@sha256:abc",
+            "/inst@sha256:abc",
+            "type/@sha256:abc",
+            "type/inst@",
+        ] {
+            assert!(parse_output_token(token).is_none(), "accepted '{token}'");
+        }
+    }
+
+    #[test]
+    fn revision_hash_may_contain_further_separators() {
+        // `@` splits on the first occurrence; the instance side keeps `/`
+        // splitting on the first occurrence so nested-looking instance ids
+        // still parse deterministically.
+        let parsed = parse_output_token("a/b/c@sha256:x").unwrap();
+        assert_eq!(
+            parsed,
+            ("a".to_string(), "b/c".to_string(), "sha256:x".to_string())
+        );
+    }
+}

--- a/runa-cli/src/main.rs
+++ b/runa-cli/src/main.rs
@@ -68,6 +68,25 @@ enum Commands {
         #[arg(long)]
         work_unit: Option<String>,
     },
+    /// Supersede a recorded protocol execution so it regenerates against
+    /// unchanged inputs
+    Supersede {
+        /// Protocol whose recorded execution is superseded
+        #[arg(long)]
+        protocol: String,
+
+        /// Delegated work unit of the recorded execution
+        #[arg(long)]
+        work_unit: Option<String>,
+
+        /// Rejected output revision as <type>/<instance>@<revision>; repeatable
+        #[arg(long = "output", required = true)]
+        outputs: Vec<String>,
+
+        /// Auditable reason for rejecting the conforming output
+        #[arg(long)]
+        reason: String,
+    },
 }
 
 #[derive(Args)]
@@ -237,6 +256,23 @@ fn main() {
                     }
                 }
                 Err(err) => fatal_command_error("go", &err, err.exit_code()),
+            }
+        }
+        Commands::Supersede {
+            protocol,
+            work_unit,
+            outputs,
+            reason,
+        } => {
+            if let Err(err) = commands::supersede::run(
+                &working_dir,
+                config_override_ref,
+                &protocol,
+                work_unit.as_deref(),
+                &outputs,
+                &reason,
+            ) {
+                fatal_command_error("supersede", &err, err.exit_code());
             }
         }
     }

--- a/runa-cli/tests/supersede.rs
+++ b/runa-cli/tests/supersede.rs
@@ -1,0 +1,311 @@
+//! End-to-end coverage for `runa supersede`: the planning case from
+//! tesserine/runa#248 driven through the real CLI — execution and
+//! regeneration flow only through the normal `runa run` path, and the
+//! disposition's guards reject each mismatch with an accurate diagnostic.
+
+mod common;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+fn runa_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_runa"))
+}
+
+fn planning_manifest_toml() -> &'static str {
+    r#"
+name = "planning"
+
+[[artifact_types]]
+name = "intent"
+
+[[artifact_types]]
+name = "requirements"
+
+[[artifact_types]]
+name = "work-units"
+
+[[protocols]]
+name = "survey"
+requires = ["intent"]
+produces = ["requirements"]
+trigger = { type = "on_artifact", name = "intent" }
+
+[[protocols]]
+name = "decompose"
+requires = ["requirements"]
+produces = ["work-units"]
+trigger = { type = "on_artifact", name = "requirements" }
+"#
+}
+
+fn planning_schemas() -> &'static [(&'static str, &'static str)] {
+    &[
+        (
+            "intent",
+            r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+        ),
+        (
+            "requirements",
+            r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+        ),
+        (
+            "work-units",
+            r#"{"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}"#,
+        ),
+    ]
+}
+
+fn init_project(project_dir: &Path, manifest_path: &Path) {
+    let output = runa_bin()
+        .arg("init")
+        .arg("--methodology")
+        .arg(manifest_path)
+        .current_dir(project_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Fake agent: produces `requirements` from `survey` (content chosen by a
+/// version file so regeneration can differ) and `work-units` from
+/// `decompose`.
+fn write_fake_agent(dir: &Path) -> std::path::PathBuf {
+    let script = dir.join("fake-agent.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         payload=$(cat)\n\
+         case \"$payload\" in\n\
+           *\"# Protocol: survey\"*)\n\
+             version=$(cat requirements-version.txt)\n\
+             mkdir -p .runa/workspace/requirements\n\
+             printf '%s\\n' \"{\\\"title\\\":\\\"requirements $version\\\"}\" \
+               > .runa/workspace/requirements/radicle-native.json\n\
+             ;;\n\
+           *\"# Protocol: decompose\"*)\n\
+             mkdir -p .runa/workspace/work-units\n\
+             printf '%s\\n' '{\"title\":\"decomposed\"}' \
+               > .runa/workspace/work-units/plan.json\n\
+             ;;\n\
+           *)\n\
+             exit 19\n\
+             ;;\n\
+         esac\n",
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+fn run_cascade(project_dir: &Path, agent: &Path) -> std::process::Output {
+    runa_bin()
+        .arg("run")
+        .arg("--agent-command")
+        .arg("--")
+        .arg("sh")
+        .arg(agent)
+        .current_dir(project_dir)
+        .output()
+        .unwrap()
+}
+
+fn recorded_content_hash(project_dir: &Path, artifact_type: &str, instance_id: &str) -> String {
+    let state_path = project_dir
+        .join(".runa/store")
+        .join(artifact_type)
+        .join(format!("{instance_id}.json"));
+    let state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(state_path).unwrap()).unwrap();
+    state["content_hash"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn supersede_regenerates_the_planning_case_through_the_normal_run_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = common::write_methodology(
+        dir.path(),
+        planning_manifest_toml(),
+        planning_schemas(),
+        &["survey", "decompose"],
+    );
+
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    init_project(&project_dir, &manifest_path);
+    let agent = write_fake_agent(dir.path());
+
+    // Seed intent; the fake agent's requirements content is versioned so the
+    // regenerated revision differs while the intent stays byte-identical.
+    let workspace = project_dir.join(".runa/workspace");
+    fs::create_dir_all(workspace.join("intent")).unwrap();
+    fs::write(
+        workspace.join("intent/replace-forge-connectors.json"),
+        r#"{"title":"replace forge connectors with native radicle"}"#,
+    )
+    .unwrap();
+    fs::write(project_dir.join("requirements-version.txt"), "v1").unwrap();
+
+    // The pipeline runs to quiescence through the normal path.
+    let output = run_cascade(&project_dir, &agent);
+    assert!(
+        output.status.success(),
+        "first cascade failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Suppressed: outputs are current, nothing is ready.
+    let output = run_cascade(&project_dir, &agent);
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "expected outputs-current quiescence: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let rejected_hash = recorded_content_hash(&project_dir, "requirements", "radicle-native");
+
+    // Guard: a stale revision is rejected with a diagnostic naming the
+    // current one, and the wrong protocol is rejected by name.
+    let output = runa_bin()
+        .args([
+            "supersede",
+            "--protocol",
+            "survey",
+            "--output",
+            "requirements/radicle-native@sha256:stale",
+            "--reason",
+            "defective",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not the current revision") && stderr.contains(&rejected_hash),
+        "stale-revision diagnostic must name the current revision: {stderr}"
+    );
+
+    let output = runa_bin()
+        .args([
+            "supersede",
+            "--protocol",
+            "missing",
+            "--output",
+            &format!("requirements/radicle-native@{rejected_hash}"),
+            "--reason",
+            "defective",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown protocol: 'missing'"),
+        "unknown-protocol diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = runa_bin()
+        .args([
+            "supersede",
+            "--protocol",
+            "survey",
+            "--output",
+            "requirements-radicle-native",
+            "--reason",
+            "defective",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2), "malformed token is usage");
+
+    // The disposition itself, targeting the exact current revision.
+    let output = runa_bin()
+        .args([
+            "supersede",
+            "--protocol",
+            "survey",
+            "--output",
+            &format!("requirements/radicle-native@{rejected_hash}"),
+            "--reason",
+            "governance found the requirements substantively defective",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "supersede failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The producer is READY against the unchanged intent, and downstream
+    // state derived from the rejected output is no longer current.
+    let output = runa_bin()
+        .args(["state", "--json"])
+        .current_dir(&project_dir)
+        .output()
+        .unwrap();
+    let state: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    let status_of = |name: &str| {
+        state["protocols"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["name"] == name)
+            .unwrap()["status"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    assert_eq!(status_of("survey"), "ready");
+    assert_eq!(status_of("decompose"), "ready");
+
+    // Regeneration flows only through the normal run path and records the
+    // new execution; the corrected revision reopens and completes downstream.
+    fs::write(project_dir.join("requirements-version.txt"), "v2").unwrap();
+    let output = run_cascade(&project_dir, &agent);
+    assert!(
+        output.status.success(),
+        "regeneration cascade failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let regenerated_hash = recorded_content_hash(&project_dir, "requirements", "radicle-native");
+    assert_ne!(regenerated_hash, rejected_hash);
+
+    let output = run_cascade(&project_dir, &agent);
+    assert_eq!(output.status.code(), Some(4), "pipeline current again");
+
+    // The rejected execution and output remain inspectable as lineage.
+    let records: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(project_dir.join(".runa/store/execution-records.json")).unwrap(),
+    )
+    .unwrap();
+    let supersessions = records["supersessions"].as_array().unwrap();
+    assert_eq!(supersessions.len(), 1);
+    assert_eq!(supersessions[0]["protocol"], "survey");
+    assert_eq!(
+        supersessions[0]["reason"],
+        "governance found the requirements substantively defective"
+    );
+    assert_eq!(
+        supersessions[0]["rejected_outputs"][0]["content_hash"],
+        serde_json::Value::String(rejected_hash),
+    );
+    assert_eq!(
+        supersessions[0]["rejected_outputs"][0]["content"]["title"],
+        "requirements v1"
+    );
+}


### PR DESCRIPTION
Closes #248.

## What this delivers

The **supersession disposition**: the sanctioned, auditable runtime operation by which a conforming-but-rejected protocol output re-enters the graph for regeneration against unchanged inputs.

- **Surface** — `runa supersede --protocol <NAME> [--work-unit <ID>] --output <type>/<instance>@<revision> --reason <TEXT>` (`--output` repeatable). Runs the implicit scan first; scoped invocations run canonical work-unit identity validation. Guarded against current reality with a diagnostic naming each mismatch: unknown protocol, no execution record for the scope, undeclared output type, unrecorded instance, stale revision (names the current hash). Exit codes: 0 applied / 1 rejected against reality / 2 malformed / 6 infrastructure.
- **State model** — the `execution-records.json` envelope gains an append-only `supersessions` list; each entry carries the target pair, the required reason, the rejected revisions **with their preserved content** (read back from the workspace and verified against the supplied hash), and the displaced record. **Pendingness is computed, never stored**: pending ⇔ the pair has no current record, so every recording path (`step`, `run`, `go`, session staged commit) resolves it, and the session's stage/restore rollback stays transactionally correct for free.
- **Currency** — in `protocol_is_current` (selection + the dry-run projection mirror): a pending pair is not current with the timestamp fallback bypassed; an execution record whose recorded input snapshot contains a pending-rejected revision is not current. So the producer is READY against unchanged inputs, and downstream state derived from the rejected output reopens at disposition time. After regeneration the taint lifts and downstream currency is the ordinary snapshot rule.
- **Docs** — ARCHITECTURE.md (store, layout, currency rules, command), docs/cli-reference.md (full `runa supersede` entry), docs/session-surface-contract.md (Disposition-Authority now names the sanctioned path), CHANGELOG.md.

## Acceptance criteria → evidence

- Sanctioned regeneration through a documented runtime surface → `runa supersede` + docs; e2e test drives it through the real CLI.
- Rejected execution/output inspectable as lineage → supersession entries with preserved content; asserted in store, selection, and e2e tests.
- Producer READY; downstream no longer current → `supersession_regenerates_the_planning_case_against_unchanged_inputs` (selection) and the e2e `state --json` assertions.
- Normal `go`/session path serves and records regeneration → currency logic is the shared evaluator all paths consume; the e2e regenerates through live `runa run` (fake agent) and asserts the recorded resolution.
- Wrong protocol / identity / stale revision rejected with accurate diagnostics → typed `SupersedeError` variants; store test covers all six rejections; e2e covers stale-hash (naming the current one), unknown-protocol, and malformed-token exits.
- Complete planning case test (`intent → survey → requirements → decompose`, rejection after decomposition, regeneration against the byte-identical intent, downstream invalidation) → both a libagent selection test and the CLI end-to-end test.
- Interface/CLI/architecture docs → included.
- No workspace edit, output deletion, or hand-spawned fixed-protocol MCP in the supported path → the contract text states it; the operation touches only the record envelope.

## Design-boundary conformance

No timestamp stands proxy for judgment (identity + content-hash guard, verified against both store metadata and workspace bytes); the intent is untouched; the rejected artifact is preserved; reopening requires an auditable reason and exact target; readiness and postconditions are never bypassed. Rejected alternatives (trigger-consumed disposition artifact; bare record-clearing) and their grounds are on the issue: https://github.com/tesserine/runa/issues/248#issuecomment-4935015019

## Verification

`cargo fmt --check` clean; `cargo clippy` adds zero warnings over the #242 baseline (the two pre-existing dead-code test helpers); full workspace suite: **+11 passing tests** (4 store, 2 selection, 1 projection, 3 CLI-unit, 1 CLI e2e) with the failure set byte-identical to clean `main` in this container (59 environment-bound failures — temp-repo git pushes and agent-exec fixtures — present before and after; no regression).